### PR TITLE
feat: add windows support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,39 +75,46 @@ jobs:
           # GoReleaser uploads as name_template (e.g. stepsecurity-dev-machine-guard_darwin_amd64)
           # but keeps them in build subdirs locally. We copy to dist/ with release names
           # so cosign signs the same bytes users verify against.
-          AMD64_SRC=$(find dist -type f -name 'stepsecurity-dev-machine-guard' -path '*darwin_amd64*' | head -1)
-          ARM64_SRC=$(find dist -type f -name 'stepsecurity-dev-machine-guard' -path '*darwin_arm64*' | head -1)
 
-          for label in "amd64:${AMD64_SRC}" "arm64:${ARM64_SRC}"; do
-            name="${label%%:*}"
-            path="${label#*:}"
-            if [ -z "$path" ] || [ ! -f "$path" ]; then
-              echo "::error::Binary not found for ${name}"
+          declare -A ARTIFACTS=(
+            ["darwin_amd64"]="stepsecurity-dev-machine-guard"
+            ["darwin_arm64"]="stepsecurity-dev-machine-guard"
+            ["windows_amd64"]="stepsecurity-dev-machine-guard.exe"
+            ["windows_arm64"]="stepsecurity-dev-machine-guard.exe"
+          )
+
+          for target in "${!ARTIFACTS[@]}"; do
+            binary="${ARTIFACTS[$target]}"
+            src=$(find dist -type f -name "$binary" -path "*${target}*" | head -1)
+            if [ -z "$src" ] || [ ! -f "$src" ]; then
+              echo "::error::Binary not found for ${target}"
               find dist -type f
               exit 1
             fi
+            cp "$src" "dist/stepsecurity-dev-machine-guard_${target}${binary##stepsecurity-dev-machine-guard}"
           done
-
-          cp "$AMD64_SRC" dist/stepsecurity-dev-machine-guard_darwin_amd64
-          cp "$ARM64_SRC" dist/stepsecurity-dev-machine-guard_darwin_arm64
           echo "Prepared release artifacts for signing"
 
       - name: Sign artifacts with Sigstore (keyless)
         run: |
-          cosign sign-blob dist/stepsecurity-dev-machine-guard_darwin_amd64 \
-            --bundle dist/stepsecurity-dev-machine-guard_darwin_amd64.bundle --yes
-          cosign sign-blob dist/stepsecurity-dev-machine-guard_darwin_arm64 \
-            --bundle dist/stepsecurity-dev-machine-guard_darwin_arm64.bundle --yes
-          cosign sign-blob stepsecurity-dev-machine-guard.sh \
-            --bundle dist/stepsecurity-dev-machine-guard.sh.bundle --yes
+          for artifact in \
+            dist/stepsecurity-dev-machine-guard_darwin_amd64 \
+            dist/stepsecurity-dev-machine-guard_darwin_arm64 \
+            dist/stepsecurity-dev-machine-guard_windows_amd64.exe \
+            dist/stepsecurity-dev-machine-guard_windows_arm64.exe \
+            stepsecurity-dev-machine-guard.sh; do
+            cosign sign-blob "$artifact" --bundle "${artifact}.bundle" --yes
+          done
 
       - name: Generate checksums
         run: |
-          # Separate checksum file for cosign-signed artifacts (script + bundles).
-          # GoReleaser already generates checksums for the Go binaries in its own SHA256SUMS file.
-          sha256sum dist/stepsecurity-dev-machine-guard_darwin_amd64 > dist/cosign-checksums.txt
-          sha256sum dist/stepsecurity-dev-machine-guard_darwin_arm64 >> dist/cosign-checksums.txt
-          sha256sum stepsecurity-dev-machine-guard.sh >> dist/cosign-checksums.txt
+          sha256sum \
+            dist/stepsecurity-dev-machine-guard_darwin_amd64 \
+            dist/stepsecurity-dev-machine-guard_darwin_arm64 \
+            dist/stepsecurity-dev-machine-guard_windows_amd64.exe \
+            dist/stepsecurity-dev-machine-guard_windows_arm64.exe \
+            stepsecurity-dev-machine-guard.sh \
+            > dist/cosign-checksums.txt
 
       - name: Upload signature bundles and checksums to release
         env:
@@ -116,6 +123,8 @@ jobs:
           gh release upload "${{ steps.version.outputs.tag }}" \
             dist/stepsecurity-dev-machine-guard_darwin_amd64.bundle \
             dist/stepsecurity-dev-machine-guard_darwin_arm64.bundle \
+            dist/stepsecurity-dev-machine-guard_windows_amd64.exe.bundle \
+            dist/stepsecurity-dev-machine-guard_windows_arm64.exe.bundle \
             dist/stepsecurity-dev-machine-guard.sh.bundle \
             dist/cosign-checksums.txt \
             --clobber
@@ -135,4 +144,6 @@ jobs:
           subject-path: |
             dist/stepsecurity-dev-machine-guard_darwin_amd64
             dist/stepsecurity-dev-machine-guard_darwin_arm64
+            dist/stepsecurity-dev-machine-guard_windows_amd64.exe
+            dist/stepsecurity-dev-machine-guard_windows_arm64.exe
             stepsecurity-dev-machine-guard.sh

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .vscode/
 .idea/
 .claude/
+.plans/
 
 # Output files
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@
 !docs/**/*.html
 !images/**/*.html
 
-# Go build artifacts
-/stepsecurity-dev-machine-guard
+# Go build artifacts — never commit compiled binaries
+**/stepsecurity-dev-machine-guard
+*.exe
 dist/
 
 # Temporary files

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
     binary: stepsecurity-dev-machine-guard
     goos:
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/internal/buildinfo.ReleaseTag=$(TAG) \
 	-X $(MODULE)/internal/buildinfo.ReleaseBranch=$(BRANCH)
 
-.PHONY: build build-windows test lint clean smoke
+.PHONY: build build-windows deploy-windows test lint clean smoke
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/stepsecurity-dev-machine-guard
 
 build-windows:
 	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY).exe ./cmd/stepsecurity-dev-machine-guard
+
+deploy-windows:
+	@bash scripts/deploy-windows.sh $(DEPLOY_ARGS)
 
 test:
 	go test ./... -v -race -count=1

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/internal/buildinfo.ReleaseTag=$(TAG) \
 	-X $(MODULE)/internal/buildinfo.ReleaseBranch=$(BRANCH)
 
-.PHONY: build test lint clean smoke
+.PHONY: build build-windows test lint clean smoke
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/stepsecurity-dev-machine-guard
+
+build-windows:
+	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY).exe ./cmd/stepsecurity-dev-machine-guard
 
 test:
 	go test ./... -v -race -count=1

--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/step-security/dev-machine-guard/internal/buildinfo"
 	"github.com/step-security/dev-machine-guard/internal/cli"
@@ -84,6 +85,10 @@ func main() {
 
 	case "install":
 		fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
+		if runtime.GOOS == "windows" {
+			log.Error("Scheduled scanning is not yet supported on Windows. Use the scan command directly.")
+			os.Exit(1)
+		}
 		if !config.IsEnterpriseMode() {
 			log.Error("Enterprise configuration not found. Run '%s configure' or download the script from your StepSecurity dashboard.", os.Args[0])
 			os.Exit(1)
@@ -101,6 +106,10 @@ func main() {
 
 	case "uninstall":
 		fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
+		if runtime.GOOS == "windows" {
+			log.Error("Scheduled scanning is not yet supported on Windows. Use the scan command directly.")
+			os.Exit(1)
+		}
 		if err := launchd.Uninstall(exec, log); err != nil {
 			log.Error("%v", err)
 			os.Exit(1)

--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -84,7 +84,7 @@ func main() {
 		}
 
 	case "install":
-		fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
+		_, _ = fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
 		if runtime.GOOS == "windows" {
 			log.Error("Scheduled scanning is not yet supported on Windows. Use the scan command directly.")
 			os.Exit(1)
@@ -105,7 +105,7 @@ func main() {
 		}
 
 	case "uninstall":
-		fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
+		_, _ = fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
 		if runtime.GOOS == "windows" {
 			log.Error("Scheduled scanning is not yet supported on Windows. Use the scan command directly.")
 			os.Exit(1)

--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/launchd"
 	"github.com/step-security/dev-machine-guard/internal/progress"
 	"github.com/step-security/dev-machine-guard/internal/scan"
+	"github.com/step-security/dev-machine-guard/internal/schtasks"
 	"github.com/step-security/dev-machine-guard/internal/telemetry"
 )
 
@@ -85,17 +86,20 @@ func main() {
 
 	case "install":
 		_, _ = fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
-		if runtime.GOOS == "windows" {
-			log.Error("Scheduled scanning is not yet supported on Windows. Use the scan command directly.")
-			os.Exit(1)
-		}
 		if !config.IsEnterpriseMode() {
 			log.Error("Enterprise configuration not found. Run '%s configure' or download the script from your StepSecurity dashboard.", os.Args[0])
 			os.Exit(1)
 		}
-		if err := launchd.Install(exec, log); err != nil {
-			log.Error("%v", err)
-			os.Exit(1)
+		if runtime.GOOS == "windows" {
+			if err := schtasks.Install(exec, log); err != nil {
+				log.Error("%v", err)
+				os.Exit(1)
+			}
+		} else {
+			if err := launchd.Install(exec, log); err != nil {
+				log.Error("%v", err)
+				os.Exit(1)
+			}
 		}
 		log.Progress("Sending initial telemetry...")
 		fmt.Println()
@@ -107,12 +111,15 @@ func main() {
 	case "uninstall":
 		_, _ = fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n\n", buildinfo.Version)
 		if runtime.GOOS == "windows" {
-			log.Error("Scheduled scanning is not yet supported on Windows. Use the scan command directly.")
-			os.Exit(1)
-		}
-		if err := launchd.Uninstall(exec, log); err != nil {
-			log.Error("%v", err)
-			os.Exit(1)
+			if err := schtasks.Uninstall(exec, log); err != nil {
+				log.Error("%v", err)
+				os.Exit(1)
+			}
+		} else {
+			if err := launchd.Uninstall(exec, log); err != nil {
+				log.Error("%v", err)
+				os.Exit(1)
+			}
 		}
 
 	default:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -93,13 +93,13 @@ func Parse(args []string) (*Config, error) {
 		case arg == "--verbose":
 			cfg.Verbose = true
 		case arg == "-v" || arg == "--version" || arg == "version":
-			fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n", buildinfo.VersionString())
+			_, _ = fmt.Fprintf(os.Stdout, "StepSecurity Dev Machine Guard v%s\n", buildinfo.VersionString())
 			os.Exit(0)
 		case arg == "-h" || arg == "--help" || arg == "help":
 			printHelp()
 			os.Exit(0)
 		default:
-			return nil, fmt.Errorf("Unknown option: %s\nRun '%s --help' for usage information.", arg, filepath.Base(os.Args[0]))
+			return nil, fmt.Errorf("unknown option: %s, run '%s --help' for usage information", arg, filepath.Base(os.Args[0]))
 		}
 		i++
 	}
@@ -109,7 +109,7 @@ func Parse(args []string) (*Config, error) {
 
 func printHelp() {
 	name := filepath.Base(os.Args[0])
-	fmt.Fprintf(os.Stdout, `StepSecurity Dev Machine Guard v%s
+	_, _ = fmt.Fprintf(os.Stdout, `StepSecurity Dev Machine Guard v%s
 
 Usage: %s [COMMAND] [OPTIONS]
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -116,8 +116,8 @@ Usage: %s [COMMAND] [OPTIONS]
 Commands:
   configure            Configure enterprise settings and search directories
   configure show       Show current configuration
-  install              Install launchd for periodic scanning (enterprise)
-  uninstall            Remove launchd configuration (enterprise)
+  install              Install scheduled scanning (enterprise)
+  uninstall            Remove scheduled scanning (enterprise)
   send-telemetry       Upload scan results to the StepSecurity dashboard (enterprise)
 
 Output formats (community mode, mutually exclusive):

--- a/internal/detector/agent.go
+++ b/internal/detector/agent.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"context"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -67,7 +68,7 @@ func (d *AgentDetector) Detect(ctx context.Context, searchDirs []string) []model
 func (d *AgentDetector) findAgent(spec agentSpec, homeDir string) (string, bool) {
 	// Check detection paths
 	for _, relPath := range spec.DetectionPaths {
-		fullPath := homeDir + "/" + relPath
+		fullPath := filepath.Join(homeDir, relPath)
 		if d.exec.DirExists(fullPath) || d.exec.FileExists(fullPath) {
 			return fullPath, true
 		}
@@ -103,12 +104,23 @@ func (d *AgentDetector) getVersion(ctx context.Context, spec agentSpec) string {
 
 // detectClaudeCowork checks for Claude Cowork (a mode within Claude Desktop 0.7+).
 func (d *AgentDetector) detectClaudeCowork(ctx context.Context) (model.AITool, bool) {
-	claudePath := "/Applications/Claude.app"
-	if !d.exec.DirExists(claudePath) {
-		return model.AITool{}, false
+	var claudePath, version string
+
+	if d.exec.GOOS() == "windows" {
+		localAppData := d.exec.Getenv("LOCALAPPDATA")
+		claudePath = filepath.Join(localAppData, "Programs", "Claude")
+		if !d.exec.DirExists(claudePath) {
+			return model.AITool{}, false
+		}
+		version = readRegistryVersion(ctx, d.exec, "Claude")
+	} else {
+		claudePath = "/Applications/Claude.app"
+		if !d.exec.DirExists(claudePath) {
+			return model.AITool{}, false
+		}
+		version = readPlistVersion(ctx, d.exec, filepath.Join(claudePath, "Contents", "Info.plist"))
 	}
 
-	version := readPlistVersion(ctx, d.exec, claudePath+"/Contents/Info.plist")
 	if version == "unknown" {
 		return model.AITool{}, false
 	}

--- a/internal/detector/agent_test.go
+++ b/internal/detector/agent_test.go
@@ -96,3 +96,45 @@ func TestIsCoworkVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestAgentDetector_Windows_ClaudeCowork(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetHomeDir(`C:\Users\testuser`)
+	mock.SetEnv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
+
+	// detectClaudeCowork on Windows uses filepath.Join(localAppData, "Programs", "Claude").
+	// On macOS host, filepath.Join keeps backslashes and inserts "/":
+	claudePath := `C:\Users\testuser\AppData\Local` + "/Programs/Claude"
+	mock.SetDir(claudePath)
+
+	// Version via readRegistryVersion with appName "Claude".
+	// First registry root tried by readRegistryVersion.
+	mock.SetCommand(
+		"HKLM\\SOFTWARE\\...\\Claude\n    DisplayVersion    REG_SZ    0.7.5\n",
+		"", 0,
+		"reg", "query", `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`, "/s", "/f", "Claude", "/d",
+	)
+
+	det := NewAgentDetector(mock)
+	results := det.Detect(context.Background(), []string{`C:\Users\testuser`})
+
+	found := false
+	for _, r := range results {
+		if r.Name == "claude-cowork" {
+			found = true
+			if r.Vendor != "Anthropic" {
+				t.Errorf("expected Anthropic, got %s", r.Vendor)
+			}
+			if r.Version != "0.7.5" {
+				t.Errorf("expected 0.7.5, got %s", r.Version)
+			}
+			if r.InstallPath != claudePath {
+				t.Errorf("expected install path %s, got %s", claudePath, r.InstallPath)
+			}
+		}
+	}
+	if !found {
+		t.Error("claude-cowork not found")
+	}
+}

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -164,7 +164,9 @@ func (d *AICLIDetector) getVersion(ctx context.Context, spec cliToolSpec, binary
 }
 
 // cleanVersionString strips a leading tool name prefix from version output.
-// e.g. "codex-cli 0.118.0" -> "0.118.0", "aider 0.86.2" -> "0.86.2"
+// It finds the first token that looks like a version number (starts with a digit
+// or "v" followed by a digit) and returns it, preserving any "v" prefix.
+// e.g. "codex-cli 0.118.0" -> "0.118.0", "aider 0.86.2" -> "0.86.2", "v1.2.3" -> "v1.2.3"
 func cleanVersionString(v string) string {
 	parts := strings.Fields(v)
 	for _, p := range parts {

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -157,10 +157,23 @@ func (d *AICLIDetector) getVersion(ctx context.Context, spec cliToolSpec, binary
 	if len(lines) > 0 {
 		v := strings.TrimSpace(lines[0])
 		if v != "" {
-			return v
+			return cleanVersionString(v)
 		}
 	}
 	return "unknown"
+}
+
+// cleanVersionString strips a leading tool name prefix from version output.
+// e.g. "codex-cli 0.118.0" -> "0.118.0", "aider 0.86.2" -> "0.86.2"
+func cleanVersionString(v string) string {
+	parts := strings.Fields(v)
+	for _, p := range parts {
+		trimmed := strings.TrimLeft(p, "v")
+		if len(trimmed) > 0 && trimmed[0] >= '0' && trimmed[0] <= '9' {
+			return p
+		}
+	}
+	return v
 }
 
 func (d *AICLIDetector) findConfigDir(spec cliToolSpec, homeDir string) string {

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -2,6 +2,8 @@ package detector
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -121,10 +123,16 @@ func (d *AICLIDetector) Detect(ctx context.Context) []model.AITool {
 func (d *AICLIDetector) findBinary(ctx context.Context, spec cliToolSpec, homeDir string) (string, bool) {
 	for _, bin := range spec.Binaries {
 		expanded := expandTilde(bin, homeDir)
-		if strings.Contains(expanded, "/") {
-			// Absolute/relative path - check if it exists
+		if expanded != bin {
+			// Path was expanded from tilde — it's a home-relative path, check if it exists
 			if d.exec.FileExists(expanded) {
 				return expanded, true
+			}
+			// On Windows, also try with .exe suffix
+			if d.exec.GOOS() == "windows" && !strings.HasSuffix(expanded, ".exe") {
+				if d.exec.FileExists(expanded + ".exe") {
+					return expanded + ".exe", true
+				}
 			}
 			continue
 		}
@@ -167,7 +175,7 @@ func (d *AICLIDetector) findConfigDir(spec cliToolSpec, homeDir string) string {
 
 func expandTilde(path, homeDir string) string {
 	if strings.HasPrefix(path, "~/") {
-		return homeDir + path[1:]
+		return filepath.Join(homeDir, filepath.FromSlash(path[2:]))
 	}
 	return path
 }
@@ -175,7 +183,22 @@ func expandTilde(path, homeDir string) string {
 func getHomeDir(exec executor.Executor) string {
 	u, err := exec.CurrentUser()
 	if err != nil {
-		return "/tmp"
+		return os.TempDir()
 	}
 	return u.HomeDir
+}
+
+// resolveEnvPath replaces %ENVVAR% patterns in Windows-style paths using the executor.
+func resolveEnvPath(exec executor.Executor, path string) string {
+	for strings.Contains(path, "%") {
+		start := strings.Index(path, "%")
+		end := strings.Index(path[start+1:], "%")
+		if end < 0 {
+			break
+		}
+		envName := path[start+1 : start+1+end]
+		envVal := exec.Getenv(envName)
+		path = path[:start] + envVal + path[start+2+end:]
+	}
+	return filepath.FromSlash(path)
 }

--- a/internal/detector/extension.go
+++ b/internal/detector/extension.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
@@ -78,7 +79,7 @@ func (d *ExtensionDetector) collectFromDir(extDir, ideType string) []model.Exten
 		}
 
 		// Get install date from directory modification time
-		info, err := d.exec.Stat(extDir + "/" + dirname)
+		info, err := d.exec.Stat(filepath.Join(extDir, dirname))
 		if err == nil {
 			ext.InstallDate = info.ModTime().Unix()
 		}
@@ -130,7 +131,7 @@ func parseExtensionDir(dirname, ideType string) *model.Extension {
 
 // loadObsolete reads the .obsolete file and returns a set of dirname -> true.
 func (d *ExtensionDetector) loadObsolete(extDir string) map[string]bool {
-	obsoleteFile := extDir + "/.obsolete"
+	obsoleteFile := filepath.Join(extDir, ".obsolete")
 	data, err := d.exec.ReadFile(obsoleteFile)
 	if err != nil {
 		return nil

--- a/internal/detector/framework.go
+++ b/internal/detector/framework.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -41,7 +42,7 @@ func (d *FrameworkDetector) Detect(ctx context.Context) []model.AITool {
 		}
 
 		version := d.getVersion(ctx, binaryPath)
-		isRunning := d.isProcessRunning(ctx, spec.ProcessName)
+		isRunning := isProcessRunning(ctx, d.exec, spec.ProcessName)
 
 		results = append(results, model.AITool{
 			Name:       spec.Name,
@@ -86,24 +87,25 @@ func (d *FrameworkDetector) getVersion(ctx context.Context, binaryPath string) s
 	return "unknown"
 }
 
-func (d *FrameworkDetector) isProcessRunning(ctx context.Context, processName string) bool {
-	_, _, exitCode, _ := d.exec.Run(ctx, "pgrep", "-x", processName)
-	return exitCode == 0
-}
-
 func (d *FrameworkDetector) detectLMStudioApp(ctx context.Context) (model.AITool, bool) {
-	appPath := "/Applications/LM Studio.app"
-	if !d.exec.DirExists(appPath) {
-		return model.AITool{}, false
+	var appPath, version string
+
+	if d.exec.GOOS() == "windows" {
+		localAppData := d.exec.Getenv("LOCALAPPDATA")
+		appPath = filepath.Join(localAppData, "Programs", "LM Studio")
+		if !d.exec.DirExists(appPath) {
+			return model.AITool{}, false
+		}
+		version = readRegistryVersion(ctx, d.exec, "LM Studio")
+	} else {
+		appPath = "/Applications/LM Studio.app"
+		if !d.exec.DirExists(appPath) {
+			return model.AITool{}, false
+		}
+		version = readPlistVersion(ctx, d.exec, filepath.Join(appPath, "Contents", "Info.plist"))
 	}
 
-	version := readPlistVersion(ctx, d.exec, appPath+"/Contents/Info.plist")
-
-	isRunning := false
-	_, _, exitCode, _ := d.exec.Run(ctx, "pgrep", "-f", "LM Studio")
-	if exitCode == 0 {
-		isRunning = true
-	}
+	running := isProcessRunningFuzzy(ctx, d.exec, "LM Studio")
 
 	return model.AITool{
 		Name:       "lm-studio",
@@ -111,6 +113,6 @@ func (d *FrameworkDetector) detectLMStudioApp(ctx context.Context) (model.AITool
 		Type:       "framework",
 		Version:    version,
 		BinaryPath: appPath,
-		IsRunning:  &isRunning,
+		IsRunning:  &running,
 	}, true
 }

--- a/internal/detector/framework_test.go
+++ b/internal/detector/framework_test.go
@@ -74,3 +74,45 @@ func TestFrameworkDetector_LMStudioApp(t *testing.T) {
 		t.Error("lm-studio not found")
 	}
 }
+
+func TestFrameworkDetector_Windows_FindsOllama(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetPath("ollama", `C:\Program Files\Ollama\ollama.exe`)
+
+	mock.SetCommand("0.5.4\n", "", 0, `C:\Program Files\Ollama\ollama.exe`, "--version")
+
+	// isProcessRunning on Windows: tasklist /FI "IMAGENAME eq ollama.exe" /NH
+	mock.SetCommand(
+		"ollama.exe                   12345 Console                    1    100,000 K\n",
+		"", 0,
+		"tasklist", "/FI", "IMAGENAME eq ollama.exe", "/NH",
+	)
+
+	// LM Studio app detection on Windows also runs; ensure it doesn't interfere.
+	// detectLMStudioApp will try Getenv("LOCALAPPDATA") which is empty, so DirExists will fail.
+	// isProcessRunningFuzzy on Windows calls tasklist /NH
+	mock.SetCommand("", "", 1, "tasklist", "/NH")
+
+	det := NewFrameworkDetector(mock)
+	results := det.Detect(context.Background())
+
+	found := false
+	for _, r := range results {
+		if r.Name == "ollama" {
+			found = true
+			if r.Type != "framework" {
+				t.Errorf("expected framework, got %s", r.Type)
+			}
+			if r.Version != "0.5.4" {
+				t.Errorf("expected 0.5.4, got %s", r.Version)
+			}
+			if r.IsRunning == nil || !*r.IsRunning {
+				t.Error("expected is_running=true")
+			}
+		}
+	}
+	if !found {
+		t.Error("ollama not found")
+	}
+}

--- a/internal/detector/ide.go
+++ b/internal/detector/ide.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -10,22 +11,56 @@ import (
 )
 
 type ideSpec struct {
-	AppName      string
-	IDEType      string
-	Vendor       string
-	AppPath      string
-	BinaryPath   string // relative to AppPath
-	VersionFlag  string
+	AppName     string
+	IDEType     string
+	Vendor      string
+	AppPath     string   // macOS: /Applications/X.app
+	BinaryPath  string   // macOS: relative to AppPath
+	WinPaths    []string // Windows: candidate install dirs (may contain %ENVVAR%)
+	WinBinary   string   // Windows: binary relative to install dir
+	VersionFlag string
 }
 
 var ideDefinitions = []ideSpec{
-	{"Visual Studio Code", "vscode", "Microsoft", "/Applications/Visual Studio Code.app", "Contents/Resources/app/bin/code", "--version"},
-	{"Cursor", "cursor", "Cursor", "/Applications/Cursor.app", "Contents/Resources/app/bin/cursor", "--version"},
-	{"Windsurf", "windsurf", "Codeium", "/Applications/Windsurf.app", "Contents/MacOS/Windsurf", "--version"},
-	{"Antigravity", "antigravity", "Google", "/Applications/Antigravity.app", "Contents/MacOS/Antigravity", "--version"},
-	{"Zed", "zed", "Zed", "/Applications/Zed.app", "Contents/MacOS/zed", ""},
-	{"Claude", "claude_desktop", "Anthropic", "/Applications/Claude.app", "", ""},
-	{"Microsoft Copilot", "microsoft_copilot_desktop", "Microsoft", "/Applications/Copilot.app", "", ""},
+	{
+		AppName: "Visual Studio Code", IDEType: "vscode", Vendor: "Microsoft",
+		AppPath: "/Applications/Visual Studio Code.app", BinaryPath: "Contents/Resources/app/bin/code",
+		WinPaths: []string{`%PROGRAMFILES%\Microsoft VS Code`, `%LOCALAPPDATA%\Programs\Microsoft VS Code`}, WinBinary: `bin\code.cmd`,
+		VersionFlag: "--version",
+	},
+	{
+		AppName: "Cursor", IDEType: "cursor", Vendor: "Cursor",
+		AppPath: "/Applications/Cursor.app", BinaryPath: "Contents/Resources/app/bin/cursor",
+		WinPaths: []string{`%LOCALAPPDATA%\Programs\cursor`}, WinBinary: "Cursor.exe",
+		VersionFlag: "--version",
+	},
+	{
+		AppName: "Windsurf", IDEType: "windsurf", Vendor: "Codeium",
+		AppPath: "/Applications/Windsurf.app", BinaryPath: "Contents/MacOS/Windsurf",
+		WinPaths: []string{`%LOCALAPPDATA%\Programs\Windsurf`}, WinBinary: "Windsurf.exe",
+		VersionFlag: "--version",
+	},
+	{
+		AppName: "Antigravity", IDEType: "antigravity", Vendor: "Google",
+		AppPath: "/Applications/Antigravity.app", BinaryPath: "Contents/MacOS/Antigravity",
+		WinPaths: []string{`%LOCALAPPDATA%\Programs\Antigravity`}, WinBinary: "Antigravity.exe",
+		VersionFlag: "--version",
+	},
+	{
+		AppName: "Zed", IDEType: "zed", Vendor: "Zed",
+		AppPath: "/Applications/Zed.app", BinaryPath: "Contents/MacOS/zed",
+		WinPaths: []string{`%LOCALAPPDATA%\Zed`}, WinBinary: "zed.exe",
+	},
+	{
+		AppName: "Claude", IDEType: "claude_desktop", Vendor: "Anthropic",
+		AppPath: "/Applications/Claude.app",
+		WinPaths: []string{`%LOCALAPPDATA%\Programs\Claude`},
+	},
+	{
+		AppName: "Microsoft Copilot", IDEType: "microsoft_copilot_desktop", Vendor: "Microsoft",
+		AppPath: "/Applications/Copilot.app",
+		WinPaths: []string{`%LOCALAPPDATA%\Programs\Copilot`},
+	},
 }
 
 // IDEDetector detects installed IDEs and AI desktop apps.
@@ -41,47 +76,93 @@ func (d *IDEDetector) Detect(ctx context.Context) []model.IDE {
 	var results []model.IDE
 
 	for _, spec := range ideDefinitions {
-		if !d.exec.DirExists(spec.AppPath) {
+		if d.exec.GOOS() == "windows" {
+			if ide, ok := d.detectWindows(ctx, spec); ok {
+				results = append(results, ide)
+			}
+		} else {
+			if ide, ok := d.detectDarwin(ctx, spec); ok {
+				results = append(results, ide)
+			}
+		}
+	}
+
+	return results
+}
+
+func (d *IDEDetector) detectDarwin(ctx context.Context, spec ideSpec) (model.IDE, bool) {
+	if !d.exec.DirExists(spec.AppPath) {
+		return model.IDE{}, false
+	}
+
+	version := "unknown"
+
+	// Try version from binary
+	if spec.BinaryPath != "" && spec.VersionFlag != "" {
+		binaryFull := filepath.Join(spec.AppPath, spec.BinaryPath)
+		if d.exec.FileExists(binaryFull) {
+			version = runVersionCmd(ctx, d.exec, binaryFull, spec.VersionFlag)
+		}
+	}
+
+	// Fallback: Info.plist
+	if version == "unknown" {
+		version = readPlistVersion(ctx, d.exec, filepath.Join(spec.AppPath, "Contents", "Info.plist"))
+	}
+
+	return model.IDE{
+		IDEType: spec.IDEType, Version: version, InstallPath: spec.AppPath,
+		Vendor: spec.Vendor, IsInstalled: true,
+	}, true
+}
+
+func (d *IDEDetector) detectWindows(ctx context.Context, spec ideSpec) (model.IDE, bool) {
+	for _, winPath := range spec.WinPaths {
+		resolved := resolveEnvPath(d.exec, winPath)
+		if !d.exec.DirExists(resolved) {
 			continue
 		}
 
 		version := "unknown"
 
 		// Try version from binary
-		if spec.BinaryPath != "" && spec.VersionFlag != "" {
-			binaryFull := spec.AppPath + "/" + spec.BinaryPath
+		if spec.WinBinary != "" && spec.VersionFlag != "" {
+			binaryFull := filepath.Join(resolved, spec.WinBinary)
 			if d.exec.FileExists(binaryFull) {
-				stdout, _, _, err := d.exec.RunWithTimeout(ctx, 10*time.Second, binaryFull, spec.VersionFlag)
-				if err == nil {
-					lines := strings.SplitN(stdout, "\n", 2)
-					if len(lines) > 0 {
-						v := strings.TrimSpace(lines[0])
-						if v != "" {
-							version = v
-						}
-					}
-				}
+				version = runVersionCmd(ctx, d.exec, binaryFull, spec.VersionFlag)
 			}
 		}
 
-		// Fallback: Info.plist
+		// Fallback: registry
 		if version == "unknown" {
-			version = readPlistVersion(ctx, d.exec, spec.AppPath+"/Contents/Info.plist")
+			version = readRegistryVersion(ctx, d.exec, spec.AppName)
 		}
 
-		results = append(results, model.IDE{
-			IDEType:     spec.IDEType,
-			Version:     version,
-			InstallPath: spec.AppPath,
-			Vendor:      spec.Vendor,
-			IsInstalled: true,
-		})
+		return model.IDE{
+			IDEType: spec.IDEType, Version: version, InstallPath: resolved,
+			Vendor: spec.Vendor, IsInstalled: true,
+		}, true
 	}
-
-	return results
+	return model.IDE{}, false
 }
 
-// readPlistVersion reads CFBundleShortVersionString from an Info.plist.
+// runVersionCmd runs a binary with a version flag and extracts the first line.
+func runVersionCmd(ctx context.Context, exec executor.Executor, binary, flag string) string {
+	stdout, _, _, err := exec.RunWithTimeout(ctx, 10*time.Second, binary, flag)
+	if err != nil {
+		return "unknown"
+	}
+	lines := strings.SplitN(stdout, "\n", 2)
+	if len(lines) > 0 {
+		v := strings.TrimSpace(lines[0])
+		if v != "" {
+			return v
+		}
+	}
+	return "unknown"
+}
+
+// readPlistVersion reads CFBundleShortVersionString from an Info.plist (macOS).
 func readPlistVersion(ctx context.Context, exec executor.Executor, plistPath string) string {
 	if !exec.FileExists(plistPath) {
 		return "unknown"
@@ -91,6 +172,39 @@ func readPlistVersion(ctx context.Context, exec executor.Executor, plistPath str
 		v := strings.TrimSpace(stdout)
 		if v != "" {
 			return v
+		}
+	}
+	return "unknown"
+}
+
+// readAppVersion reads app version using platform-appropriate method.
+func readAppVersion(ctx context.Context, exec executor.Executor, darwinPlistPath, winAppName string) string {
+	if exec.GOOS() == "windows" {
+		return readRegistryVersion(ctx, exec, winAppName)
+	}
+	return readPlistVersion(ctx, exec, darwinPlistPath)
+}
+
+// readRegistryVersion searches Windows Uninstall registry keys for DisplayVersion.
+func readRegistryVersion(ctx context.Context, exec executor.Executor, appName string) string {
+	for _, root := range []string{
+		`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`,
+		`HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`,
+		`HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`,
+	} {
+		stdout, _, _, err := exec.Run(ctx, "reg", "query", root, "/s", "/f", appName, "/d")
+		if err != nil {
+			continue
+		}
+		// Parse "DisplayVersion    REG_SZ    x.y.z" from reg query output
+		for _, line := range strings.Split(stdout, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, "DisplayVersion") {
+				parts := strings.Fields(line)
+				if len(parts) >= 3 {
+					return parts[len(parts)-1]
+				}
+			}
 		}
 	}
 	return "unknown"

--- a/internal/detector/ide.go
+++ b/internal/detector/ide.go
@@ -177,14 +177,6 @@ func readPlistVersion(ctx context.Context, exec executor.Executor, plistPath str
 	return "unknown"
 }
 
-// readAppVersion reads app version using platform-appropriate method.
-func readAppVersion(ctx context.Context, exec executor.Executor, darwinPlistPath, winAppName string) string {
-	if exec.GOOS() == "windows" {
-		return readRegistryVersion(ctx, exec, winAppName)
-	}
-	return readPlistVersion(ctx, exec, darwinPlistPath)
-}
-
 // readRegistryVersion searches Windows Uninstall registry keys for DisplayVersion.
 func readRegistryVersion(ctx context.Context, exec executor.Executor, appName string) string {
 	for _, root := range []string{

--- a/internal/detector/ide_test.go
+++ b/internal/detector/ide_test.go
@@ -77,3 +77,81 @@ func TestIDEDetector_MultipleIDEs(t *testing.T) {
 		t.Fatalf("expected 2 IDEs, got %d", len(results))
 	}
 }
+
+func TestIDEDetector_Windows_FindsVSCode(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetEnv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
+	mock.SetEnv("PROGRAMFILES", `C:\Program Files`)
+
+	// resolveEnvPath("%PROGRAMFILES%\Microsoft VS Code") on macOS produces
+	// the backslash-containing path since filepath.FromSlash is a no-op.
+	vscodePath := `C:\Program Files\Microsoft VS Code`
+	mock.SetDir(vscodePath)
+
+	// filepath.Join on macOS uses "/" between parts, keeps existing backslashes.
+	binaryPath := vscodePath + `/bin\code.cmd`
+	mock.SetFile(binaryPath, []byte{})
+	mock.SetCommand("1.96.0\n1234abcd\nx64", "", 0, binaryPath, "--version")
+
+	det := NewIDEDetector(mock)
+	results := det.Detect(context.Background())
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 IDE, got %d", len(results))
+	}
+	if results[0].IDEType != "vscode" {
+		t.Errorf("expected vscode, got %s", results[0].IDEType)
+	}
+	if results[0].Version != "1.96.0" {
+		t.Errorf("expected 1.96.0, got %s", results[0].Version)
+	}
+	if results[0].Vendor != "Microsoft" {
+		t.Errorf("expected Microsoft, got %s", results[0].Vendor)
+	}
+	if !results[0].IsInstalled {
+		t.Error("expected is_installed=true")
+	}
+	if results[0].InstallPath != vscodePath {
+		t.Errorf("expected install path %s, got %s", vscodePath, results[0].InstallPath)
+	}
+}
+
+func TestIDEDetector_Windows_FindsClaude(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetEnv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
+
+	// resolveEnvPath("%LOCALAPPDATA%\Programs\Claude") on macOS:
+	// result is "C:\Users\testuser\AppData\Local\Programs\Claude"
+	// (all backslashes since the spec uses backslashes throughout)
+	claudePath := `C:\Users\testuser\AppData\Local\Programs\Claude`
+	mock.SetDir(claudePath)
+
+	// Claude has no WinBinary, so version falls back to readRegistryVersion.
+	// Registry query tries multiple roots; succeed on the first one.
+	mock.SetCommand(
+		"HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Claude\n    DisplayVersion    REG_SZ    0.8.2\n",
+		"", 0,
+		"reg", "query", `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`, "/s", "/f", "Claude", "/d",
+	)
+
+	det := NewIDEDetector(mock)
+	results := det.Detect(context.Background())
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 IDE, got %d", len(results))
+	}
+	if results[0].IDEType != "claude_desktop" {
+		t.Errorf("expected claude_desktop, got %s", results[0].IDEType)
+	}
+	if results[0].Version != "0.8.2" {
+		t.Errorf("expected 0.8.2, got %s", results[0].Version)
+	}
+	if results[0].Vendor != "Anthropic" {
+		t.Errorf("expected Anthropic, got %s", results[0].Vendor)
+	}
+	if !results[0].IsInstalled {
+		t.Error("expected is_installed=true")
+	}
+}

--- a/internal/detector/mcp.go
+++ b/internal/detector/mcp.go
@@ -192,7 +192,7 @@ func stripJSONCComments(input []byte) []byte {
 		// Block comment
 		if i+1 < len(input) && input[i] == '/' && input[i+1] == '*' {
 			i += 2
-			for i+1 < len(input) && !(input[i] == '*' && input[i+1] == '/') {
+			for i+1 < len(input) && (input[i] != '*' || input[i+1] != '/') {
 				i++
 			}
 			i += 2 // skip */

--- a/internal/detector/mcp.go
+++ b/internal/detector/mcp.go
@@ -11,21 +11,22 @@ import (
 )
 
 type mcpConfigSpec struct {
-	SourceName string
-	ConfigPath string // relative to home; uses ~ prefix
-	Vendor     string
+	SourceName    string
+	ConfigPath    string // macOS/Unix path (~/... expanded)
+	WinConfigPath string // Windows path (%ENVVAR%/... expanded); empty means same as ConfigPath
+	Vendor        string
 }
 
 var mcpConfigDefinitions = []mcpConfigSpec{
-	{"claude_desktop", "~/Library/Application Support/Claude/claude_desktop_config.json", "Anthropic"},
-	{"claude_code", "~/.claude/settings.json", "Anthropic"},
-	{"claude_code", "~/.claude.json", "Anthropic"},
-	{"cursor", "~/.cursor/mcp.json", "Cursor"},
-	{"windsurf", "~/.codeium/windsurf/mcp_config.json", "Codeium"},
-	{"antigravity", "~/.gemini/antigravity/mcp_config.json", "Google"},
-	{"zed", "~/.config/zed/settings.json", "Zed"},
-	{"open_interpreter", "~/.config/open-interpreter/config.yaml", "OpenSource"},
-	{"codex", "~/.codex/config.toml", "OpenAI"},
+	{"claude_desktop", "~/Library/Application Support/Claude/claude_desktop_config.json", "%APPDATA%/Claude/claude_desktop_config.json", "Anthropic"},
+	{"claude_code", "~/.claude/settings.json", "", "Anthropic"},
+	{"claude_code", "~/.claude.json", "", "Anthropic"},
+	{"cursor", "~/.cursor/mcp.json", "", "Cursor"},
+	{"windsurf", "~/.codeium/windsurf/mcp_config.json", "", "Codeium"},
+	{"antigravity", "~/.gemini/antigravity/mcp_config.json", "", "Google"},
+	{"zed", "~/.config/zed/settings.json", "", "Zed"},
+	{"open_interpreter", "~/.config/open-interpreter/config.yaml", "", "OpenSource"},
+	{"codex", "~/.codex/config.toml", "", "OpenAI"},
 }
 
 // MCPDetector collects MCP configuration files.
@@ -44,7 +45,7 @@ func (d *MCPDetector) Detect(_ context.Context, userIdentity string, enterprise 
 	var results []model.MCPConfig
 
 	for _, spec := range mcpConfigDefinitions {
-		configPath := expandTilde(spec.ConfigPath, homeDir)
+		configPath := d.resolveConfigPath(spec, homeDir)
 
 		if !d.exec.FileExists(configPath) {
 			continue
@@ -66,7 +67,7 @@ func (d *MCPDetector) DetectEnterprise(_ context.Context) []model.MCPConfigEnter
 	var results []model.MCPConfigEnterprise
 
 	for _, spec := range mcpConfigDefinitions {
-		configPath := expandTilde(spec.ConfigPath, homeDir)
+		configPath := d.resolveConfigPath(spec, homeDir)
 
 		if !d.exec.FileExists(configPath) {
 			continue
@@ -90,6 +91,14 @@ func (d *MCPDetector) DetectEnterprise(_ context.Context) []model.MCPConfigEnter
 	}
 
 	return results
+}
+
+// resolveConfigPath returns the appropriate config path for the current platform.
+func (d *MCPDetector) resolveConfigPath(spec mcpConfigSpec, homeDir string) string {
+	if d.exec.GOOS() == "windows" && spec.WinConfigPath != "" {
+		return resolveEnvPath(d.exec, spec.WinConfigPath)
+	}
+	return expandTilde(spec.ConfigPath, homeDir)
 }
 
 // filterMCPContent extracts MCP-relevant fields from a config file.

--- a/internal/detector/mcp_test.go
+++ b/internal/detector/mcp_test.go
@@ -81,3 +81,33 @@ func TestMCPDetector_Enterprise(t *testing.T) {
 		t.Error("expected non-empty base64 content")
 	}
 }
+
+func TestMCPDetector_Windows_FindsConfigs(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetHomeDir(`C:\Users\testuser`)
+	mock.SetEnv("APPDATA", `C:\Users\testuser\AppData\Roaming`)
+
+	// claude_desktop WinConfigPath: "%APPDATA%/Claude/claude_desktop_config.json"
+	// After resolveEnvPath on macOS host:
+	//   env replacement -> "C:\Users\testuser\AppData\Roaming/Claude/claude_desktop_config.json"
+	//   filepath.FromSlash (macOS no-op) -> same
+	claudeConfigPath := `C:\Users\testuser\AppData\Roaming` + "/Claude/claude_desktop_config.json"
+	mock.SetFile(claudeConfigPath, []byte(`{"mcpServers":{}}`))
+
+	det := NewMCPDetector(mock)
+	results := det.Detect(context.Background(), "testuser", false)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(results))
+	}
+	if results[0].ConfigSource != "claude_desktop" {
+		t.Errorf("expected claude_desktop, got %s", results[0].ConfigSource)
+	}
+	if results[0].ConfigPath != claudeConfigPath {
+		t.Errorf("expected config path %s, got %s", claudeConfigPath, results[0].ConfigPath)
+	}
+	if results[0].Vendor != "Anthropic" {
+		t.Errorf("expected Anthropic, got %s", results[0].Vendor)
+	}
+}

--- a/internal/detector/nodepm_test.go
+++ b/internal/detector/nodepm_test.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
@@ -48,6 +49,58 @@ func TestNodePMDetector_NoneFound(t *testing.T) {
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 package managers, got %d", len(results))
+	}
+}
+
+func TestNodePMDetector_Windows_FindsNPM(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetPath("npm", `C:\Program Files\nodejs\npm.cmd`)
+	mock.SetCommand("10.2.0\n", "", 0, "npm", "--version")
+
+	det := NewNodePMDetector(mock)
+	results := det.DetectManagers(context.Background())
+
+	if len(results) < 1 {
+		t.Fatal("expected at least 1 package manager on Windows")
+	}
+	if results[0].Name != "npm" {
+		t.Errorf("expected npm, got %s", results[0].Name)
+	}
+	if results[0].Version != "10.2.0" {
+		t.Errorf("expected 10.2.0, got %s", results[0].Version)
+	}
+	if results[0].Path != `C:\Program Files\nodejs\npm.cmd` {
+		t.Errorf("expected Windows path, got %s", results[0].Path)
+	}
+}
+
+func TestDetectProjectPM_Windows(t *testing.T) {
+	// Note: filepath.Join is host-OS dependent; on macOS it uses "/" even for
+	// Windows-style project dirs. We use filepath.Join here to match what
+	// DetectProjectPM produces internally.
+	projectDir := `C:\Users\dev\myapp`
+	tests := []struct {
+		name     string
+		lockFile string
+		expected string
+	}{
+		{"npm lock", "package-lock.json", "npm"},
+		{"yarn lock", "yarn.lock", "yarn"},
+		{"pnpm lock", "pnpm-lock.yaml", "pnpm"},
+		{"bun lock", "bun.lock", "bun"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := executor.NewMock()
+			mock.SetGOOS("windows")
+			mock.SetFile(filepath.Join(projectDir, tt.lockFile), []byte{})
+			got := DetectProjectPM(mock, projectDir)
+			if got != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, got)
+			}
+		})
 	}
 }
 

--- a/internal/detector/nodeproject.go
+++ b/internal/detector/nodeproject.go
@@ -61,7 +61,7 @@ func (d *NodeProjectDetector) countInDir(dir string) int {
 
 // DetectProjectPM detects which package manager a project uses based on lock files.
 func DetectProjectPM(exec executor.Executor, projectDir string) string {
-	if strings.Contains(projectDir, "/.bun/install/") {
+	if strings.Contains(filepath.ToSlash(projectDir), "/.bun/install/") {
 		return "bun"
 	}
 	if exec.FileExists(filepath.Join(projectDir, "bun.lock")) || exec.FileExists(filepath.Join(projectDir, "bun.lockb")) {

--- a/internal/detector/nodescan.go
+++ b/internal/detector/nodescan.go
@@ -190,7 +190,7 @@ func (s *NodeScanner) ScanProjects(ctx context.Context, searchDirs []string) []m
 				return nil
 			}
 			projectDir := filepath.Dir(path)
-			if strings.Contains(projectDir, "/node_modules/") {
+			if isInsideNodeModules(projectDir) {
 				return nil
 			}
 			// Get modification time for sorting
@@ -321,4 +321,12 @@ func (s *NodeScanner) getOutput(ctx context.Context, binary string, args ...stri
 		return ""
 	}
 	return strings.TrimSpace(stdout)
+}
+
+// isInsideNodeModules returns true if the path contains a node_modules component.
+// Uses strings.ReplaceAll instead of filepath.ToSlash so the check works
+// regardless of the host OS (important for cross-platform mock tests).
+func isInsideNodeModules(projectDir string) bool {
+	normalized := strings.ReplaceAll(projectDir, "\\", "/")
+	return strings.Contains(normalized, "/node_modules/")
 }

--- a/internal/detector/nodescan.go
+++ b/internal/detector/nodescan.go
@@ -105,7 +105,8 @@ func (s *NodeScanner) scanYarnGlobal(ctx context.Context) (model.NodeScanResult,
 	}
 
 	start := time.Now()
-	stdout, stderr, exitCode, _ := s.exec.RunWithTimeout(ctx, 60*time.Second, "bash", "-c", "cd '"+globalDir+"' && yarn list --json --depth=0")
+	shellCmd := "cd " + platformShellQuote(s.exec, globalDir) + " && yarn list --json --depth=0"
+	stdout, stderr, exitCode, _ := runShellCmd(ctx, s.exec, 60*time.Second, shellCmd)
 	duration := time.Since(start).Milliseconds()
 
 	errMsg := ""
@@ -281,11 +282,11 @@ func (s *NodeScanner) scanProject(ctx context.Context, projectDir string) model.
 	}
 
 	start := time.Now()
-	shellCmd := "cd " + shellQuote(projectDir) + " && " + cmd
+	cmdStr := "cd " + platformShellQuote(s.exec, projectDir) + " && " + cmd
 	for _, a := range args {
-		shellCmd += " " + a
+		cmdStr += " " + a
 	}
-	stdout, stderr, exitCode, _ := s.exec.RunWithTimeout(ctx, 30*time.Second, "bash", "-c", shellCmd)
+	stdout, stderr, exitCode, _ := runShellCmd(ctx, s.exec, 30*time.Second, cmdStr)
 	duration := time.Since(start).Milliseconds()
 
 	errMsg := ""
@@ -320,8 +321,4 @@ func (s *NodeScanner) getOutput(ctx context.Context, binary string, args ...stri
 		return ""
 	}
 	return strings.TrimSpace(stdout)
-}
-
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/internal/detector/nodescan_test.go
+++ b/internal/detector/nodescan_test.go
@@ -1,0 +1,244 @@
+package detector
+
+import (
+	"context"
+	"encoding/base64"
+	"path/filepath"
+	"testing"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/progress"
+)
+
+func newTestScanner(exec *executor.Mock) *NodeScanner {
+	log := progress.NewLogger(false)
+	return NewNodeScanner(exec, log)
+}
+
+func TestNodeScanner_ScanNPMGlobal(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetPath("npm", "/usr/local/bin/npm")
+	mock.SetCommand("10.2.0\n", "", 0, "npm", "--version")
+	mock.SetCommand("/usr/local\n", "", 0, "npm", "config", "get", "prefix")
+	mock.SetCommand(`{"dependencies":{"express":{"version":"4.18.2"}}}`, "", 0, "npm", "list", "-g", "--json", "--depth=3")
+
+	scanner := newTestScanner(mock)
+	results := scanner.ScanGlobalPackages(context.Background())
+
+	npmFound := false
+	for _, r := range results {
+		if r.PackageManager == "npm" {
+			npmFound = true
+			if r.ProjectPath != "/usr/local" {
+				t.Errorf("expected ProjectPath /usr/local, got %s", r.ProjectPath)
+			}
+			if r.PMVersion != "10.2.0" {
+				t.Errorf("expected PMVersion 10.2.0, got %s", r.PMVersion)
+			}
+			if r.ExitCode != 0 {
+				t.Errorf("expected ExitCode 0, got %d", r.ExitCode)
+			}
+			decoded, _ := base64.StdEncoding.DecodeString(r.RawStdoutBase64)
+			if len(decoded) == 0 {
+				t.Error("expected non-empty RawStdoutBase64")
+			}
+		}
+	}
+	if !npmFound {
+		t.Fatal("expected npm in global scan results")
+	}
+}
+
+func TestNodeScanner_ScanNPMGlobal_Windows(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetPath("npm", `C:\Program Files\nodejs\npm.cmd`)
+	mock.SetCommand("10.2.0\n", "", 0, "npm", "--version")
+	// npm config get prefix returns a Windows-style path on real Windows.
+	// The code stores it directly (no filepath.* processing), so the mock
+	// value flows through unchanged.
+	mock.SetCommand(`C:\Users\dev\AppData\Roaming\npm`+"\n", "", 0, "npm", "config", "get", "prefix")
+	mock.SetCommand(`{"dependencies":{"express":{"version":"4.18.2"}}}`, "", 0, "npm", "list", "-g", "--json", "--depth=3")
+
+	scanner := newTestScanner(mock)
+	results := scanner.ScanGlobalPackages(context.Background())
+
+	npmFound := false
+	for _, r := range results {
+		if r.PackageManager == "npm" {
+			npmFound = true
+			if r.ProjectPath != `C:\Users\dev\AppData\Roaming\npm` {
+				t.Errorf("expected Windows npm prefix, got %s", r.ProjectPath)
+			}
+			if r.PMVersion != "10.2.0" {
+				t.Errorf("expected PMVersion 10.2.0, got %s", r.PMVersion)
+			}
+			if r.ExitCode != 0 {
+				t.Errorf("expected ExitCode 0, got %d", r.ExitCode)
+			}
+		}
+	}
+	if !npmFound {
+		t.Fatal("expected npm in global scan results on Windows")
+	}
+}
+
+func TestNodeScanner_ScanYarnGlobal_Windows(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetPath("yarn", `C:\Program Files\nodejs\yarn.cmd`)
+	mock.SetCommand("1.22.19\n", "", 0, "yarn", "--version")
+	mock.SetCommand(`C:\Users\dev\AppData\Local\Yarn\Data\global`+"\n", "", 0, "yarn", "global", "dir")
+	// runShellCmd dispatches to cmd /c on Windows; platformShellQuote uses double quotes
+	mock.SetCommand(`{"type":"tree","data":{"trees":[]}}`, "", 0,
+		"cmd", "/c", `cd "C:\Users\dev\AppData\Local\Yarn\Data\global" && yarn list --json --depth=0`)
+
+	scanner := newTestScanner(mock)
+	results := scanner.ScanGlobalPackages(context.Background())
+
+	yarnFound := false
+	for _, r := range results {
+		if r.PackageManager == "yarn" {
+			yarnFound = true
+			if r.ProjectPath != `C:\Users\dev\AppData\Local\Yarn\Data\global` {
+				t.Errorf("expected Windows yarn global dir, got %s", r.ProjectPath)
+			}
+			if r.PMVersion != "1.22.19" {
+				t.Errorf("expected PMVersion 1.22.19, got %s", r.PMVersion)
+			}
+		}
+	}
+	if !yarnFound {
+		t.Fatal("expected yarn in global scan results on Windows")
+	}
+}
+
+func TestNodeScanner_ScanPnpmGlobal_Windows(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetPath("pnpm", `C:\Users\dev\AppData\Local\pnpm\pnpm.cmd`)
+	mock.SetCommand("9.1.0\n", "", 0, "pnpm", "--version")
+	// pnpm root -g returns the global node_modules dir. The code calls
+	// filepath.Dir on it. Since filepath.Dir is host-OS dependent, we use
+	// forward slashes here so the test works on macOS hosts too.
+	mock.SetCommand("C:/Users/dev/AppData/Local/pnpm/global/5/node_modules\n", "", 0, "pnpm", "root", "-g")
+	mock.SetCommand(`{"dependencies":{"typescript":{"version":"5.4.0"}}}`, "", 0, "pnpm", "list", "-g", "--json", "--depth=3")
+
+	scanner := newTestScanner(mock)
+	results := scanner.ScanGlobalPackages(context.Background())
+
+	pnpmFound := false
+	for _, r := range results {
+		if r.PackageManager == "pnpm" {
+			pnpmFound = true
+			// filepath.Dir strips the last component (node_modules)
+			expected := "C:/Users/dev/AppData/Local/pnpm/global/5"
+			if r.ProjectPath != expected {
+				t.Errorf("expected ProjectPath %s, got %s", expected, r.ProjectPath)
+			}
+			if r.PMVersion != "9.1.0" {
+				t.Errorf("expected PMVersion 9.1.0, got %s", r.PMVersion)
+			}
+		}
+	}
+	if !pnpmFound {
+		t.Fatal("expected pnpm in global scan results on Windows")
+	}
+}
+
+func TestNodeScanner_ScanProject_Windows(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetPath("npm", `C:\Program Files\nodejs\npm.cmd`)
+	mock.SetCommand("10.2.0\n", "", 0, "npm", "--version")
+	// DetectProjectPM uses filepath.Join which is host-dependent;
+	// construct the mock file path the same way the code will.
+	mock.SetFile(filepath.Join(`C:\Users\dev\myapp`, "package-lock.json"), []byte{})
+	mock.SetCommand(`{"dependencies":{"lodash":{"version":"4.17.21"}}}`, "", 0,
+		"cmd", "/c", `cd "C:\Users\dev\myapp" && npm ls --json --depth=3`)
+
+	scanner := newTestScanner(mock)
+	result := scanner.scanProject(context.Background(), `C:\Users\dev\myapp`)
+
+	if result.PackageManager != "npm" {
+		t.Errorf("expected npm, got %s", result.PackageManager)
+	}
+	if result.ProjectPath != `C:\Users\dev\myapp` {
+		t.Errorf("expected project path C:\\Users\\dev\\myapp, got %s", result.ProjectPath)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("expected ExitCode 0, got %d", result.ExitCode)
+	}
+	if result.PMVersion != "10.2.0" {
+		t.Errorf("expected PMVersion 10.2.0, got %s", result.PMVersion)
+	}
+	decoded, _ := base64.StdEncoding.DecodeString(result.RawStdoutBase64)
+	if len(decoded) == 0 {
+		t.Error("expected non-empty RawStdoutBase64")
+	}
+}
+
+func TestNodeScanner_ScanProject_YarnBerry_Windows(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetPath("yarn", `C:\Program Files\nodejs\yarn.cmd`)
+	mock.SetCommand("4.1.0\n", "", 0, "yarn", "--version")
+	// Use filepath.Join to construct mock file paths matching the code's behavior.
+	projectDir := `C:\Users\dev\myapp`
+	mock.SetFile(filepath.Join(projectDir, "yarn.lock"), []byte{})
+	mock.SetFile(filepath.Join(projectDir, ".yarnrc.yml"), []byte{})
+	mock.SetCommand(`{"name":"myapp","children":[]}`, "", 0,
+		"cmd", "/c", `cd "C:\Users\dev\myapp" && yarn info --all --json`)
+
+	scanner := newTestScanner(mock)
+	result := scanner.scanProject(context.Background(), projectDir)
+
+	if result.PackageManager != "yarn-berry" {
+		t.Errorf("expected yarn-berry, got %s", result.PackageManager)
+	}
+	if result.PMVersion != "4.1.0" {
+		t.Errorf("expected PMVersion 4.1.0, got %s", result.PMVersion)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("expected ExitCode 0, got %d", result.ExitCode)
+	}
+}
+
+func TestNodeScanner_ScanGlobalPackages_NoneInstalled(t *testing.T) {
+	mock := executor.NewMock()
+	scanner := newTestScanner(mock)
+	results := scanner.ScanGlobalPackages(context.Background())
+
+	if len(results) != 0 {
+		t.Errorf("expected 0 results when no PMs installed, got %d", len(results))
+	}
+}
+
+func TestIsInsideNodeModules(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Unix-style paths
+		{"/Users/dev/node_modules/foo", true},
+		{"/Users/dev/myapp", false},
+		{"/Users/dev/node_modules_backup/foo", false},
+		{"/node_modules/", true},
+		// Windows-style paths (backslashes)
+		{`C:\Users\dev\node_modules\foo`, true},
+		{`C:\Users\dev\myapp`, false},
+		{`C:\node_modules\pkg`, true},
+		{`\node_modules\`, true},
+		// Edge cases
+		{"node_modules", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isInsideNodeModules(tt.path)
+			if got != tt.want {
+				t.Errorf("isInsideNodeModules(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/detector/process.go
+++ b/internal/detector/process.go
@@ -1,0 +1,31 @@
+package detector
+
+import (
+	"context"
+	"strings"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+)
+
+// isProcessRunning checks if a process with the given name is running.
+// On Unix, uses pgrep -x; on Windows, uses tasklist with IMAGENAME filter.
+func isProcessRunning(ctx context.Context, exec executor.Executor, name string) bool {
+	if exec.GOOS() == "windows" {
+		stdout, _, exitCode, _ := exec.Run(ctx, "tasklist", "/FI",
+			"IMAGENAME eq "+name+".exe", "/NH")
+		return exitCode == 0 && !strings.Contains(stdout, "INFO: No tasks")
+	}
+	_, _, exitCode, _ := exec.Run(ctx, "pgrep", "-x", name)
+	return exitCode == 0
+}
+
+// isProcessRunningFuzzy checks if any process matches a substring pattern.
+// On Unix, uses pgrep -f; on Windows, scans tasklist output.
+func isProcessRunningFuzzy(ctx context.Context, exec executor.Executor, pattern string) bool {
+	if exec.GOOS() == "windows" {
+		stdout, _, _, _ := exec.Run(ctx, "tasklist", "/NH")
+		return strings.Contains(strings.ToLower(stdout), strings.ToLower(pattern))
+	}
+	_, _, exitCode, _ := exec.Run(ctx, "pgrep", "-f", pattern)
+	return exitCode == 0
+}

--- a/internal/detector/shellcmd.go
+++ b/internal/detector/shellcmd.go
@@ -1,0 +1,29 @@
+package detector
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+)
+
+// runShellCmd runs a shell command string using the platform-appropriate shell.
+// On Unix: bash -c "command"
+// On Windows: cmd /c "command"
+func runShellCmd(ctx context.Context, exec executor.Executor, timeout time.Duration, command string) (string, string, int, error) {
+	if exec.GOOS() == "windows" {
+		return exec.RunWithTimeout(ctx, timeout, "cmd", "/c", command)
+	}
+	return exec.RunWithTimeout(ctx, timeout, "bash", "-c", command)
+}
+
+// platformShellQuote quotes a string for use in a shell command.
+// On Unix: single quotes with escaping.
+// On Windows: double quotes with escaping.
+func platformShellQuote(exec executor.Executor, s string) string {
+	if exec.GOOS() == "windows" {
+		return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -11,17 +11,62 @@ import (
 // Gather collects device information (hostname, serial, OS version, user identity).
 func Gather(ctx context.Context, exec executor.Executor) model.Device {
 	hostname, _ := exec.Hostname()
-	serial := getSerialNumber(ctx, exec)
-	osVersion := getOSVersion(ctx, exec)
 	userIdentity := getDeveloperIdentity(exec)
+	platform := exec.GOOS()
+
+	var serial, osVersion string
+	switch platform {
+	case "windows":
+		serial = getSerialNumberWindows(ctx, exec)
+		osVersion = getOSVersionWindows(ctx, exec)
+	default:
+		serial = getSerialNumber(ctx, exec)
+		osVersion = getOSVersion(ctx, exec)
+	}
 
 	return model.Device{
 		Hostname:     hostname,
 		SerialNumber: serial,
 		OSVersion:    osVersion,
-		Platform:     "darwin",
+		Platform:     platform,
 		UserIdentity: userIdentity,
 	}
+}
+
+func getSerialNumberWindows(ctx context.Context, exec executor.Executor) string {
+	// Try wmic
+	stdout, _, _, err := exec.Run(ctx, "wmic", "bios", "get", "serialnumber")
+	if err == nil {
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		if len(lines) >= 2 {
+			serial := strings.TrimSpace(lines[1])
+			if serial != "" && serial != "SerialNumber" {
+				return serial
+			}
+		}
+	}
+	// Fallback: PowerShell
+	stdout, _, _, err = exec.Run(ctx, "powershell", "-NoProfile", "-Command",
+		"(Get-CimInstance -ClassName Win32_BIOS).SerialNumber")
+	if err == nil {
+		s := strings.TrimSpace(stdout)
+		if s != "" {
+			return s
+		}
+	}
+	return "unknown"
+}
+
+func getOSVersionWindows(ctx context.Context, exec executor.Executor) string {
+	stdout, _, _, err := exec.Run(ctx, "powershell", "-NoProfile", "-Command",
+		"[System.Environment]::OSVersion.Version.ToString()")
+	if err == nil {
+		v := strings.TrimSpace(stdout)
+		if v != "" {
+			return v
+		}
+	}
+	return "unknown"
 }
 
 func getSerialNumber(ctx context.Context, exec executor.Executor) string {

--- a/internal/device/device_test.go
+++ b/internal/device/device_test.go
@@ -57,3 +57,38 @@ func TestGather_EmailIdentity(t *testing.T) {
 		t.Errorf("identity: expected dev@example.com, got %s", dev.UserIdentity)
 	}
 }
+
+func TestGather_Windows(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetHostname("WIN-DESKTOP")
+	mock.SetHomeDir(`C:\Users\testuser`)
+	mock.SetUsername("testuser")
+
+	// wmic for serial number
+	mock.SetCommand("SerialNumber\nWIN-SERIAL-123\n", "", 0,
+		"wmic", "bios", "get", "serialnumber")
+
+	// PowerShell for OS version
+	mock.SetCommand("10.0.22631.0\n", "", 0,
+		"powershell", "-NoProfile", "-Command",
+		"[System.Environment]::OSVersion.Version.ToString()")
+
+	dev := Gather(context.Background(), mock)
+
+	if dev.Hostname != "WIN-DESKTOP" {
+		t.Errorf("hostname: expected WIN-DESKTOP, got %s", dev.Hostname)
+	}
+	if dev.Platform != "windows" {
+		t.Errorf("platform: expected windows, got %s", dev.Platform)
+	}
+	if dev.SerialNumber != "WIN-SERIAL-123" {
+		t.Errorf("serial: expected WIN-SERIAL-123, got %s", dev.SerialNumber)
+	}
+	if dev.OSVersion != "10.0.22631.0" {
+		t.Errorf("os_version: expected 10.0.22631.0, got %s", dev.OSVersion)
+	}
+	if dev.UserIdentity != "testuser" {
+		t.Errorf("user_identity: expected testuser, got %s", dev.UserIdentity)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -9,7 +9,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 )
 
@@ -82,15 +81,6 @@ func (r *Real) RunWithTimeout(ctx context.Context, timeout time.Duration, name s
 	return stdout, stderr, code, err
 }
 
-func (r *Real) RunAsUser(ctx context.Context, username, command string) (string, error) {
-	if !r.IsRoot() {
-		stdout, _, _, err := r.Run(ctx, "bash", "-c", command)
-		return strings.TrimSpace(stdout), err
-	}
-	stdout, _, _, err := r.Run(ctx, "sudo", "-H", "-u", username, "bash", "-l", "-c", command)
-	return strings.TrimSpace(stdout), err
-}
-
 func (r *Real) LookPath(name string) (string, error) {
 	return exec.LookPath(name)
 }
@@ -123,10 +113,6 @@ func (r *Real) Hostname() (string, error) {
 
 func (r *Real) Getenv(key string) string {
 	return os.Getenv(key)
-}
-
-func (r *Real) IsRoot() bool {
-	return os.Getuid() == 0
 }
 
 func (r *Real) CurrentUser() (*user.User, error) {

--- a/internal/executor/executor_unix.go
+++ b/internal/executor/executor_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package executor
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+func (r *Real) IsRoot() bool {
+	return os.Getuid() == 0
+}
+
+func (r *Real) RunAsUser(ctx context.Context, username, command string) (string, error) {
+	if !r.IsRoot() {
+		stdout, _, _, err := r.Run(ctx, "bash", "-c", command)
+		return strings.TrimSpace(stdout), err
+	}
+	stdout, _, _, err := r.Run(ctx, "sudo", "-H", "-u", username, "bash", "-l", "-c", command)
+	return strings.TrimSpace(stdout), err
+}

--- a/internal/executor/executor_windows.go
+++ b/internal/executor/executor_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package executor
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+func (r *Real) IsRoot() bool {
+	cmd := exec.Command("net", "session")
+	err := cmd.Run()
+	return err == nil
+}
+
+func (r *Real) RunAsUser(ctx context.Context, _ string, command string) (string, error) {
+	stdout, _, _, err := r.Run(ctx, "cmd", "/c", command)
+	return strings.TrimSpace(stdout), err
+}

--- a/internal/executor/mock.go
+++ b/internal/executor/mock.go
@@ -145,6 +145,12 @@ func (m *Mock) SetGlob(pattern string, matches []string) {
 	m.globs[pattern] = matches
 }
 
+func (m *Mock) SetGOOS(goos string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.goos = goos
+}
+
 // --- Executor interface ---
 
 func (m *Mock) Run(_ context.Context, name string, args ...string) (string, string, int, error) {

--- a/internal/launchd/launchd.go
+++ b/internal/launchd/launchd.go
@@ -80,7 +80,7 @@ func Install(exec executor.Executor, log *progress.Logger) error {
 	if err != nil {
 		return fmt.Errorf("creating plist file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	tmpl, err := template.New("plist").Parse(plistTmpl)
 	if err != nil {
@@ -136,7 +136,7 @@ func doUninstall(ctx context.Context, exec executor.Executor, log *progress.Logg
 
 	// Remove plist
 	if exec.FileExists(plistPath) {
-		os.Remove(plistPath)
+		_ = os.Remove(plistPath)
 		log.Progress("Removed plist file: %s", plistPath)
 	}
 

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -6,12 +6,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
 )
-
-const lockFilePath = "/tmp/stepsecurity-dev-machine-guard.lock"
 
 // Lock represents an acquired instance lock.
 type Lock struct {
@@ -61,16 +58,3 @@ func (l *Lock) Release() {
 	}
 }
 
-// isProcessAlive checks if a process with the given PID exists.
-// Returns true if the process is alive (signal 0 succeeds or returns EPERM).
-func isProcessAlive(pid int) bool {
-	err := syscall.Kill(pid, 0)
-	if err == nil {
-		return true // process exists and we can signal it
-	}
-	// EPERM means the process exists but we don't have permission to signal it
-	if errors.Is(err, syscall.EPERM) {
-		return true
-	}
-	return false // ESRCH or other error — process doesn't exist
-}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -42,7 +42,7 @@ func Acquire(_ executor.Executor) (*Lock, error) {
 	}
 
 	_, err = fmt.Fprintf(f, "%d", os.Getpid())
-	f.Close()
+	_ = f.Close()
 	if err != nil {
 		_ = os.Remove(lockFilePath)
 		return nil, fmt.Errorf("writing PID to lock file: %w", err)

--- a/internal/lock/lock_unix.go
+++ b/internal/lock/lock_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package lock
+
+import (
+	"errors"
+	"syscall"
+)
+
+var lockFilePath = "/tmp/stepsecurity-dev-machine-guard.lock"
+
+// isProcessAlive checks if a process with the given PID exists.
+// Returns true if the process is alive (signal 0 succeeds or returns EPERM).
+func isProcessAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true // process exists and we can signal it
+	}
+	// EPERM means the process exists but we don't have permission to signal it
+	if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false // ESRCH or other error — process doesn't exist
+}

--- a/internal/lock/lock_windows.go
+++ b/internal/lock/lock_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package lock
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var lockFilePath = filepath.Join(os.TempDir(), "stepsecurity-dev-machine-guard.lock")
+
+// isProcessAlive checks if a process with the given PID exists using tasklist.
+func isProcessAlive(pid int) bool {
+	cmd := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return !strings.Contains(string(output), "No tasks")
+}

--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -169,7 +169,7 @@ const htmlTemplate = `<!DOCTYPE html>
 <div class="device-grid">
   <div class="field"><span class="field-label">Hostname</span><span class="field-value">{{.Device.Hostname}}</span></div>
   <div class="field"><span class="field-label">Serial</span><span class="field-value">{{.Device.SerialNumber}}</span></div>
-  <div class="field"><span class="field-label">macOS</span><span class="field-value">{{.Device.OSVersion}}</span></div>
+  <div class="field"><span class="field-label">{{if eq .Device.Platform "windows"}}Windows{{else}}macOS{{end}}</span><span class="field-value">{{.Device.OSVersion}}</span></div>
   <div class="field"><span class="field-label">User</span><span class="field-value">{{.Device.UserIdentity}}</span></div>
 </div>
 

--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -41,7 +41,7 @@ func HTML(outputFile string, result *model.ScanResult) error {
 	if err != nil {
 		return fmt.Errorf("creating HTML file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanTime := time.Unix(result.ScanTimestamp, 0).Format("2006-01-02 15:04:05")
 

--- a/internal/output/html_test.go
+++ b/internal/output/html_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestHTML_GeneratesFile(t *testing.T) {
 	tmpFile := os.TempDir() + "/test-dmg-report.html"
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	result := &model.ScanResult{
 		AgentVersion:     "1.9.0",
@@ -55,7 +55,7 @@ func TestHTML_GeneratesFile(t *testing.T) {
 
 func TestHTML_ContainsData(t *testing.T) {
 	tmpFile := os.TempDir() + "/test-dmg-data.html"
-	defer os.Remove(tmpFile)
+	defer func() { _ = os.Remove(tmpFile) }()
 
 	result := &model.ScanResult{
 		ScanTimestamp: 1700000000,

--- a/internal/output/pretty.go
+++ b/internal/output/pretty.go
@@ -36,7 +36,11 @@ func Pretty(w io.Writer, result *model.ScanResult, colorMode string) error {
 	fmt.Fprintf(w, "  %s%sDEVICE%s\n", c.purple, c.bold, c.reset)
 	fmt.Fprintf(w, "    %-16s %s\n", "Hostname", result.Device.Hostname)
 	fmt.Fprintf(w, "    %-16s %s\n", "Serial", result.Device.SerialNumber)
-	fmt.Fprintf(w, "    %-16s %s\n", "macOS", result.Device.OSVersion)
+	osLabel := "macOS"
+	if result.Device.Platform == "windows" {
+		osLabel = "Windows"
+	}
+	fmt.Fprintf(w, "    %-16s %s\n", osLabel, result.Device.OSVersion)
 	fmt.Fprintf(w, "    %-16s %s\n", "User", result.Device.UserIdentity)
 	fmt.Fprintln(w)
 

--- a/internal/output/pretty.go
+++ b/internal/output/pretty.go
@@ -11,6 +11,7 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/model"
 )
 
+//nolint:errcheck // fmt.Fprint* to io.Writer; errors surface through the writer
 // Pretty writes human-readable formatted output.
 func Pretty(w io.Writer, result *model.ScanResult, colorMode string) error {
 	c := setupColors(colorMode)
@@ -143,6 +144,7 @@ func Pretty(w io.Writer, result *model.ScanResult, colorMode string) error {
 	return nil
 }
 
+//nolint:errcheck // terminal output
 func printSectionHeader(w io.Writer, c *colors, title string, count int) {
 	padding := 35 - len(title)
 	if padding < 1 {

--- a/internal/schtasks/schtasks.go
+++ b/internal/schtasks/schtasks.go
@@ -42,20 +42,14 @@ func Install(exec executor.Executor, log *progress.Logger) error {
 		return fmt.Errorf("creating log directory: %w", err)
 	}
 
-	// Build the task command with output redirection
-	taskCmd := fmt.Sprintf(`cmd /c "\"%s\" send-telemetry >> \"%s\agent.log\" 2>> \"%s\agent.error.log\""`,
-		binaryPath, logDir, logDir)
-
-	// Build schtasks arguments
-	args := []string{"/create", "/tn", taskName, "/tr", taskCmd,
-		"/sc", "HOURLY", "/mo", strconv.Itoa(hours), "/f"}
-	if exec.IsRoot() {
-		args = append(args, "/ru", "SYSTEM")
-	}
+	args := buildCreateArgs(binaryPath, logDir, hours, exec.IsRoot())
 
 	_, stderr, exitCode, err := exec.Run(ctx, "schtasks", args...)
-	if err != nil || exitCode != 0 {
-		return fmt.Errorf("failed to create scheduled task: %s", stderr)
+	if err != nil {
+		return fmt.Errorf("failed to create scheduled task: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("failed to create scheduled task (exit code %d): %s", exitCode, stderr)
 	}
 
 	log.Progress("Windows Task Scheduler configuration completed successfully")
@@ -81,8 +75,11 @@ func Uninstall(exec executor.Executor, log *progress.Logger) error {
 
 func doUninstall(ctx context.Context, exec executor.Executor, log *progress.Logger) error {
 	_, stderr, exitCode, err := exec.Run(ctx, "schtasks", "/delete", "/tn", taskName, "/f")
-	if err != nil || exitCode != 0 {
-		return fmt.Errorf("failed to delete scheduled task: %s", stderr)
+	if err != nil {
+		return fmt.Errorf("failed to delete scheduled task: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("failed to delete scheduled task (exit code %d): %s", exitCode, stderr)
 	}
 
 	log.Progress("Removed scheduled task: %s", taskName)
@@ -93,6 +90,17 @@ func doUninstall(ctx context.Context, exec executor.Executor, log *progress.Logg
 func isConfigured(ctx context.Context, exec executor.Executor) bool {
 	_, _, exitCode, _ := exec.Run(ctx, "schtasks", "/query", "/tn", taskName)
 	return exitCode == 0
+}
+
+func buildCreateArgs(binaryPath, logDir string, hours int, isAdmin bool) []string {
+	taskCmd := fmt.Sprintf(`cmd /c "\"%s\" send-telemetry >> \"%s\agent.log\" 2>> \"%s\agent.error.log\""`,
+		binaryPath, logDir, logDir)
+	args := []string{"/create", "/tn", taskName, "/tr", taskCmd,
+		"/sc", "HOURLY", "/mo", strconv.Itoa(hours), "/f"}
+	if isAdmin {
+		args = append(args, "/ru", "SYSTEM")
+	}
+	return args
 }
 
 func resolveLogDir(exec executor.Executor) string {

--- a/internal/schtasks/schtasks.go
+++ b/internal/schtasks/schtasks.go
@@ -1,0 +1,107 @@
+package schtasks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/step-security/dev-machine-guard/internal/config"
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/progress"
+)
+
+const taskName = "StepSecurity Agent"
+
+// Install configures Windows Task Scheduler for periodic scanning.
+// If already installed, upgrades by removing and re-creating the task.
+func Install(exec executor.Executor, log *progress.Logger) error {
+	ctx := context.Background()
+
+	// Check for existing installation and upgrade
+	if isConfigured(ctx, exec) {
+		log.Progress("Existing agent installation detected. Upgrading...")
+		if err := doUninstall(ctx, exec, log); err != nil {
+			log.Progress("Warning: failed to remove previous installation: %v", err)
+		}
+		log.Progress("Previous installation removed. Installing new version...")
+	}
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("determining binary path: %w", err)
+	}
+
+	hours, _ := strconv.Atoi(config.ScanFrequencyHours)
+	if hours <= 0 {
+		hours = 4
+	}
+
+	logDir := resolveLogDir(exec)
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return fmt.Errorf("creating log directory: %w", err)
+	}
+
+	// Build the task command with output redirection
+	taskCmd := fmt.Sprintf(`cmd /c "\"%s\" send-telemetry >> \"%s\agent.log\" 2>> \"%s\agent.error.log\""`,
+		binaryPath, logDir, logDir)
+
+	// Build schtasks arguments
+	args := []string{"/create", "/tn", taskName, "/tr", taskCmd,
+		"/sc", "HOURLY", "/mo", strconv.Itoa(hours), "/f"}
+	if exec.IsRoot() {
+		args = append(args, "/ru", "SYSTEM")
+	}
+
+	_, stderr, exitCode, err := exec.Run(ctx, "schtasks", args...)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("failed to create scheduled task: %s", stderr)
+	}
+
+	log.Progress("Windows Task Scheduler configuration completed successfully")
+	log.Progress("  Task: %s", taskName)
+	log.Progress("  Logs: %s\\agent.log", logDir)
+	log.Progress("Installation complete!")
+	log.Progress("The agent will now run automatically every %d hours", hours)
+
+	return nil
+}
+
+// Uninstall removes the scheduled task.
+func Uninstall(exec executor.Executor, log *progress.Logger) error {
+	ctx := context.Background()
+
+	if !isConfigured(ctx, exec) {
+		log.Progress("Agent is not currently configured for periodic execution")
+		return nil
+	}
+
+	return doUninstall(ctx, exec, log)
+}
+
+func doUninstall(ctx context.Context, exec executor.Executor, log *progress.Logger) error {
+	_, stderr, exitCode, err := exec.Run(ctx, "schtasks", "/delete", "/tn", taskName, "/f")
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("failed to delete scheduled task: %s", stderr)
+	}
+
+	log.Progress("Removed scheduled task: %s", taskName)
+	log.Progress("Windows Task Scheduler configuration removed successfully")
+	return nil
+}
+
+func isConfigured(ctx context.Context, exec executor.Executor) bool {
+	_, _, exitCode, _ := exec.Run(ctx, "schtasks", "/query", "/tn", taskName)
+	return exitCode == 0
+}
+
+func resolveLogDir(exec executor.Executor) string {
+	if exec.IsRoot() {
+		return `C:\ProgramData\StepSecurity`
+	}
+	homeDir, _ := exec.CurrentUser()
+	if homeDir != nil {
+		return homeDir.HomeDir + `\.stepsecurity`
+	}
+	return `C:\ProgramData\StepSecurity`
+}

--- a/internal/schtasks/schtasks.go
+++ b/internal/schtasks/schtasks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/progress"
 )
 
-const taskName = "StepSecurity Agent"
+const taskName = "StepSecurity Dev Machine Guard"
 
 // Install configures Windows Task Scheduler for periodic scanning.
 // If already installed, upgrades by removing and re-creating the task.

--- a/internal/schtasks/schtasks_test.go
+++ b/internal/schtasks/schtasks_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/step-security/dev-machine-guard/internal/config"
 	"github.com/step-security/dev-machine-guard/internal/executor"
 	"github.com/step-security/dev-machine-guard/internal/progress"
 )
@@ -98,21 +97,47 @@ func TestResolveLogDir_Admin(t *testing.T) {
 	}
 }
 
-func TestInstall_CustomFrequency(t *testing.T) {
-	origFreq := config.ScanFrequencyHours
-	t.Cleanup(func() { config.ScanFrequencyHours = origFreq })
-	config.ScanFrequencyHours = "6"
+func TestBuildCreateArgs_CustomFrequency(t *testing.T) {
+	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, 6, false)
 
-	mock := executor.NewMock()
-	mock.SetGOOS("windows")
-	mock.SetIsRoot(false)
-	mock.SetHomeDir(`C:\Users\testuser`)
-	// Task doesn't exist
-	mock.SetCommand("", "ERROR: not found", 1, "schtasks", "/query", "/tn", taskName)
+	// Find the /mo argument and check its value
+	foundMo := false
+	for i, a := range args {
+		if a == "/mo" && i+1 < len(args) {
+			foundMo = true
+			if args[i+1] != "6" {
+				t.Errorf("expected /mo 6, got /mo %s", args[i+1])
+			}
+		}
+	}
+	if !foundMo {
+		t.Error("expected /mo argument in schtasks create args")
+	}
+}
 
-	// Install will fail at os.Executable or schtasks create, but we're testing
-	// that the frequency is parsed correctly via the resolveLogDir and config paths.
-	// A full integration test requires the real binary on Windows.
-	_ = Install(mock, newTestLogger())
-	// If we got past the config parsing without panic, the frequency was handled correctly.
+func TestBuildCreateArgs_Admin(t *testing.T) {
+	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, 4, true)
+
+	foundRU := false
+	for i, a := range args {
+		if a == "/ru" && i+1 < len(args) {
+			foundRU = true
+			if args[i+1] != "SYSTEM" {
+				t.Errorf("expected /ru SYSTEM, got /ru %s", args[i+1])
+			}
+		}
+	}
+	if !foundRU {
+		t.Error("expected /ru SYSTEM for admin install")
+	}
+}
+
+func TestBuildCreateArgs_NonAdmin(t *testing.T) {
+	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, 4, false)
+
+	for _, a := range args {
+		if a == "/ru" {
+			t.Error("expected no /ru argument for non-admin install")
+		}
+	}
 }

--- a/internal/schtasks/schtasks_test.go
+++ b/internal/schtasks/schtasks_test.go
@@ -1,0 +1,118 @@
+package schtasks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/step-security/dev-machine-guard/internal/config"
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/progress"
+)
+
+func newTestLogger() *progress.Logger {
+	return progress.NewLogger(false)
+}
+
+func TestIsConfigured_True(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetCommand("", "", 0, "schtasks", "/query", "/tn", taskName)
+
+	got := isConfigured(context.Background(), mock)
+	if !got {
+		t.Error("expected isConfigured to return true when task exists")
+	}
+}
+
+func TestIsConfigured_False(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetCommand("", "ERROR: The system cannot find the path specified.", 1, "schtasks", "/query", "/tn", taskName)
+
+	got := isConfigured(context.Background(), mock)
+	if got {
+		t.Error("expected isConfigured to return false when task does not exist")
+	}
+}
+
+func TestUninstall_Configured(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetCommand("", "", 0, "schtasks", "/query", "/tn", taskName)
+	mock.SetCommand("SUCCESS: The scheduled task was successfully deleted.", "", 0, "schtasks", "/delete", "/tn", taskName, "/f")
+
+	err := Uninstall(mock, newTestLogger())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestUninstall_NotConfigured(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetCommand("", "ERROR: The system cannot find the path specified.", 1, "schtasks", "/query", "/tn", taskName)
+
+	err := Uninstall(mock, newTestLogger())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestInstall_CreateFails(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetHomeDir(`C:\Users\testuser`)
+	// Task doesn't exist
+	mock.SetCommand("", "ERROR: The system cannot find the path specified.", 1, "schtasks", "/query", "/tn", taskName)
+
+	// Note: Install calls os.Executable() and os.MkdirAll() which we can't mock,
+	// but the schtasks /create will fail because we haven't stubbed it.
+	err := Install(mock, newTestLogger())
+	if err == nil {
+		t.Fatal("expected error when schtasks /create is not stubbed")
+	}
+}
+
+func TestResolveLogDir_NonAdmin(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetIsRoot(false)
+	mock.SetHomeDir(`C:\Users\testuser`)
+
+	dir := resolveLogDir(mock)
+	expected := `C:\Users\testuser\.stepsecurity`
+	if dir != expected {
+		t.Errorf("expected %s, got %s", expected, dir)
+	}
+}
+
+func TestResolveLogDir_Admin(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetIsRoot(true)
+
+	dir := resolveLogDir(mock)
+	expected := `C:\ProgramData\StepSecurity`
+	if dir != expected {
+		t.Errorf("expected %s, got %s", expected, dir)
+	}
+}
+
+func TestInstall_CustomFrequency(t *testing.T) {
+	origFreq := config.ScanFrequencyHours
+	t.Cleanup(func() { config.ScanFrequencyHours = origFreq })
+	config.ScanFrequencyHours = "6"
+
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetIsRoot(false)
+	mock.SetHomeDir(`C:\Users\testuser`)
+	// Task doesn't exist
+	mock.SetCommand("", "ERROR: not found", 1, "schtasks", "/query", "/tn", taskName)
+
+	// Install will fail at os.Executable or schtasks create, but we're testing
+	// that the frequency is parsed correctly via the resolveLogDir and config paths.
+	// A full integration test requires the real binary on Windows.
+	_ = Install(mock, newTestLogger())
+	// If we got past the config parsing without panic, the frequency was handled correctly.
+}

--- a/internal/telemetry/logcapture.go
+++ b/internal/telemetry/logcapture.go
@@ -71,7 +71,7 @@ func (lc *LogCapture) Finalize() string {
 	}
 
 	// Close write end so the reader goroutine exits
-	lc.pipeWrite.Close()
+	_ = lc.pipeWrite.Close()
 	lc.pipeWrite = nil
 	lc.mu.Unlock()
 	<-lc.done
@@ -79,7 +79,7 @@ func (lc *LogCapture) Finalize() string {
 
 	// Restore stderr
 	os.Stderr = lc.origErr
-	lc.pipeRead.Close()
+	_ = lc.pipeRead.Close()
 
 	return base64.StdEncoding.EncodeToString(lc.buf.Bytes())
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -304,7 +304,7 @@ func uploadToS3(ctx context.Context, log *progress.Logger, payload *Payload) err
 	if err != nil {
 		return fmt.Errorf("requesting upload URL: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var urlResp struct {
 		UploadURL string `json:"upload_url"`
@@ -330,7 +330,7 @@ func uploadToS3(ctx context.Context, log *progress.Logger, payload *Payload) err
 	if err != nil {
 		return fmt.Errorf("uploading to S3: %w", err)
 	}
-	defer putResp.Body.Close()
+	defer func() { _ = putResp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, putResp.Body)
 
 	if putResp.StatusCode != http.StatusOK {
@@ -360,7 +360,7 @@ func uploadToS3(ctx context.Context, log *progress.Logger, payload *Payload) err
 	if err != nil {
 		return fmt.Errorf("notifying backend: %w", err)
 	}
-	defer notifyResp.Body.Close()
+	defer func() { _ = notifyResp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, notifyResp.Body)
 
 	if notifyResp.StatusCode != http.StatusOK && notifyResp.StatusCode != http.StatusCreated {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -236,7 +236,7 @@ func Run(exec executor.Executor, log *progress.Logger, cfg *cli.Config) error {
 		SerialNumber:   dev.SerialNumber,
 		UserIdentity:   dev.UserIdentity,
 		Hostname:       dev.Hostname,
-		Platform:       "darwin",
+		Platform:       dev.Platform,
 		OSVersion:      dev.OSVersion,
 		AgentVersion:   buildinfo.Version,
 		CollectedAt:    endTime.Unix(),

--- a/scripts/deploy-windows.sh
+++ b/scripts/deploy-windows.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# Deploy stepsecurity-dev-machine-guard.exe to a remote Windows machine.
+#
+# Builds the Windows binary, copies it via SCP, and optionally runs a scan.
+# Requires: go, sshpass (for password auth) or SSH key-based auth.
+#
+# Usage:
+#   ./scripts/deploy-windows.sh --host HOST --user USER [OPTIONS]
+#
+# Examples:
+#   # Password auth (prompted or via env)
+#   DEPLOY_PASSWORD='secret' ./scripts/deploy-windows.sh --host 10.0.0.5 --user Administrator
+#
+#   # SSH key auth
+#   ./scripts/deploy-windows.sh --host 10.0.0.5 --user Administrator --key ~/.ssh/id_rsa
+#
+#   # Deploy + run scan
+#   ./scripts/deploy-windows.sh --host 10.0.0.5 --user Administrator --run
+#
+#   # Skip build (binary already exists)
+#   ./scripts/deploy-windows.sh --host 10.0.0.5 --user Administrator --no-build
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BINARY_NAME="stepsecurity-dev-machine-guard.exe"
+REMOTE_DIR=""  # resolved after USER is set
+
+# Defaults
+HOST=""
+USER=""
+KEY=""
+PASSWORD="${DEPLOY_PASSWORD:-}"
+DO_BUILD=true
+DO_RUN=false
+RUN_ARGS=""
+SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --host HOST --user USER [OPTIONS]
+
+Required:
+  --host HOST         Remote Windows machine IP or hostname
+  --user USER         SSH username (e.g., Administrator)
+
+Authentication (one of):
+  --key FILE          SSH private key file
+  DEPLOY_PASSWORD     Environment variable with SSH password (uses sshpass)
+
+Options:
+  --no-build          Skip build step (use existing .exe)
+  --run [ARGS]        Run a scan after deploying (pass extra flags after --)
+  --remote-dir DIR    Remote directory (default: C:\\Users\\<USER>)
+  -h, --help          Show this help
+
+Examples:
+  DEPLOY_PASSWORD='pw' $0 --host 10.0.0.5 --user Admin
+  $0 --host 10.0.0.5 --user Admin --key ~/.ssh/id_rsa --run
+  $0 --host 10.0.0.5 --user Admin --run -- --enable-npm-scan --json
+EOF
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)       HOST="$2"; shift 2 ;;
+        --user)       USER="$2"; shift 2 ;;
+        --key)        KEY="$2"; shift 2 ;;
+        --no-build)   DO_BUILD=false; shift ;;
+        --run)        DO_RUN=true; shift ;;
+        --remote-dir) REMOTE_DIR="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        --)           shift; RUN_ARGS="$*"; break ;;
+        *)            echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Validate required args
+if [[ -z "$HOST" || -z "$USER" ]]; then
+    echo "Error: --host and --user are required" >&2
+    echo "Run with --help for usage" >&2
+    exit 1
+fi
+
+# Resolve default remote directory using the SSH user
+if [[ -z "$REMOTE_DIR" ]]; then
+    REMOTE_DIR="C:\\Users\\${USER}"
+fi
+
+# Build SSH/SCP command prefix based on auth method
+ssh_cmd() {
+    if [[ -n "$KEY" ]]; then
+        ssh $SSH_OPTS -i "$KEY" "${USER}@${HOST}" "$@"
+    elif [[ -n "$PASSWORD" ]]; then
+        if ! command -v sshpass &>/dev/null; then
+            echo "Error: sshpass required for password auth (brew install sshpass / apt install sshpass)" >&2
+            exit 1
+        fi
+        SSHPASS="$PASSWORD" sshpass -e ssh $SSH_OPTS "${USER}@${HOST}" "$@"
+    else
+        echo "Error: provide --key or set DEPLOY_PASSWORD" >&2
+        exit 1
+    fi
+}
+
+scp_cmd() {
+    local src="$1" dst="$2"
+    if [[ -n "$KEY" ]]; then
+        scp $SSH_OPTS -i "$KEY" "$src" "${USER}@${HOST}:${dst}"
+    elif [[ -n "$PASSWORD" ]]; then
+        SSHPASS="$PASSWORD" sshpass -e scp $SSH_OPTS "$src" "${USER}@${HOST}:${dst}"
+    fi
+}
+
+# Step 1: Build
+if $DO_BUILD; then
+    echo "==> Building Windows binary..."
+    (cd "$PROJECT_DIR" && make build-windows)
+    echo "    Built: ${BINARY_NAME}"
+else
+    if [[ ! -f "${PROJECT_DIR}/${BINARY_NAME}" ]]; then
+        echo "Error: ${BINARY_NAME} not found. Run without --no-build or run 'make build-windows' first." >&2
+        exit 1
+    fi
+    echo "==> Skipping build (using existing binary)"
+fi
+
+# Step 2: Deploy
+REMOTE_PATH="${REMOTE_DIR}\\${BINARY_NAME}"
+echo "==> Deploying to ${USER}@${HOST}:${REMOTE_PATH}..."
+scp_cmd "${PROJECT_DIR}/${BINARY_NAME}" "${REMOTE_PATH}"
+echo "    Deployed successfully"
+
+# Step 3: Verify
+echo "==> Verifying remote binary..."
+REMOTE_VERSION=$(ssh_cmd "${REMOTE_PATH} --version" 2>&1 || true)
+echo "    ${REMOTE_VERSION}"
+
+# Step 4: Run (optional)
+if $DO_RUN; then
+    echo "==> Running scan..."
+    ssh_cmd "${REMOTE_PATH} --color=never ${RUN_ARGS}" 2>&1
+fi
+
+echo "==> Done"

--- a/scripts/deploy-windows.sh
+++ b/scripts/deploy-windows.sh
@@ -113,7 +113,14 @@ scp_cmd() {
     if [[ -n "$KEY" ]]; then
         scp $SSH_OPTS -i "$KEY" "$src" "${USER}@${HOST}:${dst}"
     elif [[ -n "$PASSWORD" ]]; then
+        if ! command -v sshpass &>/dev/null; then
+            echo "Error: sshpass required for password auth (brew install sshpass / apt install sshpass)" >&2
+            exit 1
+        fi
         SSHPASS="$PASSWORD" sshpass -e scp $SSH_OPTS "$src" "${USER}@${HOST}:${dst}"
+    else
+        echo "Error: provide --key or set DEPLOY_PASSWORD" >&2
+        exit 1
     fi
 }
 

--- a/tests/test_smoke_go.sh
+++ b/tests/test_smoke_go.sh
@@ -215,7 +215,7 @@ else
 fi
 
 BOGUS_ERR=$("$BINARY" --bogus-flag 2>&1 || true)
-assert_contains "Invalid flag shows error" "$BOGUS_ERR" "Unknown option"
+assert_contains "Invalid flag shows error" "$BOGUS_ERR" "unknown option"
 
 #==============================================================================
 # 6. JSON schema validation


### PR DESCRIPTION
## What does this PR do?

Adds official windows support. 
<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
