### PR TITLE
fix(ci): find path for windows binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,23 +108,24 @@ jobs:
 
       - name: Sign artifacts with Sigstore
         run: |
-          for artifact in \
-            "${{ steps.binaries.outputs.darwin }}" \
-            "${{ steps.binaries.outputs.win_amd64 }}" \
-            "${{ steps.binaries.outputs.win_arm64 }}" \
-            stepsecurity-dev-machine-guard.sh; do
-            cosign sign-blob "$artifact" --bundle "${artifact}.bundle" --yes
-          done
+          cosign sign-blob "${{ steps.binaries.outputs.darwin }}" \
+            --bundle dist/stepsecurity-dev-machine-guard-darwin_unnotarized.bundle --yes
+          cosign sign-blob "${{ steps.binaries.outputs.win_amd64 }}" \
+            --bundle dist/stepsecurity-dev-machine-guard-windows_amd64.exe.bundle --yes
+          cosign sign-blob "${{ steps.binaries.outputs.win_arm64 }}" \
+            --bundle dist/stepsecurity-dev-machine-guard-windows_arm64.exe.bundle --yes
+          cosign sign-blob stepsecurity-dev-machine-guard.sh \
+            --bundle dist/stepsecurity-dev-machine-guard.sh.bundle --yes
 
       - name: Upload cosign bundles
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ steps.release.outputs.tag }}" \
-            "${{ steps.binaries.outputs.darwin }}.bundle" \
-            "${{ steps.binaries.outputs.win_amd64 }}.bundle" \
-            "${{ steps.binaries.outputs.win_arm64 }}.bundle" \
-            stepsecurity-dev-machine-guard.sh.bundle \
+            dist/stepsecurity-dev-machine-guard-darwin_unnotarized.bundle \
+            dist/stepsecurity-dev-machine-guard-windows_amd64.exe.bundle \
+            dist/stepsecurity-dev-machine-guard-windows_arm64.exe.bundle \
+            dist/stepsecurity-dev-machine-guard.sh.bundle \
             --clobber
 
       - name: Attest build provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve draft release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GoReleaser creates draft releases under an "untagged-*" slug,
+          # so gh release upload by version tag returns 404. Look up the
+          # actual tag GitHub assigned to the draft.
+          release_tag=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq '[.[] | select(.draft and .name == "${{ steps.version.outputs.tag }}")] | first | .tag_name')
+          if [ -z "$release_tag" ] || [ "$release_tag" = "null" ]; then
+            echo "::error::Could not find draft release for ${{ steps.version.outputs.tag }}"
+            exit 1
+          fi
+          echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "Resolved draft release tag: $release_tag"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
@@ -103,7 +120,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ steps.version.outputs.tag }}" \
+          gh release upload "${{ steps.release.outputs.tag }}" \
             "${{ steps.binaries.outputs.darwin }}.bundle" \
             "${{ steps.binaries.outputs.win_amd64 }}.bundle" \
             "${{ steps.binaries.outputs.win_arm64 }}.bundle" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,8 @@ jobs:
         id: binaries
         run: |
           DARWIN=$(find dist -type f -name '*darwin_unnotarized' | head -1)
-          WIN_AMD64=$(find dist -type f -name '*windows_amd64.exe' | head -1)
-          WIN_ARM64=$(find dist -type f -name '*windows_arm64.exe' | head -1)
+          WIN_AMD64=$(find dist -type f -name '*.exe' -path '*windows_amd64*' | head -1)
+          WIN_ARM64=$(find dist -type f -name '*.exe' -path '*windows_arm64*' | head -1)
 
           for label in "darwin:${DARWIN}" "windows_amd64:${WIN_AMD64}" "windows_arm64:${WIN_ARM64}"; do
             name="${label%%:*}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
             "${{ steps.binaries.outputs.darwin }}.bundle" \
             "${{ steps.binaries.outputs.win_amd64 }}.bundle" \
             "${{ steps.binaries.outputs.win_arm64 }}.bundle" \
-            dist/stepsecurity-dev-machine-guard.sh.bundle \
+            stepsecurity-dev-machine-guard.sh.bundle \
             --clobber
 
       - name: Attest build provenance


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
