### PR TITLE
feat: implement S3 upload with retry mechanism and extended timeout

### DIFF
--- a/internal/executor/executor_unix.go
+++ b/internal/executor/executor_unix.go
@@ -5,6 +5,7 @@ package executor
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -12,11 +13,44 @@ func (r *Real) IsRoot() bool {
 	return os.Getuid() == 0
 }
 
+// resolveUserShell returns the given user's configured login shell on macOS by
+// consulting Directory Services (dscl). Returns "" on non-darwin platforms, if
+// the lookup fails, or if the resolved path isn't an executable file — in which
+// case callers should fall back to /bin/bash.
+//
+// Mirrors stepsecurity-dev-machine-guard.sh:run_as_logged_in_user. Matters when
+// the user's PATH (including npm/pnpm/yarn via nvm/fnm/homebrew) is configured
+// only in zsh profile files (.zprofile/.zshrc) — bash -l on such a user sources
+// nothing and runs with a stripped PATH, producing empty package scans.
+func (r *Real) resolveUserShell(ctx context.Context, username string) string {
+	if runtime.GOOS != "darwin" || username == "" {
+		return ""
+	}
+	stdout, _, _, err := r.Run(ctx, "dscl", ".", "-read", "/Users/"+username, "UserShell")
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(strings.TrimSpace(stdout))
+	if len(fields) < 2 {
+		return ""
+	}
+	shell := fields[1]
+	info, err := os.Stat(shell)
+	if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		return ""
+	}
+	return shell
+}
+
 func (r *Real) RunAsUser(ctx context.Context, username, command string) (string, error) {
 	if !r.IsRoot() {
 		stdout, _, _, err := r.Run(ctx, "bash", "-c", command)
 		return strings.TrimSpace(stdout), err
 	}
-	stdout, _, _, err := r.Run(ctx, "sudo", "-H", "-u", username, "bash", "-l", "-c", command)
+	shell := r.resolveUserShell(ctx, username)
+	if shell == "" {
+		shell = "/bin/bash"
+	}
+	stdout, _, _, err := r.Run(ctx, "sudo", "-H", "-u", username, shell, "-l", "-c", command)
 	return strings.TrimSpace(stdout), err
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -326,25 +326,54 @@ func uploadToS3(ctx context.Context, log *progress.Logger, payload *Payload) err
 		return fmt.Errorf("empty upload URL in response")
 	}
 
-	// Upload payload to S3
-	log.Progress("Uploading telemetry to S3...")
-	putReq, err := http.NewRequestWithContext(ctx, http.MethodPut, urlResp.UploadURL, bytes.NewReader(payloadJSON))
-	if err != nil {
-		return fmt.Errorf("creating S3 PUT request: %w", err)
-	}
-	putReq.Header.Set("Content-Type", "application/json")
+	// Upload payload to S3 with retry — use a longer timeout since payloads
+	// with npm scan data and execution logs can be several MB.
+	log.Progress("Uploading telemetry to S3 (%d bytes)...", len(payloadJSON))
+	s3Client := &http.Client{Timeout: 60 * time.Second}
+	const maxRetries = 3
+	var putResp *http.Response
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		uploadStart := time.Now()
+		putReq, reqErr := http.NewRequestWithContext(ctx, http.MethodPut, urlResp.UploadURL, bytes.NewReader(payloadJSON))
+		if reqErr != nil {
+			return fmt.Errorf("creating S3 PUT request: %w", reqErr)
+		}
+		putReq.Header.Set("Content-Type", "application/json")
 
-	putResp, err := client.Do(putReq)
-	if err != nil {
-		return fmt.Errorf("uploading to S3: %w", err)
+		putResp, err = s3Client.Do(putReq)
+		elapsed := time.Since(uploadStart)
+
+		if err == nil && putResp.StatusCode == http.StatusOK {
+			log.Progress("Uploaded to S3 in %s", elapsed)
+			break
+		}
+
+		// Clean up response body before retry
+		if putResp != nil {
+			_, _ = io.Copy(io.Discard, putResp.Body)
+			_ = putResp.Body.Close()
+		}
+
+		if attempt == maxRetries {
+			if err != nil {
+				return fmt.Errorf("uploading to S3 (payload: %d bytes, elapsed: %s, attempts: %d): %w",
+					len(payloadJSON), elapsed, maxRetries, err)
+			}
+			return fmt.Errorf("S3 upload failed with status %d (payload: %d bytes, attempts: %d)",
+				putResp.StatusCode, len(payloadJSON), maxRetries)
+		}
+
+		// Log retry and backoff
+		backoff := time.Duration(attempt) * 2 * time.Second
+		if err != nil {
+			log.Progress("S3 upload attempt %d/%d failed (%s), retrying in %s...", attempt, maxRetries, elapsed, backoff)
+		} else {
+			log.Progress("S3 upload attempt %d/%d got status %d, retrying in %s...", attempt, maxRetries, putResp.StatusCode, backoff)
+		}
+		time.Sleep(backoff)
 	}
 	defer func() { _ = putResp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, putResp.Body)
-
-	if putResp.StatusCode != http.StatusOK {
-		return fmt.Errorf("S3 upload failed with status %d", putResp.StatusCode)
-	}
-	log.Progress("Uploaded to S3")
 
 	// Notify backend
 	log.Progress("Notifying backend of upload...")


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
