### PR TITLE
feat(mdm): bump version to v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [VERSIONING.md](VERSIONING.md) for why the version starts at 1.8.1.
 
+## [1.10.0] - 2026-04-20
+
+### Added
+
+- Windows support: cross-platform detection for IDEs, extensions, AI tools, frameworks, MCP configs, and Node.js scanning on Windows.
+- Homebrew scanning: detects formulae and casks with raw output capture for enterprise telemetry.
+- Python scanning: detects package managers, global packages, and projects with virtual environments.
+- User-aware executor: commands like `brew`, `pip3`, and `npm` now run in the logged-in user's context when the agent runs as root.
+- IDE plugin detection: JetBrains IDEs, Xcode Source Editor extensions, and Eclipse plugins with bundled/user-installed source tagging.
+- Project-level MCP configuration discovery and filtering.
+- S3 upload retry mechanism with exponential backoff and extended timeout for large payloads.
+- Enhanced user shell resolution for macOS `RunAsUser`.
+
+### Fixed
+
+- Populated missing performance metrics fields (brew formulae/cask counts, Python global packages/project counts).
+- S3 retry logging now includes the actual error value for easier debugging.
+- Retry backoff respects context cancellation during shutdown.
+
 ## [1.9.2] - 2026-04-15
 
 ### Fixed
@@ -72,6 +91,7 @@ First open-source release. The scanning engine was previously an internal enterp
 - Execution log capture and base64 encoding
 - Instance locking to prevent concurrent runs
 
+[1.10.0]: https://github.com/step-security/dev-machine-guard/compare/v1.9.2...v1.10.0
 [1.9.2]: https://github.com/step-security/dev-machine-guard/compare/v1.9.1...v1.9.2
 [1.9.1]: https://github.com/step-security/dev-machine-guard/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/step-security/dev-machine-guard/compare/v1.8.2...v1.9.0

--- a/examples/sample-output.json
+++ b/examples/sample-output.json
@@ -1,5 +1,5 @@
 {
-  "agent_version": "1.9.2",
+  "agent_version": "1.10.0",
   "scan_timestamp": 1741305600,
   "scan_timestamp_iso": "2026-03-07T00:00:00Z",
   "device": {

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -3,7 +3,7 @@ package buildinfo
 import "fmt"
 
 const (
-	Version  = "1.9.2"
+	Version  = "1.10.0"
 	AgentURL = "https://github.com/step-security/dev-machine-guard"
 )
 


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
