### PR TITLE
fix(ci): resolve draft release by tag_name to avoid race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           # so gh release upload by version tag returns 404. Look up the
           # actual tag GitHub assigned to the draft.
           release_tag=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq '[.[] | select(.draft and .name == "${{ steps.version.outputs.tag }}")] | first | .tag_name')
+            --jq '[.[] | select(.draft and .tag_name == "${{ steps.version.outputs.tag }}")] | first | .tag_name')
           if [ -z "$release_tag" ] || [ "$release_tag" = "null" ]; then
             echo "::error::Could not find draft release for ${{ steps.version.outputs.tag }}"
             exit 1


### PR DESCRIPTION
The jq filter in the 'Resolve draft release tag' step matched on .name, which GitHub populates asynchronously after release creation. Runs that queried too quickly (<~2s after GoReleaser) got an empty result and failed with 'Could not find draft release'. Match on .tag_name instead — it is set atomically at creation time.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
