### PR TITLE
fix(executor): source .zshrc in RunAsUser for full PATH and fix exit code propagation

### DIFF
--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -66,9 +66,8 @@ func main() {
 	if cfg.OutputFormat == "json" {
 		quiet = true
 	}
-	if cfg.Command == "send-telemetry" || cfg.Command == "install" {
-		quiet = false
-	}
+	// Note: send-telemetry and bare command (auto-detected enterprise) both
+	// respect the same quiet logic — config value wins, default is true.
 	log := progress.NewLogger(quiet)
 
 	switch cfg.Command {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,9 +240,9 @@ func RunConfigure() error {
 	}
 
 	// Quiet mode
-	currentQuiet := "false"
-	if existing.Quiet != nil && *existing.Quiet {
-		currentQuiet = "true"
+	currentQuiet := "true"
+	if existing.Quiet != nil && !*existing.Quiet {
+		currentQuiet = "false"
 	}
 	quietInput := promptValue(reader, "Quiet Mode (true/false)", currentQuiet)
 	switch strings.ToLower(quietInput) {
@@ -250,7 +250,8 @@ func RunConfigure() error {
 		v := true
 		existing.Quiet = &v
 	default:
-		existing.Quiet = nil // false is the default (omit from config)
+		v := false
+		existing.Quiet = &v
 	}
 
 	// Save
@@ -409,7 +410,7 @@ func displayOutputFormat(v string) string {
 }
 
 func displayQuiet(v *bool) string {
-	if v == nil || !*v {
+	if v != nil && !*v {
 		return "false"
 	}
 	return "true"

--- a/internal/executor/executor_unix.go
+++ b/internal/executor/executor_unix.go
@@ -4,6 +4,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -44,13 +45,34 @@ func (r *Real) resolveUserShell(ctx context.Context, username string) string {
 
 func (r *Real) RunAsUser(ctx context.Context, username, command string) (string, error) {
 	if !r.IsRoot() {
-		stdout, _, _, err := r.Run(ctx, "bash", "-c", command)
-		return strings.TrimSpace(stdout), err
+		stdout, _, exitCode, err := r.Run(ctx, "bash", "-c", command)
+		if err != nil {
+			return strings.TrimSpace(stdout), err
+		}
+		if exitCode != 0 {
+			return strings.TrimSpace(stdout), fmt.Errorf("command exited with code %d", exitCode)
+		}
+		return strings.TrimSpace(stdout), nil
 	}
 	shell := r.resolveUserShell(ctx, username)
 	if shell == "" {
 		shell = "/bin/bash"
 	}
-	stdout, _, _, err := r.Run(ctx, "sudo", "-H", "-u", username, shell, "-l", "-c", command)
-	return strings.TrimSpace(stdout), err
+
+	// Source the shell's interactive rc file for full PATH.
+	// Login shells (-l) source .zprofile/.bash_profile but skip .zshrc/.bashrc,
+	// where most users add PATH entries for nvm, n, fnm, bun, npm-global, etc.
+	rcSource := "[ -f ~/.bashrc ] && . ~/.bashrc 2>/dev/null; "
+	if strings.HasSuffix(shell, "zsh") {
+		rcSource = "[ -f ~/.zshrc ] && . ~/.zshrc 2>/dev/null; "
+	}
+
+	stdout, _, exitCode, err := r.Run(ctx, "sudo", "-H", "-u", username, shell, "-l", "-c", rcSource+command)
+	if err != nil {
+		return strings.TrimSpace(stdout), err
+	}
+	if exitCode != 0 {
+		return strings.TrimSpace(stdout), fmt.Errorf("command exited with code %d", exitCode)
+	}
+	return strings.TrimSpace(stdout), nil
 }

--- a/internal/executor/user_aware.go
+++ b/internal/executor/user_aware.go
@@ -38,7 +38,9 @@ func (e *UserAwareExecutor) Run(ctx context.Context, name string, args ...string
 	}
 	stdout, err := e.inner.RunAsUser(ctx, e.username, cmd)
 	if err != nil {
-		return stdout, err.Error(), 1, err
+		exitCode := 1
+		_, _ = fmt.Sscanf(err.Error(), "command exited with code %d", &exitCode)
+		return stdout, err.Error(), exitCode, err
 	}
 	return stdout, "", 0, nil
 }
@@ -59,10 +61,11 @@ func (e *UserAwareExecutor) RunAsUser(ctx context.Context, username, command str
 
 func (e *UserAwareExecutor) LookPath(name string) (string, error) {
 	stdout, err := e.inner.RunAsUser(context.Background(), e.username, "which "+name)
-	if err != nil || strings.TrimSpace(stdout) == "" {
+	path := strings.TrimSpace(stdout)
+	if err != nil || path == "" || !strings.HasPrefix(path, "/") {
 		return "", fmt.Errorf("%s not found in user PATH", name)
 	}
-	return strings.TrimSpace(stdout), nil
+	return path, nil
 }
 
 // --- Pass-through methods ---


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
