### PR TITLE
chore(release): bump version to 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [VERSIONING.md](VERSIONING.md) for why the version starts at 1.8.1.
 
+## [1.10.2] - 2026-04-22
+
+### Added
+
+- **Windows Eclipse plugin detection**: Multi-stage detection pipeline using detected IDE install paths (registry-aware), well-known path probes (Oomph installer, vendor variants like STS/MyEclipse, D:-Z: drive scanning), and install validation to eliminate false positives.
+- **Eclipse p2 director integration**: Uses `eclipsec.exe -listInstalledRoots` for authoritative marketplace plugin identification. Falls back to `bundles.info` parsing if unavailable.
+- **`--include-bundled-plugins` flag**: Bundled/platform plugins (e.g., Eclipse's 500+ OSGi bundles) are now filtered out by default to reduce noise and payload size (~124KB → ~21KB). Use the flag to include them.
+- **Sigstore signing retry logic**: Release workflow retries artifact signing with Sigstore on transient failures.
+
 ## [1.10.1] - 2026-04-21
 
 ### Added
@@ -108,6 +117,8 @@ First open-source release. The scanning engine was previously an internal enterp
 - Execution log capture and base64 encoding
 - Instance locking to prevent concurrent runs
 
+[1.10.2]: https://github.com/step-security/dev-machine-guard/compare/v1.10.1...v1.10.2
+[1.10.1]: https://github.com/step-security/dev-machine-guard/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/step-security/dev-machine-guard/compare/v1.9.2...v1.10.0
 [1.9.2]: https://github.com/step-security/dev-machine-guard/compare/v1.9.1...v1.9.2
 [1.9.1]: https://github.com/step-security/dev-machine-guard/compare/v1.9.0...v1.9.1

--- a/examples/sample-output.json
+++ b/examples/sample-output.json
@@ -1,5 +1,5 @@
 {
-  "agent_version": "1.10.1",
+  "agent_version": "1.10.2",
   "scan_timestamp": 1741305600,
   "scan_timestamp_iso": "2026-03-07T00:00:00Z",
   "device": {

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -3,7 +3,7 @@ package buildinfo
 import "fmt"
 
 const (
-	Version  = "1.10.1"
+	Version  = "1.10.2"
 	AgentURL = "https://github.com/step-security/dev-machine-guard"
 )
 


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
