### PR TITLE
track IntelliJ/JetBrains plugins in collect_user_extensions (This PR adds support for detecting and tracking installed plugins in IntelliJ IDEA and other JetBrains IDEs (PyCharm, GoLand, WebStorm, etc.) as part of the dev machine extension scan.)

### DIFF
--- a/stepsecurity-dev-machine-guard.sh
+++ b/stepsecurity-dev-machine-guard.sh
@@ -1371,6 +1371,31 @@ collect_user_extensions() {
         fi
     fi
 
+    # 2. IntelliJ / JetBrains Plugins Detection
+    local jb_root="$user_home/Library/Application Support/JetBrains"
+    if [ -d "$jb_root" ]; then
+        print_progress "Scanning JetBrains plugins for ${username}..."
+        # Loop through every folder in the JetBrains directory
+        for jb_dir in "$jb_root"/*; do
+        # Check if a 'plugins' subdirectory exists within that versioned folder
+        local plugins_path="$jb_dir/plugins"
+        if [ -d "$plugins_path" ]; then
+            # Loop through the actual installed plugins
+            for plugin in "$plugins_path"/*; do
+                if [ -d "$plugin" ]; then
+                    local p_name=$(basename "$plugin")
+                    [ "$first" = false ] && all_extensions="${all_extensions},"
+                    
+                    # Format as JSON to match the VSCode extension schema
+                    all_extensions="${all_extensions}{\"id\":\"${p_name}\",\"name\":\"${p_name}\",\"version\":\"unknown\",\"publisher\":\"JetBrains\",\"ide_type\":\"intellij\"}"
+                    total_count=$((total_count + 1))
+                    first=false
+                fi
+            done
+        fi
+        done
+    fi
+
     # Collect Cursor extensions
     local cursor_ext_dir="$user_home/.cursor/extensions"
     if [ -d "$cursor_ext_dir" ]; then


### PR DESCRIPTION
## Summary

This PR adds support for detecting and tracking installed plugins in IntelliJ IDEA and other JetBrains IDEs (PyCharm, GoLand, WebStorm, etc.) as part of the dev machine extension scan.

## Changes

In `collect_user_extensions()`, added a new detection block that:
- Scans `~/Library/Application Support/JetBrains/*/plugins/` — the standard macOS location where all JetBrains IDEs store their plugins
- Handles multiple installed JetBrains products and versions automatically (e.g. `IntelliJIdea2024.1`, `PyCharm2023.3`, etc.)
- Reports each plugin using the existing extension JSON schema with `ide_type: "intellij"`, consistent with how VSCode and Cursor extensions are reported

## Motivation

IntelliJ IDEA is one of the most widely used IDEs among Java/Kotlin/backend developers. Tracking its plugins alongside VSCode and Cursor extensions gives a more complete picture of the tools installed on a developer's machine.

## Testing

Tested on macOS with IntelliJ IDEA installed. Plugins are correctly detected and reported in both `--pretty` an