### PR TITLE
chore(linux): add packaged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,18 +85,25 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
-      - name: Locate binaries
+      - name: Locate binaries and packages
         id: binaries
         run: |
           DARWIN=$(find dist -type f -name '*darwin_unnotarized' | head -1)
           WIN_AMD64=$(find dist -type f -name '*.exe' -path '*windows_amd64*' | head -1)
           WIN_ARM64=$(find dist -type f -name '*.exe' -path '*windows_arm64*' | head -1)
+          LINUX_AMD64=$(find dist -type f -name '*-linux_amd64' | head -1)
+          LINUX_ARM64=$(find dist -type f -name '*-linux_arm64' | head -1)
 
-          for label in "darwin:${DARWIN}" "windows_amd64:${WIN_AMD64}" "windows_arm64:${WIN_ARM64}"; do
+          DEB_AMD64=$(find dist -type f -name '*-amd64.deb' | head -1)
+          DEB_ARM64=$(find dist -type f -name '*-arm64.deb' | head -1)
+          RPM_AMD64=$(find dist -type f -name '*-amd64.rpm' | head -1)
+          RPM_ARM64=$(find dist -type f -name '*-arm64.rpm' | head -1)
+
+          for label in "darwin:${DARWIN}" "windows_amd64:${WIN_AMD64}" "windows_arm64:${WIN_ARM64}" "linux_amd64:${LINUX_AMD64}" "linux_arm64:${LINUX_ARM64}" "deb_amd64:${DEB_AMD64}" "deb_arm64:${DEB_ARM64}" "rpm_amd64:${RPM_AMD64}" "rpm_arm64:${RPM_ARM64}"; do
             name="${label%%:*}"
             path="${label#*:}"
             if [ -z "$path" ] || [ ! -f "$path" ]; then
-              echo "::error::Binary not found for ${name}"
+              echo "::error::Artifact not found for ${name}"
               find dist -type f
               exit 1
             fi
@@ -105,6 +112,12 @@ jobs:
           echo "darwin=$DARWIN" >> "$GITHUB_OUTPUT"
           echo "win_amd64=$WIN_AMD64" >> "$GITHUB_OUTPUT"
           echo "win_arm64=$WIN_ARM64" >> "$GITHUB_OUTPUT"
+          echo "linux_amd64=$LINUX_AMD64" >> "$GITHUB_OUTPUT"
+          echo "linux_arm64=$LINUX_ARM64" >> "$GITHUB_OUTPUT"
+          echo "deb_amd64=$DEB_AMD64" >> "$GITHUB_OUTPUT"
+          echo "deb_arm64=$DEB_ARM64" >> "$GITHUB_OUTPUT"
+          echo "rpm_amd64=$RPM_AMD64" >> "$GITHUB_OUTPUT"
+          echo "rpm_arm64=$RPM_ARM64" >> "$GITHUB_OUTPUT"
 
       - name: Sign artifacts with Sigstore
         shell: bash
@@ -131,6 +144,20 @@ jobs:
             "dist/stepsecurity-dev-machine-guard-windows_amd64.exe.bundle"
           sign_with_retry "${{ steps.binaries.outputs.win_arm64 }}" \
             "dist/stepsecurity-dev-machine-guard-windows_arm64.exe.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.linux_amd64 }}" \
+            "dist/stepsecurity-dev-machine-guard-linux_amd64.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.linux_arm64 }}" \
+            "dist/stepsecurity-dev-machine-guard-linux_arm64.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.deb_amd64 }}" \
+            "${{ steps.binaries.outputs.deb_amd64 }}.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.deb_arm64 }}" \
+            "${{ steps.binaries.outputs.deb_arm64 }}.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.rpm_amd64 }}" \
+            "${{ steps.binaries.outputs.rpm_amd64 }}.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.rpm_arm64 }}" \
+            "${{ steps.binaries.outputs.rpm_arm64 }}.bundle"
+          sign_with_retry "stepsecurity-dev-machine-guard.sh" \
+            "dist/stepsecurity-dev-machine-guard.sh.bundle"
       - name: Upload cosign bundles
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -139,6 +166,13 @@ jobs:
             dist/stepsecurity-dev-machine-guard-darwin_unnotarized.bundle \
             dist/stepsecurity-dev-machine-guard-windows_amd64.exe.bundle \
             dist/stepsecurity-dev-machine-guard-windows_arm64.exe.bundle \
+            dist/stepsecurity-dev-machine-guard-linux_amd64.bundle \
+            dist/stepsecurity-dev-machine-guard-linux_arm64.bundle \
+            "${{ steps.binaries.outputs.deb_amd64 }}.bundle" \
+            "${{ steps.binaries.outputs.deb_arm64 }}.bundle" \
+            "${{ steps.binaries.outputs.rpm_amd64 }}.bundle" \
+            "${{ steps.binaries.outputs.rpm_arm64 }}.bundle" \
+            dist/stepsecurity-dev-machine-guard.sh.bundle \
             --clobber
 
       - name: Attest build provenance
@@ -148,3 +182,10 @@ jobs:
             ${{ steps.binaries.outputs.darwin }}
             ${{ steps.binaries.outputs.win_amd64 }}
             ${{ steps.binaries.outputs.win_arm64 }}
+            ${{ steps.binaries.outputs.linux_amd64 }}
+            ${{ steps.binaries.outputs.linux_arm64 }}
+            ${{ steps.binaries.outputs.deb_amd64 }}
+            ${{ steps.binaries.outputs.deb_arm64 }}
+            ${{ steps.binaries.outputs.rpm_amd64 }}
+            ${{ steps.binaries.outputs.rpm_arm64 }}
+            stepsecurity-dev-machine-guard.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
     goos:
       - darwin
       - windows
+      - linux
     goarch:
       - amd64
       - arm64
@@ -36,12 +37,28 @@ archives:
     formats:
       - binary
     name_template: "stepsecurity-dev-machine-guard-{{ .Version }}-darwin_unnotarized"
-  - id: windows
+  - id: windows-linux
     ids:
       - stepsecurity-dev-machine-guard
     formats:
       - binary
-    name_template: "stepsecurity-dev-machine-guard-{{ .Version }}-windows_{{ .Arch }}"
+    name_template: "stepsecurity-dev-machine-guard-{{ .Version }}-{{ .Os }}_{{ .Arch }}"
+
+nfpms:
+  - id: linux-packages
+    package_name: stepsecurity-dev-machine-guard
+    vendor: StepSecurity
+    homepage: https://github.com/step-security/dev-machine-guard
+    maintainer: StepSecurity <support@stepsecurity.io>
+    description: Detect compromised tools on developer machines
+    license: Apache-2.0
+    formats:
+      - deb
+      - rpm
+    ids:
+      - stepsecurity-dev-machine-guard
+    bindir: /usr/local/bin
+    file_name_template: "stepsecurity-dev-machine-guard-{{ .Version }}-{{ .Arch }}"
 
 release:
   draft: true

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/internal/buildinfo.ReleaseTag=$(TAG) \
 	-X $(MODULE)/internal/buildinfo.ReleaseBranch=$(BRANCH)
 
-.PHONY: build build-windows deploy-windows test lint clean smoke
+.PHONY: build build-windows build-linux deploy-windows test lint clean smoke
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/stepsecurity-dev-machine-guard
 
 build-windows:
 	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY).exe ./cmd/stepsecurity-dev-machine-guard
+
+build-linux:
+	GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY)-linux ./cmd/stepsecurity-dev-machine-guard
 
 deploy-windows:
 	@bash scripts/deploy-windows.sh $(DEPLOY_ARGS)
@@ -27,7 +30,7 @@ lint:
 	golangci-lint run ./...
 
 clean:
-	rm -f $(BINARY)
+	rm -f $(BINARY) $(BINARY).exe $(BINARY)-linux
 
 smoke: build
 	bash tests/test_smoke_go.sh

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,8 +10,8 @@ This document describes how releases are created, signed, notarized, and verifie
 
 Releases are a two-phase process:
 
-1. **CI (automated)** — GitHub Actions builds the universal macOS binary, signs it with Sigstore, and creates a **draft** release with the binary named `stepsecurity-dev-machine-guard-VERSION-darwin_unnotarized`.
-2. **Apple notarization (manual)** — Download the binary, sign and notarize it with an Apple Developer account, upload the notarized binary to the draft release, and publish.
+1. **CI (automated)** — GitHub Actions builds the universal macOS binary, Windows binaries (amd64 + arm64), and Linux binaries (amd64 + arm64), signs them all with Sigstore, and creates a **draft** release.
+2. **Apple notarization (manual)** — Download the macOS binary, sign and notarize it with an Apple Developer account, upload the notarized binary to the draft release, and publish.
 
 ---
 
@@ -34,10 +34,12 @@ Update [CHANGELOG.md](../CHANGELOG.md). Commit and push to `main`.
 
 The workflow will:
 - Create a git tag (`v1.9.1`)
-- Build a universal macOS binary (amd64 + arm64) via GoReleaser
-- Sign with Sigstore cosign (keyless)
-- Upload as `stepsecurity-dev-machine-guard-VERSION-darwin_unnotarized` to a **draft** release
-- Record the SHA256 of the unnotarized binary in the release notes
+- Build via GoReleaser:
+  - Universal macOS binary (amd64 + arm64)
+  - Windows binaries (amd64 + arm64)
+  - Linux binaries (amd64 + arm64)
+- Sign all artifacts with Sigstore cosign (keyless)
+- Upload to a **draft** release
 - Generate SLSA build provenance attestation
 
 ### 3. Apple notarization (manual)
@@ -86,13 +88,31 @@ Each release includes:
 |----------|-------------|
 | `stepsecurity-dev-machine-guard-VERSION-darwin` | Notarized universal macOS binary (amd64 + arm64) |
 | `stepsecurity-dev-machine-guard-VERSION-darwin_unnotarized` | Original CI-built binary (for provenance verification) |
-| `stepsecurity-dev-machine-guard-VERSION-darwin_unnotarized.bundle` | Sigstore cosign bundle for the unnotarized binary |
+| `stepsecurity-dev-machine-guard-darwin_unnotarized.bundle` | Sigstore cosign bundle for the unnotarized binary |
+| `stepsecurity-dev-machine-guard-VERSION-windows_amd64.exe` | Windows 64-bit binary |
+| `stepsecurity-dev-machine-guard-windows_amd64.exe.bundle` | Sigstore cosign bundle for the Windows amd64 binary |
+| `stepsecurity-dev-machine-guard-VERSION-windows_arm64.exe` | Windows ARM64 binary |
+| `stepsecurity-dev-machine-guard-windows_arm64.exe.bundle` | Sigstore cosign bundle for the Windows arm64 binary |
+| `stepsecurity-dev-machine-guard-VERSION-linux_amd64` | Linux 64-bit binary |
+| `stepsecurity-dev-machine-guard-linux_amd64.bundle` | Sigstore cosign bundle for the Linux amd64 binary |
+| `stepsecurity-dev-machine-guard-VERSION-linux_arm64` | Linux ARM64 binary |
+| `stepsecurity-dev-machine-guard-linux_arm64.bundle` | Sigstore cosign bundle for the Linux arm64 binary |
+| `stepsecurity-dev-machine-guard-VERSION-amd64.deb` | Debian/Ubuntu amd64 package |
+| `stepsecurity-dev-machine-guard-VERSION-amd64.deb.bundle` | Sigstore cosign bundle for the Debian amd64 package |
+| `stepsecurity-dev-machine-guard-VERSION-arm64.deb` | Debian/Ubuntu arm64 package |
+| `stepsecurity-dev-machine-guard-VERSION-arm64.deb.bundle` | Sigstore cosign bundle for the Debian arm64 package |
+| `stepsecurity-dev-machine-guard-VERSION-amd64.rpm` | RHEL/Fedora amd64 package |
+| `stepsecurity-dev-machine-guard-VERSION-amd64.rpm.bundle` | Sigstore cosign bundle for the RPM amd64 package |
+| `stepsecurity-dev-machine-guard-VERSION-arm64.rpm` | RHEL/Fedora arm64 package |
+| `stepsecurity-dev-machine-guard-VERSION-arm64.rpm.bundle` | Sigstore cosign bundle for the RPM arm64 package |
+| `stepsecurity-dev-machine-guard.sh` | Legacy shell script |
+| `stepsecurity-dev-machine-guard.sh.bundle` | Sigstore cosign bundle for the shell script |
 
 ---
 
 ## Verifying a Release
 
-### Verify a release
+### Verify macOS release
 
 ```bash
 VERSION="1.9.1"
@@ -107,12 +127,59 @@ spctl --assess --type execute "stepsecurity-dev-machine-guard-${VERSION}-darwin"
 
 # Verify Sigstore signature on the unnotarized binary
 cosign verify-blob "stepsecurity-dev-machine-guard-${VERSION}-darwin_unnotarized" \
-  --bundle "stepsecurity-dev-machine-guard-${VERSION}-darwin_unnotarized.bundle" \
+  --bundle "stepsecurity-dev-machine-guard-darwin_unnotarized.bundle" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --certificate-identity-regexp "github.com/.*/dev-machine-guard"
+  --certificate-identity-regexp "^https://github.com/step-security/dev-machine-guard/.github/workflows/"
 
 # Verify build provenance
 gh attestation verify "stepsecurity-dev-machine-guard-${VERSION}-darwin_unnotarized" \
+  --repo step-security/dev-machine-guard
+```
+
+### Install via package manager (Linux)
+
+**Debian / Ubuntu:**
+
+```bash
+VERSION="1.9.1"
+ARCH="amd64"  # or arm64
+
+gh release download "v${VERSION}" --repo step-security/dev-machine-guard \
+  --pattern "stepsecurity-dev-machine-guard-${VERSION}-${ARCH}.deb"
+
+sudo dpkg -i "stepsecurity-dev-machine-guard-${VERSION}-${ARCH}.deb"
+```
+
+**RHEL / Fedora:**
+
+```bash
+VERSION="1.9.1"
+ARCH="amd64"  # or arm64
+
+gh release download "v${VERSION}" --repo step-security/dev-machine-guard \
+  --pattern "stepsecurity-dev-machine-guard-${VERSION}-${ARCH}.rpm"
+
+sudo rpm -i "stepsecurity-dev-machine-guard-${VERSION}-${ARCH}.rpm"
+```
+
+### Verify Linux release
+
+```bash
+VERSION="1.9.1"
+ARCH="amd64"  # or arm64
+
+# Download release artifacts
+gh release download "v${VERSION}" --repo step-security/dev-machine-guard \
+  --pattern "stepsecurity-dev-machine-guard-${VERSION}-linux_${ARCH}*"
+
+# Verify Sigstore signature
+cosign verify-blob "stepsecurity-dev-machine-guard-${VERSION}-linux_${ARCH}" \
+  --bundle "stepsecurity-dev-machine-guard-linux_${ARCH}.bundle" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --certificate-identity-regexp "^https://github.com/step-security/dev-machine-guard/.github/workflows/"
+
+# Verify build provenance
+gh attestation verify "stepsecurity-dev-machine-guard-${VERSION}-linux_${ARCH}" \
   --repo step-security/dev-machine-guard
 ```
 


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
