### PR TITLE
fix(aicli): handle detection for GitHub Copilot CLI version

### DIFF
--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
 	"github.com/step-security/dev-machine-guard/internal/model"
 )
-
-var versionTokenRE = regexp.MustCompile(`\d+\.\d+`)
 
 type cliToolSpec struct {
 	Name        string
@@ -65,8 +62,8 @@ var cliToolDefinitions = []cliToolSpec{
 		// even when the real CLI isn't installed and replies to `--version` with
 		// "GitHub Copilot CLI is not installed. Would you like to install it? (Y/n)".
 		VerifyFunc: func(ctx context.Context, exec executor.Executor, binary string) bool {
-			stdout, _, _, err := exec.RunWithTimeout(ctx, 10*time.Second, binary, "--version")
-			if err != nil {
+			stdout, _, exitCode, err := exec.RunWithTimeout(ctx, 10*time.Second, binary, "--version")
+			if err != nil || exitCode != 0 {
 				return false
 			}
 			lower := strings.ToLower(stdout)
@@ -74,7 +71,7 @@ var cliToolDefinitions = []cliToolSpec{
 				strings.Contains(lower, "would you like to install") {
 				return false
 			}
-			return versionTokenRE.MatchString(stdout)
+			return true
 		},
 	},
 	{

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
 	"github.com/step-security/dev-machine-guard/internal/model"
 )
+
+var versionTokenRE = regexp.MustCompile(`\d+\.\d+`)
 
 type cliToolSpec struct {
 	Name        string
@@ -58,6 +61,21 @@ var cliToolDefinitions = []cliToolSpec{
 		Vendor:     "Microsoft",
 		Binaries:   []string{"copilot", "gh-copilot"},
 		ConfigDirs: []string{"~/.config/github-copilot"},
+		// Reject the VS Code Copilot Chat extension's shim, which lives on PATH
+		// even when the real CLI isn't installed and replies to `--version` with
+		// "GitHub Copilot CLI is not installed. Would you like to install it? (Y/n)".
+		VerifyFunc: func(ctx context.Context, exec executor.Executor, binary string) bool {
+			stdout, _, _, err := exec.RunWithTimeout(ctx, 10*time.Second, binary, "--version")
+			if err != nil {
+				return false
+			}
+			lower := strings.ToLower(stdout)
+			if strings.Contains(lower, "not installed") ||
+				strings.Contains(lower, "would you like to install") {
+				return false
+			}
+			return versionTokenRE.MatchString(stdout)
+		},
 	},
 	{
 		Name:       "microsoft-ai-shell",
@@ -175,7 +193,7 @@ func cleanVersionString(v string) string {
 			return p
 		}
 	}
-	return v
+	return "unknown"
 }
 
 func (d *AICLIDetector) findConfigDir(spec cliToolSpec, homeDir string) string {

--- a/internal/detector/aicli_test.go
+++ b/internal/detector/aicli_test.go
@@ -65,6 +65,23 @@ func TestAICLIDetector_RejectsCopilotInstallPrompt(t *testing.T) {
 	}
 }
 
+func TestAICLIDetector_RejectsCopilotNonZeroExit(t *testing.T) {
+	shimPath := "/usr/local/bin/copilot"
+	mock := executor.NewMock()
+	mock.SetPath("copilot", shimPath)
+	// Output matches the version regex but exit code is non-zero — should be rejected.
+	mock.SetCommand("copilot 1.2 internal error\n", "", 1, shimPath, "--version")
+
+	det := NewAICLIDetector(mock)
+	results := det.Detect(context.Background())
+
+	for _, r := range results {
+		if r.Name == "github-copilot-cli" {
+			t.Errorf("github-copilot-cli should not be detected when --version exits non-zero; got %+v", r)
+		}
+	}
+}
+
 func TestAICLIDetector_AcceptsRealCopilotVersion(t *testing.T) {
 	mock := executor.NewMock()
 	mock.SetPath("copilot", "/usr/local/bin/copilot")

--- a/internal/detector/aicli_test.go
+++ b/internal/detector/aicli_test.go
@@ -49,6 +49,47 @@ func TestAICLIDetector_NoToolsFound(t *testing.T) {
 	}
 }
 
+func TestAICLIDetector_RejectsCopilotInstallPrompt(t *testing.T) {
+	shimPath := "/Users/testuser/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli/copilot"
+	mock := executor.NewMock()
+	mock.SetPath("copilot", shimPath)
+	mock.SetCommand("? GitHub Copilot CLI is not installed. Would you like to install it? (Y/n)\n", "", 0, shimPath, "--version")
+
+	det := NewAICLIDetector(mock)
+	results := det.Detect(context.Background())
+
+	for _, r := range results {
+		if r.Name == "github-copilot-cli" {
+			t.Errorf("github-copilot-cli should not be detected when --version returns the install prompt; got %+v", r)
+		}
+	}
+}
+
+func TestAICLIDetector_AcceptsRealCopilotVersion(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetPath("copilot", "/usr/local/bin/copilot")
+	mock.SetCommand("GitHub Copilot CLI version 0.0.336\n", "", 0, "/usr/local/bin/copilot", "--version")
+
+	det := NewAICLIDetector(mock)
+	results := det.Detect(context.Background())
+
+	found := false
+	for _, r := range results {
+		if r.Name == "github-copilot-cli" {
+			found = true
+			if r.Version != "0.0.336" {
+				t.Errorf("expected version 0.0.336, got %s", r.Version)
+			}
+			if r.BinaryPath != "/usr/local/bin/copilot" {
+				t.Errorf("expected /usr/local/bin/copilot, got %s", r.BinaryPath)
+			}
+		}
+	}
+	if !found {
+		t.Error("github-copilot-cli not found in results")
+	}
+}
+
 func TestAICLIDetector_VersionUnknown(t *testing.T) {
 	mock := executor.NewMock()
 	mock.SetPath("codex", "/usr/local/bin/codex")


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
