### PR TITLE
fix(release): linux release workflow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,8 @@ jobs:
           DARWIN=$(find dist -type f -name '*darwin_unnotarized' | head -1)
           WIN_AMD64=$(find dist -type f -name '*.exe' -path '*windows_amd64*' | head -1)
           WIN_ARM64=$(find dist -type f -name '*.exe' -path '*windows_arm64*' | head -1)
-          LINUX_AMD64=$(find dist -type f -name '*-linux_amd64' | head -1)
-          LINUX_ARM64=$(find dist -type f -name '*-linux_arm64' | head -1)
+          LINUX_AMD64=$(find dist -type f -name 'stepsecurity-dev-machine-guard' -path '*linux_amd64*' | head -1)
+          LINUX_ARM64=$(find dist -type f -name 'stepsecurity-dev-machine-guard' -path '*linux_arm64*' | head -1)
 
           DEB_AMD64=$(find dist -type f -name '*-amd64.deb' | head -1)
           DEB_ARM64=$(find dist -type f -name '*-arm64.deb' | head -1)
@@ -156,8 +156,6 @@ jobs:
             "${{ steps.binaries.outputs.rpm_amd64 }}.bundle"
           sign_with_retry "${{ steps.binaries.outputs.rpm_arm64 }}" \
             "${{ steps.binaries.outputs.rpm_arm64 }}.bundle"
-          sign_with_retry "stepsecurity-dev-machine-guard.sh" \
-            "dist/stepsecurity-dev-machine-guard.sh.bundle"
       - name: Upload cosign bundles
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +170,6 @@ jobs:
             "${{ steps.binaries.outputs.deb_arm64 }}.bundle" \
             "${{ steps.binaries.outputs.rpm_amd64 }}.bundle" \
             "${{ steps.binaries.outputs.rpm_arm64 }}.bundle" \
-            dist/stepsecurity-dev-machine-guard.sh.bundle \
             --clobber
 
       - name: Attest build provenance
@@ -188,4 +185,3 @@ jobs:
             ${{ steps.binaries.outputs.deb_arm64 }}
             ${{ steps.binaries.outputs.rpm_amd64 }}
             ${{ steps.binaries.outputs.rpm_arm64 }}
-            stepsecurity-dev-machine-guard.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,7 @@ archives:
     formats:
       - binary
     name_template: "stepsecurity-dev-machine-guard-{{ .Version }}-{{ .Os }}_{{ .Arch }}"
+    allow_different_binary_count: true
 
 nfpms:
   - id: linux-packages


### PR DESCRIPTION
- .goreleaser.yml: add allow_different_binary_count for windows-linux archive (universal_binaries replace:true removes darwin from build ID causing archive to be skipped)
- release.yml: fix find patterns for linux binaries to match GoReleaser's actual on-disk output paths
- release.yml: remove references to non-existent stepsecurity-dev-machine-guard.sh from signing, upload, and attestation steps

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
