### PR TITLE
feat(aicli): add detection for Cursor Agent CLI and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [VERSIONING.md](VERSIONING.md) for why the version starts at 1.8.1.
 
+## [Unreleased]
+
+### Added
+
+- **Cursor Agent CLI detection**: `cursor-agent` (Cursor's agent CLI, installed via `curl https://cursor.com/install`) is now detected as a distinct AI CLI tool, separate from the existing Cursor IDE record. Machines with both installed will now report two artifacts.
+
 ## [1.10.2] - 2026-04-22
 
 ### Added

--- a/SCAN_COVERAGE.md
+++ b/SCAN_COVERAGE.md
@@ -39,6 +39,7 @@ This document catalogs everything Dev Machine Guard detects. Contributions to ex
 | Microsoft AI Shell    | Microsoft | `aish`, `ai`                | `~/.aish`                       |
 | Aider                 | OpenSource| `aider`                     | `~/.aider`                      |
 | OpenCode              | OpenSource| `opencode`                  | `~/.config/opencode`            |
+| Cursor Agent          | Cursor    | `cursor-agent`              | `~/.cursor`                     |
 
 ## General-Purpose AI Agents
 

--- a/examples/sample-output.json
+++ b/examples/sample-output.json
@@ -27,6 +27,14 @@
       "config_dir": "/Users/developer/.codex"
     },
     {
+      "name": "cursor-agent",
+      "vendor": "Cursor",
+      "type": "cli_tool",
+      "version": "2026.02.27-e7d2ef6",
+      "binary_path": "/Users/developer/.local/bin/cursor-agent",
+      "config_dir": "/Users/developer/.cursor"
+    },
+    {
       "name": "openclaw",
       "vendor": "OpenSource",
       "type": "general_agent",
@@ -176,7 +184,7 @@
     { "path": "/Users/developer/projects/web-scraper/.venv", "package_manager": "uv" }
   ],
   "summary": {
-    "ai_agents_and_tools_count": 5,
+    "ai_agents_and_tools_count": 6,
     "ide_installations_count": 4,
     "ide_extensions_count": 4,
     "mcp_configs_count": 2,

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -93,6 +93,12 @@ var cliToolDefinitions = []cliToolSpec{
 		ConfigDirs:  []string{"~/.config/opencode"},
 		VersionFlag: "-v",
 	},
+	{
+		Name:       "cursor-agent",
+		Vendor:     "Cursor",
+		Binaries:   []string{"cursor-agent", "~/.local/bin/cursor-agent"},
+		ConfigDirs: []string{"~/.cursor"},
+	},
 }
 
 // AICLIDetector detects AI CLI tools.

--- a/internal/detector/aicli_test.go
+++ b/internal/detector/aicli_test.go
@@ -128,3 +128,64 @@ func TestAICLIDetector_VersionUnknown(t *testing.T) {
 		t.Error("codex not found")
 	}
 }
+
+func TestAICLIDetector_FindsCursorAgent(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetPath("cursor-agent", "/usr/local/bin/cursor-agent")
+	mock.SetCommand("2026.02.27-e7d2ef6\n", "", 0, "/usr/local/bin/cursor-agent", "--version")
+	mock.SetDir("/Users/testuser/.cursor")
+
+	det := NewAICLIDetector(mock)
+	results := det.Detect(context.Background())
+
+	found := false
+	for _, r := range results {
+		if r.Name == "cursor-agent" {
+			found = true
+			if r.Vendor != "Cursor" {
+				t.Errorf("expected vendor Cursor, got %s", r.Vendor)
+			}
+			if r.Type != "cli_tool" {
+				t.Errorf("expected type cli_tool, got %s", r.Type)
+			}
+			if r.Version != "2026.02.27-e7d2ef6" {
+				t.Errorf("expected version 2026.02.27-e7d2ef6, got %s", r.Version)
+			}
+			if r.BinaryPath != "/usr/local/bin/cursor-agent" {
+				t.Errorf("expected /usr/local/bin/cursor-agent, got %s", r.BinaryPath)
+			}
+			if r.ConfigDir != "/Users/testuser/.cursor" {
+				t.Errorf("expected config dir /Users/testuser/.cursor, got %s", r.ConfigDir)
+			}
+		}
+	}
+	if !found {
+		t.Error("cursor-agent not found in results")
+	}
+}
+
+func TestAICLIDetector_FindsCursorAgentInLocalBin(t *testing.T) {
+	// Binary is not on PATH, but the official installer's symlink at
+	// ~/.local/bin/cursor-agent exists. The home-relative fallback should pick it up.
+	homeBinPath := "/Users/testuser/.local/bin/cursor-agent"
+	mock := executor.NewMock()
+	mock.SetFile(homeBinPath, []byte{})
+	mock.SetCommand("2026.02.27-e7d2ef6\n", "", 0, homeBinPath, "--version")
+	mock.SetDir("/Users/testuser/.cursor")
+
+	det := NewAICLIDetector(mock)
+	results := det.Detect(context.Background())
+
+	found := false
+	for _, r := range results {
+		if r.Name == "cursor-agent" {
+			found = true
+			if r.BinaryPath != homeBinPath {
+				t.Errorf("expected %s, got %s", homeBinPath, r.BinaryPath)
+			}
+		}
+	}
+	if !found {
+		t.Error("cursor-agent not found via ~/.local/bin fallback")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
