### PR TITLE
fix: add support for detecting Apple Command Line Tools stubs in executors and detectors

### DIFF
--- a/internal/detector/agent.go
+++ b/internal/detector/agent.go
@@ -13,10 +13,10 @@ import (
 )
 
 type agentSpec struct {
-	Name     string
-	Vendor   string
+	Name       string
+	Vendor     string
 	ConfigDirs []string // candidate config directories (relative to home or absolute, ~ expanded). Used as ConfigDir when populated alongside a discovered binary; never used as the sole proof of installation.
-	Binaries []string // binary names to search via LookPath, or home-relative paths (~/...). At least one must resolve before the agent is considered installed.
+	Binaries   []string // binary names to search via LookPath, or home-relative paths (~/...). At least one must resolve before the agent is considered installed.
 }
 
 var agentDefinitions = []agentSpec{

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -231,10 +231,11 @@ func npmShimPackageRoot(exec executor.Executor, path string) string {
 // paths preserve backslashes, Unix paths preserve forward slashes.
 //
 // Examples:
-//   /usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe
-//     -> /usr/local/lib/node_modules/@anthropic-ai/claude-code
-//   C:\Users\u\AppData\Roaming\npm\node_modules\@scope\name\cli.js
-//     -> C:\Users\u\AppData\Roaming\npm\node_modules\@scope\name
+//
+//	/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe
+//	  -> /usr/local/lib/node_modules/@anthropic-ai/claude-code
+//	C:\Users\u\AppData\Roaming\npm\node_modules\@scope\name\cli.js
+//	  -> C:\Users\u\AppData\Roaming\npm\node_modules\@scope\name
 func nodeModulesPackageRoot(path string) string {
 	sep := pathSeparator(path)
 	norm := strings.ReplaceAll(path, "\\", "/")

--- a/internal/detector/aicli_test.go
+++ b/internal/detector/aicli_test.go
@@ -295,8 +295,8 @@ func TestNodeModulesPackageRoot(t *testing.T) {
 		{"/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe", "/usr/local/lib/node_modules/@anthropic-ai/claude-code"},
 		{"/usr/local/lib/node_modules/@openai/codex/bin/codex.js", "/usr/local/lib/node_modules/@openai/codex"},
 		{"/home/u/.npm-global/lib/node_modules/opencode/bin/opencode", "/home/u/.npm-global/lib/node_modules/opencode"},
-		{"/usr/bin/ollama", ""},                                // not a node_modules path
-		{"/Users/u/Library/foo/node_modules", ""},              // node_modules with no package after
+		{"/usr/bin/ollama", ""},                   // not a node_modules path
+		{"/Users/u/Library/foo/node_modules", ""}, // node_modules with no package after
 		{"", ""},
 	}
 	for _, tt := range tests {

--- a/internal/detector/brew.go
+++ b/internal/detector/brew.go
@@ -224,13 +224,13 @@ type brewInfoV2 struct {
 }
 
 type brewFormula struct {
-	Name      string `json:"name"`
-	Tap       string `json:"tap"`
-	Desc      string `json:"desc"`
-	License   string `json:"license"`
-	Homepage  string `json:"homepage"`
-	Deprecated bool  `json:"deprecated"`
-	Installed []struct {
+	Name       string `json:"name"`
+	Tap        string `json:"tap"`
+	Desc       string `json:"desc"`
+	License    string `json:"license"`
+	Homepage   string `json:"homepage"`
+	Deprecated bool   `json:"deprecated"`
+	Installed  []struct {
 		Version               string `json:"version"`
 		Time                  int64  `json:"time"`
 		InstalledAsDependency bool   `json:"installed_as_dependency"`

--- a/internal/detector/pythonpm.go
+++ b/internal/detector/pythonpm.go
@@ -38,6 +38,11 @@ func (d *PythonPMDetector) DetectManagers(ctx context.Context) []model.PkgManage
 		if err != nil {
 			continue
 		}
+		if d.exec.IsAppleCLTStub(ctx, path) {
+			// Skip Apple's /usr/bin/ shims on Macs without Command Line Tools;
+			// running `--version` against them pops a GUI install prompt.
+			continue
+		}
 
 		version := "unknown"
 		stdout, _, _, err := d.exec.RunWithTimeout(ctx, 10*time.Second, pm.Binary, pm.VersionCmd)
@@ -60,7 +65,8 @@ func (d *PythonPMDetector) DetectManagers(ctx context.Context) []model.PkgManage
 
 // ListPackages returns installed Python packages using pip3.
 func (d *PythonPMDetector) ListPackages(ctx context.Context) []model.PythonPackage {
-	if _, err := d.exec.LookPath("pip3"); err != nil {
+	path, err := d.exec.LookPath("pip3")
+	if err != nil || d.exec.IsAppleCLTStub(ctx, path) {
 		return nil
 	}
 	stdout, _, _, err := d.exec.RunWithTimeout(ctx, 30*time.Second, "pip3", "list", "--format", "json")

--- a/internal/detector/pythonpm_test.go
+++ b/internal/detector/pythonpm_test.go
@@ -275,6 +275,64 @@ func TestPythonProjectDetector_VenvWithoutPip(t *testing.T) {
 	}
 }
 
+// Without Xcode Command Line Tools, /usr/bin/python3 and /usr/bin/pip3 are
+// Apple shims that pop a GUI install prompt the moment they're invoked. The
+// detector must skip them so customers rolling out the agent fleet-wide don't
+// see "install developer tools" dialogs on Macs without Python.
+func TestPythonPMDetector_SkipsAppleStubWithoutCLT(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("darwin")
+	mock.SetAppleCLTInstalled(false)
+	mock.SetPath("python3", "/usr/bin/python3")
+	mock.SetPath("pip3", "/usr/bin/pip3")
+	// Intentionally NO SetCommand stubs — if the guard fails, the mock will
+	// return "no command stub" errors, but more importantly the test asserts
+	// these shims are never invoked.
+
+	det := NewPythonPMDetector(mock)
+	results := det.DetectManagers(context.Background())
+	if len(results) != 0 {
+		t.Errorf("expected /usr/bin/ stubs to be skipped, got %d results: %+v", len(results), results)
+	}
+
+	pkgs := det.ListPackages(context.Background())
+	if pkgs != nil {
+		t.Errorf("expected ListPackages to return nil when pip3 is an Apple stub, got %+v", pkgs)
+	}
+}
+
+// When CLT is installed, /usr/bin/python3 resolves to the real CLT-shipped
+// Python and must be detected as normal.
+func TestPythonPMDetector_DetectsUsrBinWhenCLTInstalled(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("darwin")
+	mock.SetAppleCLTInstalled(true)
+	mock.SetPath("python3", "/usr/bin/python3")
+	mock.SetCommand("Python 3.9.6\n", "", 0, "python3", "--version")
+
+	det := NewPythonPMDetector(mock)
+	results := det.DetectManagers(context.Background())
+	if len(results) != 1 || results[0].Name != "python3" || results[0].Version != "3.9.6" {
+		t.Errorf("expected python3 v3.9.6 from /usr/bin/python3 with CLT, got %+v", results)
+	}
+}
+
+// The stub guard is a darwin-only concern; on Linux a binary at /usr/bin/python3
+// is a real interpreter and must be detected.
+func TestPythonPMDetector_DetectsUsrBinOnLinux(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("linux")
+	mock.SetAppleCLTInstalled(false) // irrelevant on linux; verify it doesn't gate
+	mock.SetPath("python3", "/usr/bin/python3")
+	mock.SetCommand("Python 3.11.4\n", "", 0, "python3", "--version")
+
+	det := NewPythonPMDetector(mock)
+	results := det.DetectManagers(context.Background())
+	if len(results) != 1 || results[0].Version != "3.11.4" {
+		t.Errorf("expected python3 v3.11.4 on linux regardless of CLT flag, got %+v", results)
+	}
+}
+
 func mustCreateFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/detector/pythonscan.go
+++ b/internal/detector/pythonscan.go
@@ -43,6 +43,11 @@ func (s *PythonScanner) ScanGlobalPackages(ctx context.Context) []model.PythonSc
 		if err != nil {
 			continue
 		}
+		if s.exec.IsAppleCLTStub(ctx, binPath) {
+			// On a Mac without Command Line Tools, /usr/bin/pip3 etc. are install-
+			// prompt shims — invoking `list` would pop a GUI dialog for the user.
+			continue
+		}
 
 		s.log.Progress("  Checking %s global packages...", spec.name)
 		version := s.getVersion(ctx, spec.binary, spec.versionCmd)

--- a/internal/detector/pythonscan_test.go
+++ b/internal/detector/pythonscan_test.go
@@ -1,0 +1,47 @@
+package detector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/progress"
+)
+
+// On a Mac without CLT installed, /usr/bin/pip3 is an Apple shim that pops a
+// GUI dialog when invoked. ScanGlobalPackages must skip it; otherwise every
+// fleet endpoint without CLT triggers the prompt on first run.
+func TestPythonScanner_SkipsAppleStubWithoutCLT(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("darwin")
+	mock.SetAppleCLTInstalled(false)
+	mock.SetPath("pip3", "/usr/bin/pip3")
+	// No SetCommand for pip3 list — if the guard fails the test surfaces it
+	// via a non-empty results slice (mock would return -1 exit with the
+	// "no command stub" error captured).
+
+	scanner := NewPythonScanner(mock, progress.NewLogger(progress.LevelError))
+	results := scanner.ScanGlobalPackages(context.Background())
+	if len(results) != 0 {
+		t.Errorf("expected Apple pip3 stub to be skipped, got %d results: %+v", len(results), results)
+	}
+}
+
+// When CLT is installed, /usr/bin/pip3 is a real binary and must be scanned.
+func TestPythonScanner_ScansUsrBinWhenCLTInstalled(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("darwin")
+	mock.SetAppleCLTInstalled(true)
+	mock.SetPath("pip3", "/usr/bin/pip3")
+	mock.SetCommand("pip 24.0\n", "", 0, "pip3", "--version")
+	mock.SetCommand(`[{"name":"requests","version":"2.32.0"}]`, "", 0, "pip3", "list", "--format", "json")
+
+	scanner := NewPythonScanner(mock, progress.NewLogger(progress.LevelError))
+	results := scanner.ScanGlobalPackages(context.Background())
+	if len(results) != 1 || results[0].PackageManager != "pip" {
+		t.Fatalf("expected one pip result with CLT installed, got %+v", results)
+	}
+	if results[0].ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", results[0].ExitCode)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -59,10 +60,20 @@ type Executor interface {
 	LoggedInUser() (*user.User, error)
 	// GOOS returns the runtime operating system.
 	GOOS() string
+	// IsAppleCLTStub reports whether binPath is an Apple Command Line Tools
+	// shim (under /usr/bin/) that would trigger the macOS "install developer
+	// tools" GUI prompt when invoked. Returns false on non-darwin systems, for
+	// paths outside /usr/bin/, or when CLT is installed. Detectors must guard
+	// every Run/RunWithTimeout on /usr/bin/-resolved binaries with this check
+	// to avoid disrupting end users on machines without CLT installed.
+	IsAppleCLTStub(ctx context.Context, binPath string) bool
 }
 
 // Real implements Executor using actual OS calls.
-type Real struct{}
+type Real struct {
+	cltOnce    sync.Once
+	cltPresent bool
+}
 
 func NewReal() *Real { return &Real{} }
 
@@ -199,4 +210,50 @@ func (r *Real) LoggedInUser() (*user.User, error) {
 
 func (r *Real) GOOS() string {
 	return runtime.GOOS
+}
+
+// appleCLTStubBinaries is the explicit set of /usr/bin/ paths that Apple
+// ships as Command Line Tools shims. Invoking any of these on a Mac without
+// CLT installed pops a GUI install prompt. A "/usr/bin/" prefix check alone
+// would over-match: /usr/bin/ssh, /usr/bin/ls, /usr/bin/env etc. are base
+// system binaries that work fine without CLT.
+//
+// Extend this set when introducing a detector that invokes another /usr/bin/
+// binary Apple wraps as a CLT shim (common examples: git, make, clang,
+// clang++, cc, c++, gcc, g++, swift, swiftc, gdb, lldb).
+var appleCLTStubBinaries = map[string]struct{}{
+	"/usr/bin/python3": {},
+	"/usr/bin/pip3":    {},
+}
+
+// IsAppleCLTStub reports whether binPath is an Apple Command Line Tools shim
+// that would trigger the macOS "install developer tools" GUI prompt when
+// invoked. Returns true iff:
+//  1. GOOS is darwin,
+//  2. binPath is a known Apple CLT shim (see appleCLTStubBinaries), AND
+//  3. Xcode Command Line Tools are not installed (`xcode-select -p` fails).
+//
+// The CLT-presence result is cached per Real instance via sync.Once: the
+// first qualifying check runs `xcode-select -p` and subsequent calls reuse
+// the cached flag (a full Python scan otherwise probes several binaries).
+//
+// `xcode-select -p` itself does NOT trigger the install prompt — it just
+// prints the developer-dir path or exits non-zero when CLT is absent.
+func (r *Real) IsAppleCLTStub(ctx context.Context, binPath string) bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	if _, ok := appleCLTStubBinaries[binPath]; !ok {
+		return false
+	}
+	r.cltOnce.Do(func() {
+		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(probeCtx, "xcode-select", "-p")
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+		err := cmd.Run()
+		r.cltPresent = err == nil && strings.TrimSpace(stdout.String()) != ""
+	})
+	return !r.cltPresent
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -233,13 +233,17 @@ var appleCLTStubBinaries = map[string]struct{}{
 //  2. binPath is a known Apple CLT shim (see appleCLTStubBinaries), AND
 //  3. Xcode Command Line Tools are not installed (`xcode-select -p` fails).
 //
-// The CLT-presence result is cached per Real instance via sync.Once: the
-// first qualifying check runs `xcode-select -p` and subsequent calls reuse
-// the cached flag (a full Python scan otherwise probes several binaries).
+// The CLT-presence result is cached per Real instance via sync.Once. The
+// probe deliberately uses context.Background() (with its own 5 s timeout)
+// rather than the caller-provided ctx: sync.Once consumes the slot on the
+// first call, so a caller arriving with a canceled or near-deadline ctx
+// could otherwise poison the cache with cltPresent=false and make every
+// subsequent check treat real binaries as stubs. The caller's ctx is
+// retained in the signature for symmetry with the Executor interface.
 //
 // `xcode-select -p` itself does NOT trigger the install prompt — it just
 // prints the developer-dir path or exits non-zero when CLT is absent.
-func (r *Real) IsAppleCLTStub(ctx context.Context, binPath string) bool {
+func (r *Real) IsAppleCLTStub(_ context.Context, binPath string) bool {
 	if runtime.GOOS != "darwin" {
 		return false
 	}
@@ -247,7 +251,7 @@ func (r *Real) IsAppleCLTStub(ctx context.Context, binPath string) bool {
 		return false
 	}
 	r.cltOnce.Do(func() {
-		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		probeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(probeCtx, "xcode-select", "-p")
 		var stdout bytes.Buffer

--- a/internal/executor/mock.go
+++ b/internal/executor/mock.go
@@ -39,6 +39,10 @@ type Mock struct {
 
 	// Symlink stubs: path -> resolved target
 	symlinks map[string]string
+
+	// macOS Command Line Tools presence (false simulates a Mac without CLT
+	// installed, where /usr/bin/python3 etc. are install-prompt shims).
+	appleCLTInstalled bool
 }
 
 type cmdResult struct {
@@ -162,6 +166,14 @@ func (m *Mock) SetGOOS(goos string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.goos = goos
+}
+
+// SetAppleCLTInstalled controls the value returned by IsAppleCLTStub.
+// Default is false (CLT not installed → /usr/bin/ binaries reported as stubs).
+func (m *Mock) SetAppleCLTInstalled(installed bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.appleCLTInstalled = installed
 }
 
 // --- Executor interface ---
@@ -302,6 +314,18 @@ func (m *Mock) GOOS() string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.goos
+}
+
+func (m *Mock) IsAppleCLTStub(_ context.Context, binPath string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.goos != "darwin" {
+		return false
+	}
+	if _, ok := appleCLTStubBinaries[binPath]; !ok {
+		return false
+	}
+	return !m.appleCLTInstalled
 }
 
 // --- helpers ---

--- a/internal/executor/mock.go
+++ b/internal/executor/mock.go
@@ -169,7 +169,8 @@ func (m *Mock) SetGOOS(goos string) {
 }
 
 // SetAppleCLTInstalled controls the value returned by IsAppleCLTStub.
-// Default is false (CLT not installed → /usr/bin/ binaries reported as stubs).
+// Default is false (CLT not installed → binaries in the appleCLTStubBinaries
+// allowlist are reported as stubs; other /usr/bin/ paths are unaffected).
 func (m *Mock) SetAppleCLTInstalled(installed bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/executor/mock_test.go
+++ b/internal/executor/mock_test.go
@@ -1,0 +1,39 @@
+package executor
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMock_IsAppleCLTStub(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name     string
+		goos     string
+		clt      bool
+		path     string
+		expected bool
+	}{
+		{"darwin /usr/bin/python3 without CLT → stub", "darwin", false, "/usr/bin/python3", true},
+		{"darwin /usr/bin/pip3 without CLT → stub", "darwin", false, "/usr/bin/pip3", true},
+		{"darwin /usr/bin/python3 with CLT → not stub", "darwin", true, "/usr/bin/python3", false},
+		{"darwin /usr/bin/ssh without CLT → not stub (base system binary)", "darwin", false, "/usr/bin/ssh", false},
+		{"darwin /usr/bin/ls without CLT → not stub (base system binary)", "darwin", false, "/usr/bin/ls", false},
+		{"darwin /usr/local/bin → never a stub", "darwin", false, "/usr/local/bin/python3", false},
+		{"darwin /opt/homebrew → never a stub", "darwin", false, "/opt/homebrew/bin/python3", false},
+		{"linux /usr/bin/python3 without CLT flag → not a stub", "linux", false, "/usr/bin/python3", false},
+		{"windows path → not a stub", "windows", false, `C:\Python\python.exe`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMock()
+			m.SetGOOS(tc.goos)
+			m.SetAppleCLTInstalled(tc.clt)
+			if got := m.IsAppleCLTStub(ctx, tc.path); got != tc.expected {
+				t.Errorf("IsAppleCLTStub(%q) on goos=%s clt=%v: got %v, want %v",
+					tc.path, tc.goos, tc.clt, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/executor/user_aware.go
+++ b/internal/executor/user_aware.go
@@ -108,3 +108,6 @@ func (e *UserAwareExecutor) EvalSymlinks(path string) (string, error) {
 }
 func (e *UserAwareExecutor) LoggedInUser() (*user.User, error) { return e.inner.LoggedInUser() }
 func (e *UserAwareExecutor) GOOS() string                      { return e.inner.GOOS() }
+func (e *UserAwareExecutor) IsAppleCLTStub(ctx context.Context, binPath string) bool {
+	return e.inner.IsAppleCLTStub(ctx, binPath)
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -142,12 +142,12 @@ type SystemPackage struct {
 	InstallTimeUnix int64  `json:"install_time_unix,omitempty"` // Unix epoch seconds when installed (rpm, dpkg, pacman)
 
 	// Provenance & trust signals
-	Vendor       string `json:"vendor,omitempty"`          // Distributor: rpm VENDOR, dpkg Origin
-	Maintainer   string `json:"maintainer,omitempty"`      // Packager identity: rpm PACKAGER, dpkg Maintainer, apk maintainer, pacman Packager
-	URL          string `json:"url,omitempty"`             // Upstream project URL
-	License      string `json:"license,omitempty"`         // SPDX license expression
-	Section      string `json:"section,omitempty"`         // dpkg Section category (e.g. "libs", "non-free/libs")
-	Signature    string `json:"signature,omitempty"`       // Signature info: rpm SIGPGP/RSAHEADER, pacman Validated By
+	Vendor        string `json:"vendor,omitempty"`          // Distributor: rpm VENDOR, dpkg Origin
+	Maintainer    string `json:"maintainer,omitempty"`      // Packager identity: rpm PACKAGER, dpkg Maintainer, apk maintainer, pacman Packager
+	URL           string `json:"url,omitempty"`             // Upstream project URL
+	License       string `json:"license,omitempty"`         // SPDX license expression
+	Section       string `json:"section,omitempty"`         // dpkg Section category (e.g. "libs", "non-free/libs")
+	Signature     string `json:"signature,omitempty"`       // Signature info: rpm SIGPGP/RSAHEADER, pacman Validated By
 	BuildTimeUnix int64  `json:"build_time_unix,omitempty"` // Unix epoch when package was built (rpm, apk, pacman)
 
 	// Size


### PR DESCRIPTION


## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
