### PR TITLE
fix: handle Windows AI hook paths

### DIFF
--- a/internal/aiagents/adapter/claudecode/adapter_test.go
+++ b/internal/aiagents/adapter/claudecode/adapter_test.go
@@ -17,7 +17,7 @@ import (
 
 // testBinary is the absolute DMG binary path tests pass to New(). The
 // uninstall matcher (managedCmdRE) is path-token-agnostic, so the
-// specific value just needs to satisfy `(^|/)stepsecurity-dev-machine-guard\s+_hook\s+`.
+// specific value just needs to satisfy the managed binary token pattern.
 const testBinary = "/usr/local/bin/stepsecurity-dev-machine-guard"
 
 // newHomeWithSettings creates a tempdir-rooted ~/.claude/settings.json
@@ -52,6 +52,58 @@ func mustParse(t *testing.T, path string) map[string]any {
 		t.Fatalf("settings JSON: %v", err)
 	}
 	return out
+}
+
+func TestIsManagedCommandMatchesPlatformBinaryPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{
+			name: "bare unix binary",
+			cmd:  "stepsecurity-dev-machine-guard _hook claude-code PreToolUse",
+			want: true,
+		},
+		{
+			name: "absolute unix binary",
+			cmd:  "/usr/local/bin/stepsecurity-dev-machine-guard _hook claude-code PreToolUse",
+			want: true,
+		},
+		{
+			name: "bare windows binary",
+			cmd:  "stepsecurity-dev-machine-guard.exe _hook claude-code PreToolUse",
+			want: true,
+		},
+		{
+			name: "absolute windows binary",
+			cmd:  `C:\Users\runneradmin\.stepsecurity\bin\stepsecurity-dev-machine-guard.exe _hook claude-code PreToolUse`,
+			want: true,
+		},
+		{
+			name: "prefixed lookalike",
+			cmd:  "mystepsecurity-dev-machine-guard.exe _hook claude-code PreToolUse",
+			want: false,
+		},
+		{
+			name: "suffixed lookalike",
+			cmd:  "stepsecurity-dev-machine-guardctl status",
+			want: false,
+		},
+		{
+			name: "hyphenated lookalike",
+			cmd:  "/usr/local/bin/stepsecurity-dev-machine-guard-foo _hook claude-code PreToolUse",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isManagedCommand(tc.cmd); got != tc.want {
+				t.Fatalf("isManagedCommand(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestInstallPreservesUserHooks(t *testing.T) {

--- a/internal/aiagents/adapter/claudecode/settings.go
+++ b/internal/aiagents/adapter/claudecode/settings.go
@@ -54,10 +54,10 @@ const settingsMode = os.FileMode(0o600)
 // managedCmdRE is the uninstall match criterion. It matches
 // an entry's `command` field when the executable token is the DMG
 // binary, regardless of which absolute path it sits behind. The
-// `(^|/)` left-side accepts both bare invocations and absolute-path
-// invocations, while rejecting prefix collisions like
+// `(^|[/\\])` left-side accepts bare invocations plus Unix and Windows
+// absolute paths, while rejecting prefix collisions like
 // `mystepsecurity-dev-machine-guard`.
-var managedCmdRE = regexp.MustCompile(`(^|/)stepsecurity-dev-machine-guard\s+_hook\s+`)
+var managedCmdRE = regexp.MustCompile(`(^|[/\\])stepsecurity-dev-machine-guard(?:\.exe)?\s+_hook\s+`)
 
 func loadSettings(path string) (*settingsDoc, error) {
 	b, err := os.ReadFile(path)

--- a/internal/aiagents/adapter/codex/adapter_test.go
+++ b/internal/aiagents/adapter/codex/adapter_test.go
@@ -19,8 +19,7 @@ import (
 
 // testBinary is the absolute DMG binary path tests pass to New(). The
 // uninstall matcher (managedCmdRE) is path-token-agnostic, so the
-// specific value just needs to satisfy
-// `(^|/)stepsecurity-dev-machine-guard\s+_hook\s+`.
+// specific value just needs to satisfy the managed binary token pattern.
 const testBinary = "/usr/local/bin/stepsecurity-dev-machine-guard"
 
 // commandFor renders the canonical command string the adapter writes
@@ -91,6 +90,58 @@ func readTOML(t *testing.T, path string) map[string]any {
 		t.Fatalf("config.toml not valid TOML: %v: %s", err, b)
 	}
 	return m
+}
+
+func TestIsManagedCommandMatchesPlatformBinaryPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{
+			name: "bare unix binary",
+			cmd:  "stepsecurity-dev-machine-guard _hook codex SessionStart",
+			want: true,
+		},
+		{
+			name: "absolute unix binary",
+			cmd:  "/usr/local/bin/stepsecurity-dev-machine-guard _hook codex SessionStart",
+			want: true,
+		},
+		{
+			name: "bare windows binary",
+			cmd:  "stepsecurity-dev-machine-guard.exe _hook codex SessionStart",
+			want: true,
+		},
+		{
+			name: "absolute windows binary",
+			cmd:  `C:\Users\runneradmin\.stepsecurity\bin\stepsecurity-dev-machine-guard.exe _hook codex SessionStart`,
+			want: true,
+		},
+		{
+			name: "prefixed lookalike",
+			cmd:  "mystepsecurity-dev-machine-guard.exe _hook codex SessionStart",
+			want: false,
+		},
+		{
+			name: "suffixed lookalike",
+			cmd:  "stepsecurity-dev-machine-guardctl status",
+			want: false,
+		},
+		{
+			name: "hyphenated lookalike",
+			cmd:  "/usr/local/bin/stepsecurity-dev-machine-guard-foo _hook codex SessionStart",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isManagedCommand(tc.cmd); got != tc.want {
+				t.Fatalf("isManagedCommand(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestNameAndManagedFiles(t *testing.T) {

--- a/internal/aiagents/adapter/codex/settings.go
+++ b/internal/aiagents/adapter/codex/settings.go
@@ -21,23 +21,23 @@ import (
 )
 
 const (
-	hookTimeoutSeconds = 30
-	matcherAll         = "*"
-	matcherSession     = "startup|resume|clear"
-	settingsMode       = os.FileMode(0o600)
+	hookTimeoutSeconds  = 30
+	matcherAll          = "*"
+	matcherSession      = "startup|resume|clear"
+	settingsMode        = os.FileMode(0o600)
 	statusMessagePrefix = "dev-machine-guard"
 )
 
 // managedCmdRE is the uninstall match criterion. It matches an entry's
 // `command` field when the executable token is the DMG binary,
-// regardless of which absolute path it sits behind. The `(^|/)`
-// left-side accepts both bare invocations and absolute-path
-// invocations, while rejecting prefix collisions like
+// regardless of which absolute path it sits behind. The `(^|[/\\])`
+// left-side accepts bare invocations plus Unix and Windows absolute
+// paths, while rejecting prefix collisions like
 // `mystepsecurity-dev-machine-guard`.
 //
 // The regex is kept identical to the claudecode adapter's so a single
 // grep covers both.
-var managedCmdRE = regexp.MustCompile(`(^|/)stepsecurity-dev-machine-guard\s+_hook\s+`)
+var managedCmdRE = regexp.MustCompile(`(^|[/\\])stepsecurity-dev-machine-guard(?:\.exe)?\s+_hook\s+`)
 
 // hooksDoc holds raw bytes for ~/.codex/hooks.json. orig is the bytes
 // as read from disk (nil if the file did not exist); json is the
@@ -453,4 +453,3 @@ func writeConfigAtomic(path string, encoded []byte) (*atomicfile.WriteResult, er
 	}
 	return &wr, nil
 }
-


### PR DESCRIPTION
## Summary
- Match DMG-managed Claude and Codex hook commands written with Windows backslash paths and `.exe` binary names.
- Add table coverage for Unix paths, Windows paths, and lookalike commands that must stay unmanaged.

## Test
- go test ./internal/aiagents/adapter/claudecode ./internal/aiagents/adapter/codex