### PR TITLE
fix(pnpm): resolve v11 global-scan regression

### DIFF
--- a/internal/detector/nodescan.go
+++ b/internal/detector/nodescan.go
@@ -210,7 +210,8 @@ func (s *NodeScanner) scanPnpmGlobal(ctx context.Context) (model.NodeScanResult,
 	globalDir = filepath.Dir(globalDir)
 
 	start := time.Now()
-	stdout, stderr, exitCode, _ := s.runCmd(ctx, 60*time.Second, "pnpm", "list", "-g", "--json", "--depth=3")
+	// pnpm v11 exits non-zero on `--depth=3` for global scans; use `--depth=Infinity` there.
+	stdout, stderr, exitCode, _ := s.runCmd(ctx, 60*time.Second, "pnpm", "list", "-g", "--json", pnpmDepthArg(version))
 	duration := time.Since(start).Milliseconds()
 
 	errMsg := ""
@@ -403,4 +404,20 @@ func (s *NodeScanner) getOutput(ctx context.Context, binary string, args ...stri
 func isInsideNodeModules(projectDir string) bool {
 	normalized := strings.ReplaceAll(projectDir, "\\", "/")
 	return strings.Contains(normalized, "/node_modules/")
+}
+
+// pnpmDepthArg picks the `--depth` arg for `pnpm list -g` based on the pnpm
+// version. pnpm v11 exits non-zero when `--depth=3` is passed to a global
+// scan; `--depth=Infinity` works on v11 and preserves transitive depth.
+// Falls back to `--depth=3` for older / unparseable versions to preserve
+// existing behavior.
+func pnpmDepthArg(version string) string {
+	v := strings.TrimSpace(version)
+	v = strings.TrimPrefix(v, "v")
+	major, _, _ := strings.Cut(v, ".")
+	n, err := strconv.Atoi(major)
+	if err == nil && n >= 11 {
+		return "--depth=Infinity"
+	}
+	return "--depth=3"
 }

--- a/internal/detector/nodescan_test.go
+++ b/internal/detector/nodescan_test.go
@@ -206,6 +206,89 @@ func TestNodeScanner_ScanProject_YarnBerry_Windows(t *testing.T) {
 	}
 }
 
+func TestPnpmDepthArg(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{"", "--depth=3"},
+		{"unknown", "--depth=3"},
+		{"9.1.0", "--depth=3"},
+		{"10.12.4", "--depth=3"},
+		{"11.0.0", "--depth=Infinity"},
+		{"11.1.1", "--depth=Infinity"},
+		{"v12.0.0\n", "--depth=Infinity"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := pnpmDepthArg(tt.version)
+			if got != tt.want {
+				t.Errorf("pnpmDepthArg(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeScanner_ScanPnpmGlobal_V11(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetPath("pnpm", "/opt/homebrew/bin/pnpm")
+	mock.SetCommand("11.1.1\n", "", 0, "pnpm", "--version")
+	mock.SetCommand("/Users/dev/Library/pnpm/global/v11/abc/node_modules\n", "", 0, "pnpm", "root", "-g")
+	// v11 must use --depth=Infinity; --depth=3 would fail in real life.
+	mock.SetCommand(`{"dependencies":{"jest":{"version":"29.7.0"}}}`, "", 0, "pnpm", "list", "-g", "--json", "--depth=Infinity")
+
+	scanner := newTestScanner(mock)
+	results := scanner.ScanGlobalPackages(context.Background())
+
+	pnpmFound := false
+	for _, r := range results {
+		if r.PackageManager == "pnpm" {
+			pnpmFound = true
+			if r.PMVersion != "11.1.1" {
+				t.Errorf("expected PMVersion 11.1.1, got %s", r.PMVersion)
+			}
+			if r.ExitCode != 0 {
+				t.Errorf("expected ExitCode 0, got %d", r.ExitCode)
+			}
+			decoded, _ := base64.StdEncoding.DecodeString(r.RawStdoutBase64)
+			if len(decoded) == 0 {
+				t.Error("expected non-empty RawStdoutBase64")
+			}
+		}
+	}
+	if !pnpmFound {
+		t.Fatal("expected pnpm in global scan results for v11")
+	}
+}
+
+func TestNodeScanner_ScanPnpmGlobal_V10_StillUsesDepth3(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetPath("pnpm", "/usr/local/bin/pnpm")
+	mock.SetCommand("10.12.4\n", "", 0, "pnpm", "--version")
+	mock.SetCommand("/Users/dev/.local/share/pnpm/global/5/node_modules\n", "", 0, "pnpm", "root", "-g")
+	// v10 must still use --depth=3 (proves we didn't break the legacy path).
+	mock.SetCommand(`{"dependencies":{"typescript":{"version":"5.4.0"}}}`, "", 0, "pnpm", "list", "-g", "--json", "--depth=3")
+
+	scanner := newTestScanner(mock)
+	results := scanner.ScanGlobalPackages(context.Background())
+
+	pnpmFound := false
+	for _, r := range results {
+		if r.PackageManager == "pnpm" {
+			pnpmFound = true
+			if r.PMVersion != "10.12.4" {
+				t.Errorf("expected PMVersion 10.12.4, got %s", r.PMVersion)
+			}
+			if r.ExitCode != 0 {
+				t.Errorf("expected ExitCode 0, got %d", r.ExitCode)
+			}
+		}
+	}
+	if !pnpmFound {
+		t.Fatal("expected pnpm in global scan results for v10")
+	}
+}
+
 func TestNodeScanner_ScanGlobalPackages_NoneInstalled(t *testing.T) {
 	mock := executor.NewMock()
 	scanner := newTestScanner(mock)


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
