### PR TITLE
fix(aiagents): write Windows hook command with forward-slash path

### DIFF
--- a/internal/aiagents/adapter/claudecode/adapter.go
+++ b/internal/aiagents/adapter/claudecode/adapter.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime"
 
 	"github.com/step-security/dev-machine-guard/internal/aiagents/adapter"
 	"github.com/step-security/dev-machine-guard/internal/aiagents/event"
@@ -144,8 +145,17 @@ func (a *Adapter) Uninstall(ctx context.Context) (adapter.UninstallResult, error
 //
 // The binary path is absolute and symlink-resolved at install time;
 // see internal/aiagents/cli/selfpath.go.
+//
+// On Windows the path is forward-slashed because Claude Code executes
+// hook commands through bash (Git Bash on windows-latest runners), and
+// bash interprets backslashes in unquoted tokens as escape sequences —
+// `C:\Users\foo` becomes `C:Usersfoo` and the binary fails to resolve.
 func (a *Adapter) commandFor(hookEvent event.HookEvent) string {
-	return a.binaryPath + " _hook " + AgentName + " " + string(hookEvent)
+	bp := a.binaryPath
+	if runtime.GOOS == "windows" {
+		bp = filepath.ToSlash(bp)
+	}
+	return bp + " _hook " + AgentName + " " + string(hookEvent)
 }
 
 // allowResponse is the Claude Code wire-format for "let the agent

--- a/internal/aiagents/adapter/codex/adapter.go
+++ b/internal/aiagents/adapter/codex/adapter.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"slices"
 
 	"github.com/step-security/dev-machine-guard/internal/aiagents/adapter"
@@ -196,8 +197,17 @@ func (a *Adapter) Uninstall(ctx context.Context) (adapter.UninstallResult, error
 //
 // The binary path is absolute and symlink-resolved at install time;
 // see internal/aiagents/cli/selfpath.go.
+//
+// On Windows the path is forward-slashed because Codex executes hook
+// commands through bash (Git Bash on windows-latest runners), and bash
+// interprets backslashes in unquoted tokens as escape sequences —
+// `C:\Users\foo` becomes `C:Usersfoo` and the binary fails to resolve.
 func (a *Adapter) commandFor(hookEvent event.HookEvent) string {
-	return a.binaryPath + " _hook " + AgentName + " " + string(hookEvent)
+	bp := a.binaryPath
+	if runtime.GOOS == "windows" {
+		bp = filepath.ToSlash(bp)
+	}
+	return bp + " _hook " + AgentName + " " + string(hookEvent)
 }
 
 // noopResponse marshals to {} — Codex treats empty output / {} as


### PR DESCRIPTION
Claude Code and Codex execute hook commands through bash on Windows (Git Bash on windows-latest runners). Bash interprets backslashes in unquoted tokens as escape sequences, so the previously written path `C:\Users\...\stepsecurity-dev-machine-guard.exe` collapsed to `C:Users...stepsecurity-dev-machine-guard.exe` and failed to resolve.

Forward-slash the binary path on Windows in both adapters' commandFor so bash sees `C:/Users/.../stepsecurity-dev-machine-guard.exe`. The existing managedCmdRE uninstall matcher already accepts `/` as the separator, so uninstall continues to recognize installed entries.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
