### PR TITLE
chore(release): update to v1.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [VERSIONING.md](VERSIONING.md) for why the version starts at 1.8.1.
 
-## [1.11.2] - 2026-05-21
+## [1.11.3] - 2026-05-21
 
 ### Added
 
 - **AI agent hook state polling**: agents periodically check the StepSecurity backend for desired hook enable/disable state and reconcile local installation to match. Silent no-op in community mode; failures are logged but never crash the scanner.
 - **Static machine resource info in device payload**: each scan now reports CPU model and count, total RAM, and disk capacity for the scanned host, giving the dashboard a clearer picture of the endpoint context.
+- **Configurable install directory + persistent stderr logs**: new `--install-dir` flag (and matching env var/config field) relocates all non-bootstrap agent state, and stderr is now captured to a rotated `agent.error.log` under the install dir so MDM/service deployments have durable diagnostics (#88).
 
 ### Fixed
 
+- **Auto-update signing**: fixed a signing regression in the previous 1.11.2 release that prevented auto-update from working. v1.11.2 has been removed; install or upgrade to 1.11.3 directly.
 - **Windows scheduled task user context**: the scheduled task now runs under the logged-in user via `/ru INTERACTIVE` instead of `SYSTEM`, so the scanner can read `HKCU`, `%USERPROFILE%`, and the user's `PATH` — fixing a class of missed detections for tools installed in user scope.
 - **Windows agent log directory permissions**: `C:\ProgramData\StepSecurity` now grants `BUILTIN\Users` Modify rights so the scheduled task (running as the logged-in user) can append to `agent.log` instead of failing with Access Denied.
 - **AI agent hook command path on Windows**: hook entries written into agent config files now use forward-slash paths, avoiding Windows shell quoting issues that could prevent the hook from firing.
@@ -179,7 +181,7 @@ First open-source release. The scanning engine was previously an internal enterp
 - Execution log capture and base64 encoding
 - Instance locking to prevent concurrent runs
 
-[1.11.2]: https://github.com/step-security/dev-machine-guard/compare/v1.11.1...v1.11.2
+[1.11.3]: https://github.com/step-security/dev-machine-guard/compare/v1.11.1...v1.11.3
 [1.11.1]: https://github.com/step-security/dev-machine-guard/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/step-security/dev-machine-guard/compare/v1.10.2...v1.11.0
 [1.10.2]: https://github.com/step-security/dev-machine-guard/compare/v1.10.1...v1.10.2

--- a/examples/sample-output.json
+++ b/examples/sample-output.json
@@ -1,5 +1,5 @@
 {
-  "agent_version": "1.11.2",
+  "agent_version": "1.11.3",
   "scan_timestamp": 1741305600,
   "scan_timestamp_iso": "2026-03-07T00:00:00Z",
   "device": {


### PR DESCRIPTION
## What does this PR do?

Bumps the release to **v1.11.3**, replacing the removed v1.11.2.

v1.11.2 was pulled because a signing regression broke auto-update. v1.11.3 carries the same content plus:
- a fix for the auto-update signing regression from v1.11.2
- the configurable install dir + persistent stderr logs from #88

CHANGELOG entry for v1.11.1 is unchanged; the prior v1.11.2 section has been folded into the new v1.11.3 section.

## Type of change

- [x] Bug fix
- [x] Enhancement

## Testing

- [x] Tested on macOS
- [x] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [x] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [x] No secrets or credentials included
- [x] Lint passes: `make lint`
- [x] Tests pass: `make test`