### PR TITLE
chore(release): bump version constant to 1.11.3

### DIFF
--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -3,7 +3,7 @@ package buildinfo
 import "fmt"
 
 const (
-	Version  = "1.11.2"
+	Version  = "1.11.3"
 	AgentURL = "https://github.com/step-security/dev-machine-guard"
 )
 


### PR DESCRIPTION
PR #94 updated the changelog and sample output for v1.11.3 but missed the Version constant in internal/buildinfo/version.go, leaving the binary still reporting 1.11.2.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
