### PR TITLE
fix(paths): add support for expanding $HOME

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -16,6 +16,7 @@ package paths
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/step-security/dev-machine-guard/internal/config"
@@ -40,8 +41,16 @@ func SetOverride(s string) {
 // Home returns the resolved install dir. Falls back to LegacyHome when
 // nothing else is set. Empty string is possible only when the home
 // directory itself cannot be resolved. A leading $HOME or ~ token in
-// any source is expanded so the returned path is always canonical —
-// matches the search_dirs handling in internal/scan/scanner.go.
+// any source is expanded via expandHome so the returned path is
+// canonical for the current OS, keeping the migration warning in main
+// from misfiring on hand-edited values like "$HOME/.stepsecurity" that
+// resolve to the legacy default.
+//
+// Note: this is a superset of resolveSearchDirs in internal/scan/scanner.go,
+// which only expands the exact literal "$HOME" — the install dir comes
+// from operator-edited config so it has to tolerate the "$HOME/foo" /
+// "~/foo" forms our docs use; search_dirs come from --search-dirs flag
+// values that operators don't combine with subpaths.
 func Home() string {
 	if cliOverride != "" {
 		return expandHome(cliOverride)
@@ -77,9 +86,12 @@ func expandHome(s string) string {
 	case s == "$HOME" || s == "~":
 		return home
 	case strings.HasPrefix(s, "$HOME/") || strings.HasPrefix(s, `$HOME\`):
-		return home + s[len("$HOME"):]
+		// filepath.Join + Clean canonicalises separators so Windows
+		// gets C:\Users\me\.stepsecurity (not C:\Users\me/.stepsecurity)
+		// and the equality check against LegacyHome() can succeed.
+		return filepath.Join(home, s[len("$HOME"):])
 	case strings.HasPrefix(s, "~/") || strings.HasPrefix(s, `~\`):
-		return home + s[len("~"):]
+		return filepath.Join(home, s[len("~"):])
 	}
 	return s
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -16,6 +16,7 @@ package paths
 
 import (
 	"os"
+	"strings"
 
 	"github.com/step-security/dev-machine-guard/internal/config"
 )
@@ -38,18 +39,49 @@ func SetOverride(s string) {
 
 // Home returns the resolved install dir. Falls back to LegacyHome when
 // nothing else is set. Empty string is possible only when the home
-// directory itself cannot be resolved.
+// directory itself cannot be resolved. A leading $HOME or ~ token in
+// any source is expanded so the returned path is always canonical —
+// matches the search_dirs handling in internal/scan/scanner.go.
 func Home() string {
 	if cliOverride != "" {
-		return cliOverride
+		return expandHome(cliOverride)
 	}
 	if v := os.Getenv(HomeEnvVar); v != "" {
-		return v
+		return expandHome(v)
 	}
 	if config.InstallDir != "" {
-		return config.InstallDir
+		return expandHome(config.InstallDir)
 	}
 	return LegacyHome()
+}
+
+// expandHome replaces a leading $HOME or ~ token with the resolved
+// user home directory. Returns the input unchanged when the home
+// directory cannot be resolved or no token is present. Callers that
+// hand-edit config.json with "$HOME/.stepsecurity" — the literal value
+// our docs use — get the same canonical form as LegacyHome(), which
+// keeps the migration warning in main from misfiring on identical
+// paths.
+func expandHome(s string) string {
+	if s == "" {
+		return s
+	}
+	if !strings.HasPrefix(s, "$HOME") && !strings.HasPrefix(s, "~") {
+		return s
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return s
+	}
+	switch {
+	case s == "$HOME" || s == "~":
+		return home
+	case strings.HasPrefix(s, "$HOME/") || strings.HasPrefix(s, `$HOME\`):
+		return home + s[len("$HOME"):]
+	case strings.HasPrefix(s, "~/") || strings.HasPrefix(s, `~\`):
+		return home + s[len("~"):]
+	}
+	return s
 }
 
 // LegacyHome returns ~/.stepsecurity. Exposed for the migration check

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -2,6 +2,7 @@ package paths
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -95,7 +96,7 @@ func TestHome_ExpandsHomeTokenFromConfig(t *testing.T) {
 	if err != nil || home == "" {
 		t.Skip("home dir unresolved in this environment")
 	}
-	want := home + "/.stepsecurity"
+	want := filepath.Join(home, ".stepsecurity")
 	if got := Home(); got != want {
 		t.Errorf("Home() = %q, want %q (config $HOME should expand)", got, want)
 	}
@@ -114,7 +115,7 @@ func TestHome_ExpandsTildeFromEnvVar(t *testing.T) {
 	if err != nil || home == "" {
 		t.Skip("home dir unresolved in this environment")
 	}
-	want := home + "/agent"
+	want := filepath.Join(home, "agent")
 	if got := Home(); got != want {
 		t.Errorf("Home() = %q, want %q (env ~ should expand)", got, want)
 	}
@@ -129,7 +130,7 @@ func TestHome_ExpandsHomeFromCLIFlag(t *testing.T) {
 	if err != nil || home == "" {
 		t.Skip("home dir unresolved in this environment")
 	}
-	want := home + "/custom"
+	want := filepath.Join(home, "custom")
 	if got := Home(); got != want {
 		t.Errorf("Home() = %q, want %q (CLI $HOME should expand)", got, want)
 	}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -86,6 +86,65 @@ func TestHome_CLIOverridesEnv(t *testing.T) {
 	}
 }
 
+func TestHome_ExpandsHomeTokenFromConfig(t *testing.T) {
+	withOverride(t, "")
+	withEnv(t, HomeEnvVar, "")
+	withConfigInstallDir(t, "$HOME/.stepsecurity")
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("home dir unresolved in this environment")
+	}
+	want := home + "/.stepsecurity"
+	if got := Home(); got != want {
+		t.Errorf("Home() = %q, want %q (config $HOME should expand)", got, want)
+	}
+	// And the migration warning's equality check must now succeed.
+	if Home() != LegacyHome() {
+		t.Errorf("Home()=%q vs LegacyHome()=%q — expected equal after $HOME expansion", Home(), LegacyHome())
+	}
+}
+
+func TestHome_ExpandsTildeFromEnvVar(t *testing.T) {
+	withOverride(t, "")
+	withConfigInstallDir(t, "")
+	withEnv(t, HomeEnvVar, "~/agent")
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("home dir unresolved in this environment")
+	}
+	want := home + "/agent"
+	if got := Home(); got != want {
+		t.Errorf("Home() = %q, want %q (env ~ should expand)", got, want)
+	}
+}
+
+func TestHome_ExpandsHomeFromCLIFlag(t *testing.T) {
+	withConfigInstallDir(t, "")
+	withEnv(t, HomeEnvVar, "")
+	withOverride(t, "$HOME/custom")
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("home dir unresolved in this environment")
+	}
+	want := home + "/custom"
+	if got := Home(); got != want {
+		t.Errorf("Home() = %q, want %q (CLI $HOME should expand)", got, want)
+	}
+}
+
+func TestHome_AbsolutePathUnchanged(t *testing.T) {
+	withOverride(t, "")
+	withEnv(t, HomeEnvVar, "")
+	withConfigInstallDir(t, "/opt/stepsecurity")
+
+	if got := Home(); got != "/opt/stepsecurity" {
+		t.Errorf("Home() = %q, want /opt/stepsecurity (absolute path must not be modified)", got)
+	}
+}
+
 func TestSetOverride_Sticks(t *testing.T) {
 	withOverride(t, "")
 	SetOverride("/sticky")


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
