### PR TITLE
fix(windows): stop console window flashes during scheduled scans

### DIFF
--- a/.github/workflows/msi-smoke.yml
+++ b/.github/workflows/msi-smoke.yml
@@ -55,7 +55,7 @@ jobs:
           wix --version
           wix extension add --global WixToolset.Util.wixext/4.0.5
 
-      - name: Build Windows .exe
+      - name: Build Windows .exes (agent + launcher)
         shell: pwsh
         run: |
           $env:GOOS = "windows"
@@ -64,7 +64,11 @@ jobs:
           go build -trimpath -ldflags "-s -w" `
             -o "$PWD\dmg-smoke.exe" `
             ./cmd/stepsecurity-dev-machine-guard
-          Get-Item "$PWD\dmg-smoke.exe" | Select-Object Name, Length
+          go build -trimpath -ldflags "-s -w -H windowsgui" `
+            -o "$PWD\dmg-smoke-task.exe" `
+            ./cmd/stepsecurity-dev-machine-guard-task
+          Get-Item "$PWD\dmg-smoke.exe", "$PWD\dmg-smoke-task.exe" |
+            Select-Object Name, Length
 
       - name: Build MSI
         shell: pwsh
@@ -83,6 +87,7 @@ jobs:
             -d Arch=x64 `
             -d "Version=$version" `
             -d "BinaryPath=$PWD\dmg-smoke.exe" `
+            -d "LauncherPath=$PWD\dmg-smoke-task.exe" `
             -out "dist\dmg-smoke.msi"
           Get-Item "dist\dmg-smoke.msi" | Select-Object Name, Length
 
@@ -112,18 +117,28 @@ jobs:
       - name: Verify install artifacts
         shell: pwsh
         run: |
-          $bin   = "C:\Program Files\StepSecurity\stepsecurity-dev-machine-guard.exe"
-          $cfg   = "C:\ProgramData\StepSecurity\config.json"
-          $task  = "StepSecurity Dev Machine Guard"
+          $bin      = "C:\Program Files\StepSecurity\stepsecurity-dev-machine-guard.exe"
+          $launcher = "C:\Program Files\StepSecurity\stepsecurity-dev-machine-guard-task.exe"
+          $cfg      = "C:\ProgramData\StepSecurity\config.json"
+          $task     = "StepSecurity Dev Machine Guard"
 
           $checks = @()
 
-          # 1. Binary on disk
+          # 1a. Agent binary on disk
           if (Test-Path $bin) {
-            Write-Host "[OK] Binary present at $bin"
+            Write-Host "[OK] Agent present at $bin"
             $checks += $true
           } else {
-            Write-Host "::error::Binary missing: $bin"
+            Write-Host "::error::Agent missing: $bin"
+            $checks += $false
+          }
+
+          # 1b. Launcher binary on disk
+          if (Test-Path $launcher) {
+            Write-Host "[OK] Launcher present at $launcher"
+            $checks += $true
+          } else {
+            Write-Host "::error::Launcher missing: $launcher"
             $checks += $false
           }
 
@@ -160,7 +175,8 @@ jobs:
             $checks += $false
           }
 
-          # 4. Scheduled task registered and runs as INTERACTIVE
+          # 4. Scheduled task registered, runs as INTERACTIVE, and its
+          # action points at the launcher (not the agent directly).
           $taskInfo = schtasks /query /tn $task /v /fo LIST 2>&1
           if ($LASTEXITCODE -eq 0) {
             $runAs = ($taskInfo | Select-String -Pattern '^\s*Run As User:').ToString()
@@ -169,6 +185,15 @@ jobs:
               $checks += $true
             } else {
               Write-Host "::error::Run As User wrong: $runAs"
+              $checks += $false
+            }
+
+            $action = ($taskInfo | Select-String -Pattern '^\s*Task To Run:').ToString()
+            if ($action -match 'stepsecurity-dev-machine-guard-task\.exe') {
+              Write-Host "[OK] Task action points at GUI launcher"
+              $checks += $true
+            } else {
+              Write-Host "::error::Task action does not point at launcher: $action"
               $checks += $false
             }
           } else {
@@ -199,12 +224,17 @@ jobs:
         run: |
           $task = "StepSecurity Dev Machine Guard"
 
-          # Binary should be gone
-          if (Test-Path "C:\Program Files\StepSecurity\stepsecurity-dev-machine-guard.exe") {
-            Write-Host "::error::Binary still present after uninstall"
-            exit 1
+          # Both binaries should be gone
+          foreach ($leftover in @(
+            "C:\Program Files\StepSecurity\stepsecurity-dev-machine-guard.exe",
+            "C:\Program Files\StepSecurity\stepsecurity-dev-machine-guard-task.exe"
+          )) {
+            if (Test-Path $leftover) {
+              Write-Host "::error::File still present after uninstall: $leftover"
+              exit 1
+            }
           }
-          Write-Host "[OK] Binary removed"
+          Write-Host "[OK] Agent + launcher removed"
 
           # Scheduled task should be gone. Capture the exit code into a
           # local — PowerShell uses $LASTEXITCODE from the last native call

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,13 @@ jobs:
         id: binaries
         run: |
           DARWIN=$(find dist -type f -name '*darwin_unnotarized' | head -1)
-          WIN_AMD64=$(find dist -type f -name '*.exe' -path '*windows_amd64*' | head -1)
-          WIN_ARM64=$(find dist -type f -name '*.exe' -path '*windows_arm64*' | head -1)
+          # Filter agent vs launcher (-task) explicitly — both ship as
+          # <name>-<version>-<os>_<arch>.exe so a bare *.exe glob would
+          # match either.
+          WIN_AMD64=$(find dist -type f -name 'stepsecurity-dev-machine-guard-*-windows_amd64.exe' ! -name '*-task-*' | head -1)
+          WIN_ARM64=$(find dist -type f -name 'stepsecurity-dev-machine-guard-*-windows_arm64.exe' ! -name '*-task-*' | head -1)
+          WIN_TASK_AMD64=$(find dist -type f -name 'stepsecurity-dev-machine-guard-task-*-windows_amd64.exe' | head -1)
+          WIN_TASK_ARM64=$(find dist -type f -name 'stepsecurity-dev-machine-guard-task-*-windows_arm64.exe' | head -1)
           LINUX_AMD64=$(find dist -type f -name 'stepsecurity-dev-machine-guard' -path '*linux_amd64*' | head -1)
           LINUX_ARM64=$(find dist -type f -name 'stepsecurity-dev-machine-guard' -path '*linux_arm64*' | head -1)
 
@@ -102,7 +107,7 @@ jobs:
           RPM_AMD64=$(find dist -type f -name '*-amd64.rpm' | head -1)
           RPM_ARM64=$(find dist -type f -name '*-arm64.rpm' | head -1)
 
-          for label in "darwin:${DARWIN}" "windows_amd64:${WIN_AMD64}" "windows_arm64:${WIN_ARM64}" "linux_amd64:${LINUX_AMD64}" "linux_arm64:${LINUX_ARM64}" "deb_amd64:${DEB_AMD64}" "deb_arm64:${DEB_ARM64}" "rpm_amd64:${RPM_AMD64}" "rpm_arm64:${RPM_ARM64}"; do
+          for label in "darwin:${DARWIN}" "windows_amd64:${WIN_AMD64}" "windows_arm64:${WIN_ARM64}" "windows_task_amd64:${WIN_TASK_AMD64}" "windows_task_arm64:${WIN_TASK_ARM64}" "linux_amd64:${LINUX_AMD64}" "linux_arm64:${LINUX_ARM64}" "deb_amd64:${DEB_AMD64}" "deb_arm64:${DEB_ARM64}" "rpm_amd64:${RPM_AMD64}" "rpm_arm64:${RPM_ARM64}"; do
             name="${label%%:*}"
             path="${label#*:}"
             if [ -z "$path" ] || [ ! -f "$path" ]; then
@@ -115,6 +120,8 @@ jobs:
           echo "darwin=$DARWIN" >> "$GITHUB_OUTPUT"
           echo "win_amd64=$WIN_AMD64" >> "$GITHUB_OUTPUT"
           echo "win_arm64=$WIN_ARM64" >> "$GITHUB_OUTPUT"
+          echo "win_task_amd64=$WIN_TASK_AMD64" >> "$GITHUB_OUTPUT"
+          echo "win_task_arm64=$WIN_TASK_ARM64" >> "$GITHUB_OUTPUT"
           echo "linux_amd64=$LINUX_AMD64" >> "$GITHUB_OUTPUT"
           echo "linux_arm64=$LINUX_ARM64" >> "$GITHUB_OUTPUT"
           echo "deb_amd64=$DEB_AMD64" >> "$GITHUB_OUTPUT"
@@ -147,6 +154,10 @@ jobs:
             "dist/stepsecurity-dev-machine-guard-windows_amd64.exe.bundle"
           sign_with_retry "${{ steps.binaries.outputs.win_arm64 }}" \
             "dist/stepsecurity-dev-machine-guard-windows_arm64.exe.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.win_task_amd64 }}" \
+            "dist/stepsecurity-dev-machine-guard-task-windows_amd64.exe.bundle"
+          sign_with_retry "${{ steps.binaries.outputs.win_task_arm64 }}" \
+            "dist/stepsecurity-dev-machine-guard-task-windows_arm64.exe.bundle"
           sign_with_retry "${{ steps.binaries.outputs.linux_amd64 }}" \
             "dist/stepsecurity-dev-machine-guard-linux_amd64.bundle"
           sign_with_retry "${{ steps.binaries.outputs.linux_arm64 }}" \
@@ -168,6 +179,8 @@ jobs:
             dist/stepsecurity-dev-machine-guard-darwin_unnotarized.bundle \
             dist/stepsecurity-dev-machine-guard-windows_amd64.exe.bundle \
             dist/stepsecurity-dev-machine-guard-windows_arm64.exe.bundle \
+            dist/stepsecurity-dev-machine-guard-task-windows_amd64.exe.bundle \
+            dist/stepsecurity-dev-machine-guard-task-windows_arm64.exe.bundle \
             dist/stepsecurity-dev-machine-guard-linux_amd64.bundle \
             dist/stepsecurity-dev-machine-guard-linux_arm64.bundle \
             "${{ steps.binaries.outputs.deb_amd64 }}.bundle" \
@@ -183,6 +196,8 @@ jobs:
             ${{ steps.binaries.outputs.darwin }}
             ${{ steps.binaries.outputs.win_amd64 }}
             ${{ steps.binaries.outputs.win_arm64 }}
+            ${{ steps.binaries.outputs.win_task_amd64 }}
+            ${{ steps.binaries.outputs.win_task_arm64 }}
             ${{ steps.binaries.outputs.linux_amd64 }}
             ${{ steps.binaries.outputs.linux_arm64 }}
             ${{ steps.binaries.outputs.deb_amd64 }}
@@ -240,10 +255,15 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ needs.release.outputs.version }}"
-          $amd64 = Get-ChildItem dist -Filter "*-windows_amd64.exe" | Select-Object -First 1
-          $arm64 = Get-ChildItem dist -Filter "*-windows_arm64.exe" | Select-Object -First 1
-          if (-not $amd64 -or -not $arm64) {
-            Write-Error "Windows .exe assets missing under dist/"
+          # Both agent and launcher .exes share the *-windows_<arch>.exe
+          # suffix; filter on the -task- segment to tell them apart.
+          $amd64       = Get-ChildItem dist -Filter "stepsecurity-dev-machine-guard-*-windows_amd64.exe" | Where-Object Name -NotLike '*-task-*' | Select-Object -First 1
+          $arm64       = Get-ChildItem dist -Filter "stepsecurity-dev-machine-guard-*-windows_arm64.exe" | Where-Object Name -NotLike '*-task-*' | Select-Object -First 1
+          $taskAmd64   = Get-ChildItem dist -Filter "stepsecurity-dev-machine-guard-task-*-windows_amd64.exe" | Select-Object -First 1
+          $taskArm64   = Get-ChildItem dist -Filter "stepsecurity-dev-machine-guard-task-*-windows_arm64.exe" | Select-Object -First 1
+          if (-not $amd64 -or -not $arm64 -or -not $taskAmd64 -or -not $taskArm64) {
+            Write-Error "Windows .exe assets (agent + launcher, both arches) missing under dist/"
+            Get-ChildItem dist | Format-Table Name
             exit 1
           }
 
@@ -253,6 +273,7 @@ jobs:
             -d Arch=x64 `
             -d "Version=$version" `
             -d "BinaryPath=$($amd64.FullName)" `
+            -d "LauncherPath=$($taskAmd64.FullName)" `
             -out "dist/stepsecurity-dev-machine-guard-$version-x64.msi"
 
           wix build packaging/windows/Product.wxs `
@@ -261,6 +282,7 @@ jobs:
             -d Arch=arm64 `
             -d "Version=$version" `
             -d "BinaryPath=$($arm64.FullName)" `
+            -d "LauncherPath=$($taskArm64.FullName)" `
             -out "dist/stepsecurity-dev-machine-guard-$version-arm64.msi"
 
           Get-ChildItem dist -Filter "*.msi" | Format-Table Name, Length

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ stepsecurity-dev-machine-guard-linux
 
 # Temporary files
 todo-remove/
+
+# Agent runtime state. When the binary or its tests run from inside the
+# repo (working dir = a subpkg, HOME pointing under it, etc.), it drops
+# config.json, agent.error.log, ai-agent-hook-errors.jsonl, hooks-state.json
+# and friends here. Never artifacts we want to track.
+**/.stepsecurity/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,29 @@ builds:
     env:
       - CGO_ENABLED=0
 
+  # GUI-subsystem launcher invoked by Windows Task Scheduler so the
+  # console-subsystem agent never gets a console window allocated.
+  # -H windowsgui flips the PE subsystem; otherwise identical config.
+  - id: stepsecurity-dev-machine-guard-task
+    main: ./cmd/stepsecurity-dev-machine-guard-task
+    binary: stepsecurity-dev-machine-guard-task
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -H windowsgui
+      - -X github.com/step-security/dev-machine-guard/internal/buildinfo.GitCommit={{.FullCommit}}
+      - -X github.com/step-security/dev-machine-guard/internal/buildinfo.ReleaseTag={{.Tag}}
+      - -X github.com/step-security/dev-machine-guard/internal/buildinfo.ReleaseBranch={{.Branch}}
+    env:
+      - CGO_ENABLED=0
+
 universal_binaries:
   - id: universal
     ids:
@@ -43,6 +66,13 @@ archives:
     formats:
       - binary
     name_template: "stepsecurity-dev-machine-guard-{{ .Version }}-{{ .Os }}_{{ .Arch }}"
+    allow_different_binary_count: true
+  - id: windows-task
+    ids:
+      - stepsecurity-dev-machine-guard-task
+    formats:
+      - binary
+    name_template: "stepsecurity-dev-machine-guard-task-{{ .Version }}-{{ .Os }}_{{ .Arch }}"
     allow_different_binary_count: true
 
 nfpms:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/internal/buildinfo.ReleaseTag=$(TAG) \
 	-X $(MODULE)/internal/buildinfo.ReleaseBranch=$(BRANCH)
 
-.PHONY: build build-windows build-windows-arm64 build-linux deploy-windows test lint clean smoke build-msi-amd64 build-msi-arm64
+.PHONY: build build-windows build-windows-task build-windows-arm64 build-windows-task-arm64 build-linux deploy-windows test lint clean smoke build-msi-amd64 build-msi-arm64
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/stepsecurity-dev-machine-guard
@@ -17,8 +17,17 @@ build:
 build-windows:
 	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY).exe ./cmd/stepsecurity-dev-machine-guard
 
+# GUI-subsystem launcher (see cmd/stepsecurity-dev-machine-guard-task).
+# `-H windowsgui` flips the PE subsystem so Windows doesn't allocate
+# a console when Task Scheduler launches it.
+build-windows-task:
+	GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS) -H windowsgui" -o $(BINARY)-task.exe ./cmd/stepsecurity-dev-machine-guard-task
+
 build-windows-arm64:
 	GOOS=windows GOARCH=arm64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY)-arm64.exe ./cmd/stepsecurity-dev-machine-guard
+
+build-windows-task-arm64:
+	GOOS=windows GOARCH=arm64 go build -trimpath -ldflags "$(LDFLAGS) -H windowsgui" -o $(BINARY)-task-arm64.exe ./cmd/stepsecurity-dev-machine-guard-task
 
 build-linux:
 	GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY)-linux ./cmd/stepsecurity-dev-machine-guard
@@ -27,7 +36,7 @@ build-linux:
 # Output: dist/stepsecurity-dev-machine-guard-<version>-{x64,arm64}.msi
 # Reads Version from internal/buildinfo so MajorUpgrade semantics line up
 # with whatever the binary reports as `--version`.
-build-msi-amd64: build-windows
+build-msi-amd64: build-windows build-windows-task
 	mkdir -p dist
 	@wix extension list --global 2>/dev/null | grep -q "WixToolset.Util.wixext" || \
 		wix extension add --global WixToolset.Util.wixext/4.0.5
@@ -37,9 +46,10 @@ build-msi-amd64: build-windows
 		-d Arch=x64 \
 		-d Version=$(VERSION) \
 		-d BinaryPath=$(CURDIR)/$(BINARY).exe \
+		-d LauncherPath=$(CURDIR)/$(BINARY)-task.exe \
 		-out dist/stepsecurity-dev-machine-guard-$(VERSION)-x64.msi
 
-build-msi-arm64: build-windows-arm64
+build-msi-arm64: build-windows-arm64 build-windows-task-arm64
 	mkdir -p dist
 	@wix extension list --global 2>/dev/null | grep -q "WixToolset.Util.wixext" || \
 		wix extension add --global WixToolset.Util.wixext/4.0.5
@@ -49,6 +59,7 @@ build-msi-arm64: build-windows-arm64
 		-d Arch=arm64 \
 		-d Version=$(VERSION) \
 		-d BinaryPath=$(CURDIR)/$(BINARY)-arm64.exe \
+		-d LauncherPath=$(CURDIR)/$(BINARY)-task-arm64.exe \
 		-out dist/stepsecurity-dev-machine-guard-$(VERSION)-arm64.msi
 
 deploy-windows:
@@ -61,7 +72,7 @@ lint:
 	golangci-lint run ./...
 
 clean:
-	rm -f $(BINARY) $(BINARY).exe $(BINARY)-arm64.exe $(BINARY)-linux
+	rm -f $(BINARY) $(BINARY).exe $(BINARY)-task.exe $(BINARY)-arm64.exe $(BINARY)-task-arm64.exe $(BINARY)-linux
 	rm -rf dist/
 
 smoke: build

--- a/cmd/stepsecurity-dev-machine-guard-task/main.go
+++ b/cmd/stepsecurity-dev-machine-guard-task/main.go
@@ -1,0 +1,110 @@
+//go:build windows
+
+// Command stepsecurity-dev-machine-guard-task is a GUI-subsystem
+// launcher that invokes the console-subsystem agent under
+// CREATE_NO_WINDOW. Built with `-ldflags "-H windowsgui"`.
+//
+// Why a separate binary: Windows allocates a console for any
+// console-subsystem process whose parent has none. Task Scheduler
+// under /ru INTERACTIVE is such a parent, so the agent itself would
+// always flash a window. The only fully-reliable suppression is for
+// the parent CreateProcess call to pass CREATE_NO_WINDOW, and the
+// only way to be that parent without flashing our own console is to
+// be GUI-subsystem. The agent stays console-subsystem so interactive
+// CLI use (install, configure, manual scans) still works normally.
+//
+// Layout: both binaries sit in the same directory. The scheduled task
+// points at this launcher; arguments forward unchanged.
+//
+// Lifecycle: the agent is assigned to a Job Object with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so it dies when the launcher
+// does — including under Stop-ScheduledTask, which only terminates
+// the registered action's PID.
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	createNoWindow uint32 = 0x08000000
+	agentBinary           = "stepsecurity-dev-machine-guard.exe"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	me, err := os.Executable()
+	if err != nil {
+		return 1
+	}
+	agent := filepath.Join(filepath.Dir(me), agentBinary)
+	if _, err := os.Stat(agent); err != nil {
+		return 1
+	}
+
+	cmd := exec.Command(agent, os.Args[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: createNoWindow,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return 1
+	}
+
+	// Best-effort: bind the agent to a kill-on-close job. The job
+	// handle stays open in this process; the kernel closes it on our
+	// exit, which fires the kill. Failure here only weakens lifecycle
+	// (orphan possible on forced termination), not the scan itself.
+	if job, jerr := newKillOnCloseJob(); jerr == nil {
+		if h, oerr := windows.OpenProcess(
+			windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+			false,
+			uint32(cmd.Process.Pid),
+		); oerr == nil {
+			_ = windows.AssignProcessToJobObject(job, h)
+			_ = windows.CloseHandle(h)
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		return 1
+	}
+	return 0
+}
+
+func newKillOnCloseJob() (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0, err
+	}
+	return job, nil
+}

--- a/internal/aiagents/cli/.stepsecurity/ai-agent-hook-errors.jsonl
+++ b/internal/aiagents/cli/.stepsecurity/ai-agent-hook-errors.jsonl
@@ -1,1 +1,0 @@
-{"ts":"2026-05-21T16:38:14.309922Z","stage":"install","code":"no_home","message":"should be silently dropped"}

--- a/internal/aiagents/enrich/npm/registry.go
+++ b/internal/aiagents/enrich/npm/registry.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/step-security/dev-machine-guard/internal/winproc"
 )
 
 // Source identifies which command produced the resolution. Empty when
@@ -25,6 +27,7 @@ var runFunc = execRun
 
 func execRun(ctx context.Context, cwd, bin string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
+	winproc.HideWindow(cmd)
 	if cwd != "" {
 		cmd.Dir = cwd
 	}

--- a/internal/config/config_windows.go
+++ b/internal/config/config_windows.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/step-security/dev-machine-guard/internal/winproc"
 	"golang.org/x/sys/windows"
 )
 
@@ -48,7 +49,9 @@ func hardenMachineConfigACL(path string) error {
 		"/grant:r", "*S-1-5-32-545:R", // BUILTIN\Users = Read
 		"/Q",
 	}
-	output, err := exec.Command("icacls", args...).CombinedOutput()
+	cmd := exec.Command("icacls", args...)
+	winproc.HideWindow(cmd)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintf(os.Stderr,
 			"warning: icacls hardening of %q failed: %v\nicacls output:\n%s\n",

--- a/internal/detector/ide.go
+++ b/internal/detector/ide.go
@@ -238,7 +238,7 @@ func (d *IDEDetector) detectDarwin(ctx context.Context, spec ideSpec) (model.IDE
 
 	// Fallback: product-info.json (JetBrains IDEs)
 	if version == "unknown" {
-		version = readProductInfoVersion(d.exec, filepath.Join(spec.AppPath, "Contents", "Resources", "product-info.json"))
+		version = readJSONVersion(d.exec, filepath.Join(spec.AppPath, "Contents", "Resources", "product-info.json"))
 	}
 
 	// Fallback: Info.plist
@@ -328,7 +328,7 @@ func (d *IDEDetector) resolveLinuxVersion(ctx context.Context, spec ideSpec, ins
 	}
 
 	// product-info.json at the root of the install dir (JetBrains, some Electron apps)
-	if v := readProductInfoVersion(d.exec, filepath.Join(installDir, "product-info.json")); v != "unknown" {
+	if v := readJSONVersion(d.exec, filepath.Join(installDir, "product-info.json")); v != "unknown" {
 		return v
 	}
 
@@ -378,9 +378,19 @@ func (d *IDEDetector) resolveWindowsVersion(ctx context.Context, spec ideSpec, i
 	return version
 }
 
-// resolveWindowsVersionFromDir tries binary, product-info.json, and .eclipseproduct.
-// Does NOT query the registry (caller handles that to avoid redundant queries).
+// resolveWindowsVersionFromDir tries package.json, the binary,
+// product-info.json, and .eclipseproduct in that order. The
+// package.json fast-path covers VS Code-derived Electron IDEs (VS
+// Code, Cursor, Windsurf, Antigravity) so we don't shell out to the
+// bin\*.cmd shim — that shim spawns cmd.exe, which flashes a console
+// under Task Scheduler. JetBrains and Zed have no package.json at
+// that path and fall through unchanged. Registry lookup is the
+// caller's final fallback.
 func (d *IDEDetector) resolveWindowsVersionFromDir(ctx context.Context, spec ideSpec, installDir string) string {
+	if v := readJSONVersion(d.exec, filepath.Join(installDir, "resources", "app", "package.json")); v != "unknown" {
+		return v
+	}
+
 	version := "unknown"
 
 	if spec.WinBinary != "" && spec.VersionFlag != "" {
@@ -391,7 +401,7 @@ func (d *IDEDetector) resolveWindowsVersionFromDir(ctx context.Context, spec ide
 	}
 
 	if version == "unknown" {
-		version = readProductInfoVersion(d.exec, filepath.Join(installDir, "product-info.json"))
+		version = readJSONVersion(d.exec, filepath.Join(installDir, "product-info.json"))
 	}
 
 	if version == "unknown" {
@@ -487,9 +497,11 @@ func runVersionCmd(ctx context.Context, exec executor.Executor, binary, flag str
 	return "unknown"
 }
 
-// readProductInfoVersion reads the "version" field from a JetBrains product-info.json file.
-// Returns "unknown" if the file does not exist or cannot be parsed.
-func readProductInfoVersion(exec executor.Executor, filePath string) string {
+// readJSONVersion reads the top-level "version" field from a JSON file.
+// Used for both JetBrains product-info.json and the VS Code-family
+// resources/app/package.json — both expose the same shape. Returns
+// "unknown" if the file does not exist or cannot be parsed.
+func readJSONVersion(exec executor.Executor, filePath string) string {
 	data, err := exec.ReadFile(filePath)
 	if err != nil {
 		return "unknown"

--- a/internal/detector/ide_test.go
+++ b/internal/detector/ide_test.go
@@ -382,6 +382,35 @@ func TestIDEDetector_Windows_FindsEclipse_UserProfile_Glob(t *testing.T) {
 	}
 }
 
+// When resources\app\package.json is readable, version must come from
+// it WITHOUT shelling out to the bin\code.cmd subprocess — that shim
+// flashes a console under Task Scheduler. The mock has no command
+// registered for the binary; if the detector falls through, the test
+// fails.
+func TestIDEDetector_Windows_VSCode_PackageJSONFastPath(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetEnv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
+	mock.SetEnv("PROGRAMFILES", `C:\Program Files`)
+
+	vscodePath := `C:\Program Files\Microsoft VS Code`
+	mock.SetDir(vscodePath)
+	mock.SetFile(vscodePath+`/bin\code.cmd`, []byte{})
+	mock.SetFile(vscodePath+`/resources/app/package.json`,
+		[]byte(`{"name":"Code","version":"1.115.0"}`))
+
+	det := NewIDEDetector(mock)
+	results := det.Detect(context.Background())
+
+	found := findIDE(results, "vscode")
+	if found == nil {
+		t.Fatal("expected VS Code to be detected")
+	}
+	if found.Version != "1.115.0" {
+		t.Errorf("version should come from package.json (1.115.0), got %s", found.Version)
+	}
+}
+
 func TestIDEDetector_Windows_VSCode_StillWorks(t *testing.T) {
 	mock := executor.NewMock()
 	mock.SetGOOS("windows")
@@ -441,7 +470,7 @@ func TestReadProductInfoVersion(t *testing.T) {
 	mock.SetFile("/test/product-info.json",
 		[]byte(`{"name":"GoLand","version":"2025.1.3","buildNumber":"251.26927.50"}`))
 
-	v := readProductInfoVersion(mock, "/test/product-info.json")
+	v := readJSONVersion(mock, "/test/product-info.json")
 	if v != "2025.1.3" {
 		t.Errorf("expected 2025.1.3, got %s", v)
 	}
@@ -449,7 +478,7 @@ func TestReadProductInfoVersion(t *testing.T) {
 
 func TestReadProductInfoVersion_MissingFile(t *testing.T) {
 	mock := executor.NewMock()
-	v := readProductInfoVersion(mock, "/nonexistent/product-info.json")
+	v := readJSONVersion(mock, "/nonexistent/product-info.json")
 	if v != "unknown" {
 		t.Errorf("expected unknown, got %s", v)
 	}
@@ -459,7 +488,7 @@ func TestReadProductInfoVersion_InvalidJSON(t *testing.T) {
 	mock := executor.NewMock()
 	mock.SetFile("/test/product-info.json", []byte(`not json`))
 
-	v := readProductInfoVersion(mock, "/test/product-info.json")
+	v := readJSONVersion(mock, "/test/product-info.json")
 	if v != "unknown" {
 		t.Errorf("expected unknown, got %s", v)
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/step-security/dev-machine-guard/internal/winproc"
 )
 
 // Executor defines the interface for all OS interactions.
@@ -82,6 +84,7 @@ func NewReal() *Real { return &Real{} }
 
 func (r *Real) Run(ctx context.Context, name string, args ...string) (string, string, int, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	winproc.HideWindow(cmd)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -111,6 +114,7 @@ func (r *Real) RunInDir(ctx context.Context, dir string, timeout time.Duration, 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)
+	winproc.HideWindow(cmd)
 	cmd.Dir = dir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -266,6 +270,7 @@ func (r *Real) IsAppleCLTStub(_ context.Context, binPath string) bool {
 		probeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(probeCtx, "xcode-select", "-p")
+		winproc.HideWindow(cmd)
 		var stdout bytes.Buffer
 		cmd.Stdout = &stdout
 		err := cmd.Run()

--- a/internal/schtasks/schtasks.go
+++ b/internal/schtasks/schtasks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	osexec "os/exec"
+	"path/filepath"
 	"strconv"
 
 	"github.com/step-security/dev-machine-guard/internal/config"
@@ -13,7 +14,10 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/progress"
 )
 
-const taskName = "StepSecurity Dev Machine Guard"
+const (
+	taskName     = "StepSecurity Dev Machine Guard"
+	launcherName = "stepsecurity-dev-machine-guard-task.exe"
+)
 
 // IsTaskRegistered reports whether the Windows scheduled task created by
 // `dev-machine-guard install` is currently registered. Used by the
@@ -55,14 +59,13 @@ func Install(exec executor.Executor, log *progress.Logger) error {
 		return fmt.Errorf("creating log directory: %w", err)
 	}
 
-	// For admin installs the log dir lives at C:\ProgramData\StepSecurity, which
-	// inherits ACLs from C:\ProgramData and only grants non-admin users
-	// Read & Execute on the files inside. The /ru INTERACTIVE task fires under
-	// whatever user is logged on — typically a non-admin developer — and
-	// cmd.exe's `>>` redirect to agent.log would fail with Access Denied, which
-	// aborts the whole task action. Grant BUILTIN\Users (SID 545) Modify rights
-	// on the log dir, propagated to files and subfolders, so any logged-in
-	// user can append to the log files.
+	// For admin installs the log dir lives at C:\ProgramData\StepSecurity,
+	// which inherits ACLs from C:\ProgramData and only grants non-admin
+	// users Read & Execute. The /ru INTERACTIVE task fires under the
+	// logged-in user (typically non-admin), and the agent's filelog
+	// opens agent.error.log here in append mode — that needs write
+	// access. Grant BUILTIN\Users (SID 545) Modify rights on the dir,
+	// propagated to files and subfolders.
 	if exec.IsRoot() {
 		_, _, _, icaclsErr := exec.Run(ctx, "icacls", logDir, "/grant", "*S-1-5-32-545:(OI)(CI)M", "/Q")
 		if icaclsErr != nil {
@@ -70,21 +73,18 @@ func Install(exec executor.Executor, log *progress.Logger) error {
 		}
 	}
 
-	// Bake STEPSECURITY_HOME into the task command. Admin/INTERACTIVE
-	// tasks (machine-wide installs) anchor at C:\ProgramData\StepSecurity
-	// so the scheduled task and the MSI's earlier write_config agree on
-	// the dir, regardless of which interactive user is logged on at fire
-	// time. Non-admin tasks track paths.Home() (whatever the user's own
-	// install dir resolves to).
-	var stepHome string
-	if exec.IsRoot() {
-		stepHome = `C:\ProgramData\StepSecurity`
-	} else {
-		stepHome = paths.Home()
-	}
+	// Pass --install-dir to the task command. logDir already carries the
+	// canonical resolution (admin → C:\ProgramData\StepSecurity,
+	// non-admin → paths.Home() with a CurrentUser fallback, finally
+	// ProgramData) so we reuse it as STEPSECURITY_HOME. Using paths.Home()
+	// directly here would emit --install-dir="" when HOME/USERPROFILE
+	// aren't resolvable, which the CLI treats as an explicit opt-out
+	// (disables file logging).
+	stepHome := logDir
 
-	args := buildCreateArgs(binaryPath, logDir, stepHome, hours, exec.IsRoot())
-	log.Debug("schtasks create: binary=%q log_dir=%q step_home=%q hours=%d is_admin=%v", binaryPath, logDir, stepHome, hours, exec.IsRoot())
+	taskBinary := resolveTaskBinary(exec, binaryPath)
+	args := buildCreateArgs(taskBinary, stepHome, hours, exec.IsRoot())
+	log.Debug("schtasks create: task_binary=%q agent=%q install_dir=%q hours=%d is_admin=%v", taskBinary, binaryPath, stepHome, hours, exec.IsRoot())
 
 	_, stderr, exitCode, err := exec.Run(ctx, "schtasks", args...)
 	log.Debug("schtasks /create: exit_code=%d err=%v", exitCode, err)
@@ -136,16 +136,28 @@ func isConfigured(ctx context.Context, exec executor.Executor) bool {
 	return exitCode == 0
 }
 
-func buildCreateArgs(binaryPath, logDir, stepHome string, hours int, isAdmin bool) []string {
-	// `set "VAR=value"` is the safe cmd.exe form when the value may
-	// contain spaces or `&` / `|` / `<` / `>` metacharacters — without
-	// the quotes, cmd.exe would split on the first space and the
-	// remainder would be treated as a separate command. Inside the outer
-	// `cmd /c "..."` quotes the inner double-quotes are escaped as `""`.
-	// stepHome ultimately comes from $HOME (e.g. `C:\Users\John Doe`),
-	// so quoting is load-bearing here.
-	taskCmd := fmt.Sprintf(`cmd /c "set ""STEPSECURITY_HOME=%s"" && \"%s\" send-telemetry >> \"%s\agent.log\" 2>> \"%s\agent.error.log\""`,
-		stepHome, binaryPath, logDir, logDir)
+// resolveTaskBinary returns the path the scheduled task should invoke.
+// When the GUI-subsystem launcher sits next to the agent (MSI install
+// layout), the task points at it so Windows doesn't allocate a console
+// for the agent under /ru INTERACTIVE. When the launcher isn't present
+// (ad-hoc deploys of just the agent .exe), we fall back to the agent
+// directly — subprocess flashes are still suppressed via winproc, only
+// the agent's own console-flash mitigation is forfeited.
+func resolveTaskBinary(exec executor.Executor, agentPath string) string {
+	launcher := filepath.Join(filepath.Dir(agentPath), launcherName)
+	if exec.FileExists(launcher) {
+		return launcher
+	}
+	return agentPath
+}
+
+// buildCreateArgs returns the schtasks /create arguments for the
+// periodic scan task. The task action invokes the binary directly
+// (no `cmd /c` wrapper) — env config and log routing both live in
+// the binary now (--install-dir + filelog), and the wrapper was the
+// source of a visible cmd.exe flash on every fire.
+func buildCreateArgs(binaryPath, stepHome string, hours int, isAdmin bool) []string {
+	taskCmd := fmt.Sprintf(`"%s" send-telemetry --install-dir="%s"`, binaryPath, stepHome)
 	args := []string{"/create", "/tn", taskName, "/tr", taskCmd,
 		"/sc", "HOURLY", "/mo", strconv.Itoa(hours), "/f"}
 	if isAdmin {

--- a/internal/schtasks/schtasks_test.go
+++ b/internal/schtasks/schtasks_test.go
@@ -2,6 +2,7 @@ package schtasks
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
@@ -103,7 +104,7 @@ func TestResolveLogDir_Admin(t *testing.T) {
 }
 
 func TestBuildCreateArgs_CustomFrequency(t *testing.T) {
-	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, `C:\logs`, 6, false)
+	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, 6, false)
 
 	// Find the /mo argument and check its value
 	foundMo := false
@@ -121,7 +122,7 @@ func TestBuildCreateArgs_CustomFrequency(t *testing.T) {
 }
 
 func TestBuildCreateArgs_Admin(t *testing.T) {
-	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, `C:\ProgramData\StepSecurity`, 4, true)
+	args := buildCreateArgs(`C:\agent.exe`, `C:\ProgramData\StepSecurity`, 4, true)
 
 	foundRU := false
 	for i, a := range args {
@@ -138,11 +139,75 @@ func TestBuildCreateArgs_Admin(t *testing.T) {
 }
 
 func TestBuildCreateArgs_NonAdmin(t *testing.T) {
-	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, `C:\logs`, 4, false)
+	args := buildCreateArgs(`C:\agent.exe`, `C:\logs`, 4, false)
 
 	for _, a := range args {
 		if a == "/ru" {
 			t.Error("expected no /ru argument for non-admin install")
 		}
+	}
+}
+
+// When the launcher binary is co-installed (MSI layout) it must be
+// preferred over the agent so the scheduled task fires through the
+// GUI-subsystem wrapper.
+//
+// Paths use forward slashes so the test is portable: filepath.{Dir,Join}
+// in resolveTaskBinary follow the host OS separator. The Windows
+// production path looks like C:\Program Files\StepSecurity\... — same
+// logic, just darwin-incompatible to assert against directly.
+func TestResolveTaskBinary_LauncherPresent(t *testing.T) {
+	mock := executor.NewMock()
+	agent := "/install/dir/stepsecurity-dev-machine-guard.exe"
+	launcher := "/install/dir/stepsecurity-dev-machine-guard-task.exe"
+	mock.SetFile(launcher, []byte{})
+
+	if got := resolveTaskBinary(mock, agent); got != launcher {
+		t.Errorf("want launcher %q, got %q", launcher, got)
+	}
+}
+
+// Ad-hoc deploys may ship only the agent .exe. The task must still
+// register correctly against the agent in that case.
+func TestResolveTaskBinary_NoLauncher(t *testing.T) {
+	mock := executor.NewMock()
+	agent := "/install/dir/stepsecurity-dev-machine-guard.exe"
+
+	if got := resolveTaskBinary(mock, agent); got != agent {
+		t.Errorf("want agent fallback %q, got %q", agent, got)
+	}
+}
+
+// The task action must invoke the binary directly. A `cmd /c` wrapper
+// (the pre-fix form) spawns a console window every time Task Scheduler
+// fires the task under an interactive user session.
+func TestBuildCreateArgs_TaskCommandFormat(t *testing.T) {
+	args := buildCreateArgs(`C:\agent.exe`, `C:\ProgramData\StepSecurity`, 4, true)
+
+	taskCmd := ""
+	for i, a := range args {
+		if a == "/tr" && i+1 < len(args) {
+			taskCmd = args[i+1]
+			break
+		}
+	}
+	if taskCmd == "" {
+		t.Fatal("no /tr argument found")
+	}
+
+	if strings.Contains(strings.ToLower(taskCmd), "cmd /c") || strings.Contains(strings.ToLower(taskCmd), "cmd.exe") {
+		t.Errorf("task command must not wrap binary in cmd: %q", taskCmd)
+	}
+	if !strings.Contains(taskCmd, "send-telemetry") {
+		t.Errorf("task command missing send-telemetry: %q", taskCmd)
+	}
+	if !strings.Contains(taskCmd, `--install-dir="C:\ProgramData\StepSecurity"`) {
+		t.Errorf("task command missing --install-dir flag: %q", taskCmd)
+	}
+	if !strings.HasPrefix(taskCmd, `"C:\agent.exe"`) {
+		t.Errorf("task command must start with quoted binary path: %q", taskCmd)
+	}
+	if strings.Contains(taskCmd, ">>") || strings.Contains(taskCmd, "STEPSECURITY_HOME=") {
+		t.Errorf("task command must not redirect output or set env vars: %q", taskCmd)
 	}
 }

--- a/internal/winproc/winproc.go
+++ b/internal/winproc/winproc.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+// Package winproc adjusts the OS-process attributes attached to an
+// *exec.Cmd. On Windows it suppresses console-window allocation for the
+// child; on every other platform it is a no-op so call sites stay
+// platform-agnostic.
+package winproc
+
+import "os/exec"
+
+// HideWindow is a no-op on non-Windows platforms.
+func HideWindow(_ *exec.Cmd) {}

--- a/internal/winproc/winproc_test.go
+++ b/internal/winproc/winproc_test.go
@@ -1,0 +1,23 @@
+package winproc
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// HideWindow must be safe to call from cross-platform code without
+// nil-checking — call-site noise is the main reason the helper exists.
+func TestHideWindow_NilSafe(t *testing.T) {
+	HideWindow(nil)
+}
+
+// On every platform a zero-value *exec.Cmd should survive HideWindow
+// unchanged in shape (no panics). Field-level assertions live in the
+// Windows-only test; this guards the non-Windows stub path too.
+func TestHideWindow_ZeroValueCmd(t *testing.T) {
+	cmd := exec.Command("true")
+	HideWindow(cmd)
+	if cmd.Path == "" {
+		t.Fatal("HideWindow corrupted cmd.Path")
+	}
+}

--- a/internal/winproc/winproc_windows.go
+++ b/internal/winproc/winproc_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package winproc
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// CREATE_NO_WINDOW. Spelled out so callers don't drag in
+// golang.org/x/sys/windows for one constant.
+const createNoWindow uint32 = 0x08000000
+
+// HideWindow tells the child not to allocate a console. Safe to call
+// twice or on a cmd whose SysProcAttr is already set: HideWindow is
+// merged, not overwritten, and CREATE_NO_WINDOW is OR'd into
+// CreationFlags. Without this, every powershell/cmd/.cmd subprocess
+// Go spawns under Task Scheduler flashes a console window.
+func HideWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}

--- a/internal/winproc/winproc_windows_test.go
+++ b/internal/winproc/winproc_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package winproc
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestHideWindow_SetsAttrs(t *testing.T) {
+	cmd := exec.Command("cmd.exe")
+	HideWindow(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr was not allocated")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("HideWindow flag not set")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
+		t.Errorf("CREATE_NO_WINDOW not OR'd into CreationFlags (got 0x%x)", cmd.SysProcAttr.CreationFlags)
+	}
+}
+
+// Pre-existing SysProcAttr fields must survive — we OR our flag in
+// rather than replacing the struct.
+func TestHideWindow_MergesExistingAttrs(t *testing.T) {
+	const otherFlag uint32 = 0x00000200 // CREATE_NEW_PROCESS_GROUP
+	cmd := exec.Command("cmd.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: otherFlag,
+		Token:         42,
+	}
+
+	HideWindow(cmd)
+
+	if cmd.SysProcAttr.CreationFlags&otherFlag == 0 {
+		t.Error("pre-existing CreationFlags bit was clobbered")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
+		t.Error("CREATE_NO_WINDOW not OR'd in")
+	}
+	if cmd.SysProcAttr.Token != 42 {
+		t.Errorf("Token field clobbered (want 42, got %d)", cmd.SysProcAttr.Token)
+	}
+}
+
+// Repeat invocations should be idempotent.
+func TestHideWindow_Idempotent(t *testing.T) {
+	cmd := exec.Command("cmd.exe")
+	HideWindow(cmd)
+	flags1 := cmd.SysProcAttr.CreationFlags
+	HideWindow(cmd)
+	if cmd.SysProcAttr.CreationFlags != flags1 {
+		t.Errorf("second call mutated CreationFlags (0x%x -> 0x%x)", flags1, cmd.SysProcAttr.CreationFlags)
+	}
+}

--- a/packaging/windows/Product.wxs
+++ b/packaging/windows/Product.wxs
@@ -7,6 +7,9 @@
 
     -d Version=<semver>       e.g. 1.8.2
     -d BinaryPath=<path>      path to stepsecurity-dev-machine-guard.exe
+    -d LauncherPath=<path>    path to stepsecurity-dev-machine-guard-task.exe
+                              (GUI-subsystem launcher Task Scheduler invokes
+                              so the agent doesn't flash a console window)
     -d Arch=<x64|arm64>       selects InstallScope + UpgradeCode
 
   Designed for SCCM/Intune deployment under environments where PowerShell
@@ -65,8 +68,12 @@
          Customers manage via SCCM, not via the user-facing ARP. -->
     <Property Id="ARPNOMODIFY" Value="1"/>
 
-    <!-- File payload: a single .exe under C:\Program Files\StepSecurity\.
-         The Source path resolves via $(var.BinaryPath) at build time. -->
+    <!-- File payload: the agent + the GUI-subsystem launcher, both under
+         C:\Program Files\StepSecurity\. Source paths resolve from
+         $(var.BinaryPath) and $(var.LauncherPath) at build time.
+         schtasks.Install picks the launcher when present (side-by-side
+         layout) so Windows doesn't allocate a console for the agent
+         under /ru INTERACTIVE. -->
     <StandardDirectory Id="$(var.ProgramFiles)">
       <Directory Id="INSTALLFOLDER" Name="StepSecurity">
         <Component Id="MainBinary" Bitness="always64">
@@ -75,11 +82,18 @@
                 Name="stepsecurity-dev-machine-guard.exe"
                 KeyPath="yes"/>
         </Component>
+        <Component Id="LauncherBinary" Bitness="always64">
+          <File Id="DMGLauncher"
+                Source="$(var.LauncherPath)"
+                Name="stepsecurity-dev-machine-guard-task.exe"
+                KeyPath="yes"/>
+        </Component>
       </Directory>
     </StandardDirectory>
 
     <Feature Id="Main" Title="Dev Machine Guard" Level="1">
       <ComponentRef Id="MainBinary"/>
+      <ComponentRef Id="LauncherBinary"/>
     </Feature>
 
     <!--


### PR DESCRIPTION
The schtasks /create action used to invoke the agent via a cmd /c wrapper, which produced a visible cmd.exe flash on every scheduled fire. This change:

- Drops the cmd /c wrapper; the task now invokes the agent (or the GUI-subsystem launcher) directly, with --install-dir / filelog handling moved into the binary.
- Adds cmd/stepsecurity-dev-machine-guard-task — a small GUI-subsystem launcher .exe used by the MSI install layout so Windows does not allocate a console for the scheduled task.
- Adds internal/winproc to suppress subprocess console flashes via CREATE_NO_WINDOW for child processes spawned by the agent.
- Wires the launcher binary into the MSI WiX manifest, .goreleaser config, Makefile, and the msi-smoke / release workflows.
- Adds Windows-side test coverage for schtasks, winproc, and the IDE detector.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
