### PR TITLE
fix(install-dir): make config field authoritative

### DIFF
--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -108,7 +108,9 @@ func main() {
 	// An explicit `--install-dir=` (empty) routes through SetDisabled,
 	// after which paths.Home() returns "" so EVERY on-disk consumer
 	// (filelog, ai-agent hook errors, any future file) uniformly skips
-	// — not just file logging.
+	// — not just file logging. cli.Parse rejects the empty form when
+	// paired with `install` / `uninstall`, where the platform installers
+	// need a real on-disk path for unit files and the log directory.
 	//
 	// The capture is installed before the logger so every subsequent
 	// stderr write — including the pipe-tee in

--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -100,24 +100,30 @@ func main() {
 	exec := executor.NewReal()
 
 	// Install dir resolution (see internal/paths.Home for the canonical
-	// chain): --install-dir CLI flag > $STEPSECURITY_HOME env var >
-	// install_dir config field > ~/.stepsecurity default. The CLI flag
-	// wins because it is the most explicit per-invocation override the
-	// operator can supply. We feed it to paths via SetOverride; an
-	// explicit `--install-dir=` (empty) is preserved and short-circuits
-	// the path computation below to disable file logging for this run.
+	// chain): --install-dir CLI flag > install_dir config field >
+	// $STEPSECURITY_HOME env var > ~/.stepsecurity default. Config beats
+	// env because config.json is the source of truth that the loader
+	// scripts write to and operators hand-edit; the env var baked into
+	// service unit files at install time can otherwise become stale.
+	// An explicit `--install-dir=` (empty) routes through SetDisabled,
+	// after which paths.Home() returns "" so EVERY on-disk consumer
+	// (filelog, ai-agent hook errors, any future file) uniformly skips
+	// — not just file logging.
 	//
 	// The capture is installed before the logger so every subsequent
 	// stderr write — including the pipe-tee in
 	// internal/telemetry/logcapture.go, which nests inside this one —
 	// flows through to disk.
 	if cfg.InstallDirSet {
-		paths.SetOverride(cfg.InstallDir) // may be "" = disabled
+		if cfg.InstallDir == "" {
+			paths.SetDisabled()
+		} else {
+			paths.SetOverride(cfg.InstallDir)
+		}
 	}
-	installDir := paths.Home()
-	disabled := cfg.InstallDirSet && cfg.InstallDir == ""
+	installDir := paths.Home() // "" when SetDisabled or home unresolved
 	logFilePath := ""
-	if !disabled && installDir != "" {
+	if installDir != "" {
 		logFilePath = filepath.Join(installDir, filelog.Filename)
 		// Pre-rotate BOTH files unconditionally. In interactive mode the
 		// stderr rotation is redundant with filelog.Start's own rotation
@@ -164,7 +170,7 @@ func main() {
 	// auto-move — too risky for v1 (silent overwrites, races with other
 	// processes, perms changes). Just point at the leftovers.
 	legacy := paths.LegacyHome()
-	if !disabled && legacy != "" && installDir != "" && installDir != legacy {
+	if legacy != "" && installDir != "" && installDir != legacy {
 		if leftovers := findLegacyLeftovers(legacy); len(leftovers) > 0 {
 			log.Warn("install dir is %s but the legacy default %s still has files: %s — copy them over manually if you want their history.",
 				installDir, legacy, strings.Join(leftovers, ", "))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -256,6 +256,17 @@ func Parse(args []string) (*Config, error) {
 		return nil, fmt.Errorf("--npmrc and --pipconfig are mutually exclusive; pick one")
 	}
 
+	// --install-dir= (explicit empty) disables file logging by routing
+	// paths.Home() to "" globally. That conflicts with `install` /
+	// `uninstall`, whose platform installers (systemd / launchd) call
+	// os.MkdirAll(paths.Home()) and bake STEPSECURITY_HOME into the unit
+	// file — both break or write nonsense values when Home() is empty.
+	// Reject the combination here with a clear message rather than
+	// letting the installer fail opaquely on an empty path.
+	if cfg.InstallDirSet && cfg.InstallDir == "" && (cfg.Command == "install" || cfg.Command == "uninstall") {
+		return nil, fmt.Errorf("--install-dir= (empty) cannot be combined with %s — pass a directory or omit the flag", cfg.Command)
+	}
+
 	return cfg, nil
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -360,6 +361,40 @@ func TestParse_InstallDir_AbsentLeavesUnset(t *testing.T) {
 	}
 	if cfg.InstallDir != "" || cfg.InstallDirSet {
 		t.Errorf("absent --install-dir should yield InstallDir=%q InstallDirSet=%v", cfg.InstallDir, cfg.InstallDirSet)
+	}
+}
+
+// TestParse_InstallDir_EmptyRejectedForInstall guards against the
+// combination that would make systemd/launchd Install mkdir an empty
+// path: --install-dir= disables paths.Home() globally, but the install
+// command unconditionally calls os.MkdirAll(paths.Home()). Rejecting at
+// parse time gives the operator a clear error instead of an opaque
+// installer failure.
+func TestParse_InstallDir_EmptyRejectedForInstall(t *testing.T) {
+	for _, cmd := range []string{"install", "uninstall"} {
+		_, err := Parse([]string{cmd, "--install-dir="})
+		if err == nil {
+			t.Errorf("Parse(%q --install-dir=) returned nil error, want rejection", cmd)
+			continue
+		}
+		if !strings.Contains(err.Error(), "--install-dir=") || !strings.Contains(err.Error(), cmd) {
+			t.Errorf("Parse(%q --install-dir=) error %q should reference the flag and the command", cmd, err)
+		}
+	}
+}
+
+// TestParse_InstallDir_EmptyAllowedWithoutInstallCommand confirms the
+// existing "disable file logging" use case for ad-hoc scans still
+// works — the rejection only fires when paired with install/uninstall.
+func TestParse_InstallDir_EmptyAllowedWithoutInstallCommand(t *testing.T) {
+	for _, args := range [][]string{
+		{"--install-dir="},
+		{"send-telemetry", "--install-dir="},
+		{"configure", "show", "--install-dir="},
+	} {
+		if _, err := Parse(args); err != nil {
+			t.Errorf("Parse(%v) returned error %v; --install-dir= should still be valid outside install/uninstall", args, err)
+		}
 	}
 }
 

--- a/internal/launchd/launchd.go
+++ b/internal/launchd/launchd.go
@@ -2,6 +2,7 @@ package launchd
 
 import (
 	"context"
+	"encoding/xml"
 	"fmt"
 	"os"
 	"strconv"
@@ -13,6 +14,18 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/paths"
 	"github.com/step-security/dev-machine-guard/internal/progress"
 )
+
+// plistEscape XML-escapes a string for use inside a plist <string>
+// element. Without this, a path containing &, <, >, ', or " would
+// produce malformed XML that launchctl rejects with an opaque parse
+// error at load time. text/template's raw substitution does no
+// escaping by default — html/template would over-escape unrelated
+// content — so we route every templated value through this helper.
+func plistEscape(s string) string {
+	var sb strings.Builder
+	_ = xml.EscapeText(&sb, []byte(s))
+	return sb.String()
+}
 
 const (
 	label           = "com.stepsecurity.agent"
@@ -114,14 +127,17 @@ func Install(exec executor.Executor, log *progress.Logger) error {
 		stepHome = paths.Home()
 	}
 
-	// Generate plist
+	// Generate plist. Every <string>-bound value is XML-escaped so a
+	// path with &, <, >, ', or " produces a well-formed plist that
+	// launchctl can actually load. IntervalSeconds is an integer, no
+	// escape needed; Label is a fixed constant.
 	plistData := plistTemplateData{
 		Label:            label,
-		BinaryPath:       binaryPath,
+		BinaryPath:       plistEscape(binaryPath),
 		IntervalSeconds:  intervalSeconds,
-		LogDir:           logDir,
-		UserHome:         userHome,
-		StepSecurityHome: stepHome,
+		LogDir:           plistEscape(logDir),
+		UserHome:         plistEscape(userHome),
+		StepSecurityHome: plistEscape(stepHome),
 	}
 
 	f, err := os.Create(plistPath)

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -78,14 +78,19 @@ func Home() string {
 	if cliDisabled {
 		return ""
 	}
+	// Read the env var once so a concurrent mutation (test helpers,
+	// future goroutine setup) can't flip the value between the switch
+	// guard and the assignment below — and so we don't pay for a second
+	// syscall on every lookup.
+	envHome := os.Getenv(HomeEnvVar)
 	var raw string
 	switch {
 	case cliOverride != "":
 		raw = cliOverride
 	case config.InstallDir != "":
 		raw = config.InstallDir
-	case os.Getenv(HomeEnvVar) != "":
-		raw = os.Getenv(HomeEnvVar)
+	case envHome != "":
+		raw = envHome
 	default:
 		return LegacyHome()
 	}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -3,10 +3,20 @@
 // from a layered set of sources so callers can stop deriving
 // ~/.stepsecurity independently:
 //
-//  1. --install-dir CLI flag (set by main via SetOverride)
-//  2. $STEPSECURITY_HOME environment variable (set by service unit / loader)
-//  3. install_dir config field (loaded by internal/config)
+//  1. --install-dir CLI flag (set by main via SetOverride / SetDisabled)
+//  2. install_dir config field (loaded by internal/config)
+//  3. $STEPSECURITY_HOME environment variable (fallback only)
 //  4. ~/.stepsecurity (legacy default)
+//
+// Why config beats env: the install_dir field in config.json is the
+// canonical source of truth — the loader scripts (agent-api) write to
+// it on every run, and operators can hand-edit it. Service installers
+// (launchd / systemd / schtasks) bake STEPSECURITY_HOME into their unit
+// files at install time, but that snapshot becomes stale the moment the
+// operator edits config.json. Letting config win means scheduler-
+// invoked runs immediately reflect a config change without requiring
+// the operator to re-run `install`. The env var stays as a defensive
+// fallback for the rare case where config.json is unreadable.
 //
 // config.json itself stays at the legacy location regardless — see
 // internal/config.LegacyDir — so the agent can always bootstrap. All
@@ -22,46 +32,68 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/config"
 )
 
-// HomeEnvVar is the environment variable consulted in resolution
-// step 2. Service installers bake this into their unit files so
-// scheduler-invoked runs see the same install dir as interactive ones.
+// HomeEnvVar is the environment variable consulted as a defensive
+// fallback when both the CLI override and config.InstallDir are unset.
+// Service installers bake this into their unit files but its precedence
+// is intentionally below config so that an edited install_dir wins.
 const HomeEnvVar = "STEPSECURITY_HOME"
 
 // cliOverride captures the --install-dir CLI flag value (step 1).
 // Set once at startup by main; never mutated thereafter.
 var cliOverride string
 
+// cliDisabled records that --install-dir= (explicit empty) was passed.
+// It is distinct from "cliOverride is empty" because the empty string
+// is also the "unset" sentinel for cliOverride itself. When set, Home()
+// returns "" so every on-disk consumer — filelog, ai-agent hook errors,
+// any future file derived from Home() — uniformly skips file output.
+var cliDisabled bool
+
 // SetOverride installs the CLI-flag value. Called by main after
 // cli.Parse and before any code that calls Home() — see
 // cmd/stepsecurity-dev-machine-guard/main.go.
 func SetOverride(s string) {
 	cliOverride = s
+	cliDisabled = false
+}
+
+// SetDisabled marks the install dir as explicitly disabled for this
+// run. After this call Home() returns "" regardless of env/config/
+// legacy values, so no on-disk artifact is written under the resolved
+// install dir. Used by main when the operator passes --install-dir=
+// (empty) to silence per-run file logging.
+func SetDisabled() {
+	cliDisabled = true
+	cliOverride = ""
 }
 
 // Home returns the resolved install dir. Falls back to LegacyHome when
-// nothing else is set. Empty string is possible only when the home
-// directory itself cannot be resolved. A leading $HOME or ~ token in
-// any source is expanded via expandHome so the returned path is
-// canonical for the current OS, keeping the migration warning in main
-// from misfiring on hand-edited values like "$HOME/.stepsecurity" that
-// resolve to the legacy default.
-//
-// Note: this is a superset of resolveSearchDirs in internal/scan/scanner.go,
-// which only expands the exact literal "$HOME" — the install dir comes
-// from operator-edited config so it has to tolerate the "$HOME/foo" /
-// "~/foo" forms our docs use; search_dirs come from --search-dirs flag
-// values that operators don't combine with subpaths.
+// nothing else is set. Returns "" when SetDisabled() was called or
+// when the home directory itself cannot be resolved. A leading $HOME
+// or ~ token in any source is expanded via expandHome so the returned
+// path is canonical for the current OS; the result is run through
+// filepath.Clean so trailing slashes and "." / ".." components don't
+// cause spurious mismatches in the migration-warning equality check.
 func Home() string {
-	if cliOverride != "" {
-		return expandHome(cliOverride)
+	if cliDisabled {
+		return ""
 	}
-	if v := os.Getenv(HomeEnvVar); v != "" {
-		return expandHome(v)
+	var raw string
+	switch {
+	case cliOverride != "":
+		raw = cliOverride
+	case config.InstallDir != "":
+		raw = config.InstallDir
+	case os.Getenv(HomeEnvVar) != "":
+		raw = os.Getenv(HomeEnvVar)
+	default:
+		return LegacyHome()
 	}
-	if config.InstallDir != "" {
-		return expandHome(config.InstallDir)
+	resolved := expandHome(raw)
+	if resolved == "" {
+		return ""
 	}
-	return LegacyHome()
+	return filepath.Clean(resolved)
 }
 
 // expandHome replaces a leading $HOME or ~ token with the resolved

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -11,12 +11,32 @@ import (
 
 // withOverride temporarily replaces the CLI override and restores it on
 // cleanup. The override is package-level mutable state, so tests serialise
-// through this helper.
+// through this helper. Also clears cliDisabled so a previous-test value
+// can't leak through.
 func withOverride(t *testing.T, v string) {
 	t.Helper()
-	prev := cliOverride
+	prevOverride := cliOverride
+	prevDisabled := cliDisabled
 	cliOverride = v
-	t.Cleanup(func() { cliOverride = prev })
+	cliDisabled = false
+	t.Cleanup(func() {
+		cliOverride = prevOverride
+		cliDisabled = prevDisabled
+	})
+}
+
+// withDisabled sets the package-level disable flag for the test and
+// restores it (plus cliOverride) on cleanup.
+func withDisabled(t *testing.T) {
+	t.Helper()
+	prevOverride := cliOverride
+	prevDisabled := cliDisabled
+	cliOverride = ""
+	cliDisabled = true
+	t.Cleanup(func() {
+		cliOverride = prevOverride
+		cliDisabled = prevDisabled
+	})
 }
 
 func withEnv(t *testing.T, key, value string) {
@@ -67,23 +87,40 @@ func TestHome_ConfigOverridesLegacy(t *testing.T) {
 	}
 }
 
-func TestHome_EnvVarOverridesConfig(t *testing.T) {
+// TestHome_ConfigOverridesEnv encodes the precedence flip that makes
+// config.InstallDir authoritative: the loader scripts write to config,
+// so editing config must immediately take effect even when a stale
+// $STEPSECURITY_HOME was baked into a unit file at install time.
+func TestHome_ConfigOverridesEnv(t *testing.T) {
 	withOverride(t, "")
-	withConfigInstallDir(t, "/from/config")
 	withEnv(t, HomeEnvVar, "/from/env")
+	withConfigInstallDir(t, "/from/config")
 
-	if got := Home(); got != "/from/env" {
-		t.Errorf("Home() = %q, want /from/env (env > config)", got)
+	if got := Home(); got != "/from/config" {
+		t.Errorf("Home() = %q, want /from/config (config > env)", got)
 	}
 }
 
-func TestHome_CLIOverridesEnv(t *testing.T) {
+// TestHome_EnvFallsThroughWhenConfigUnset confirms env is still
+// consulted when config is empty — it remains a defensive fallback,
+// just at lower precedence than config.
+func TestHome_EnvFallsThroughWhenConfigUnset(t *testing.T) {
+	withOverride(t, "")
+	withConfigInstallDir(t, "")
+	withEnv(t, HomeEnvVar, "/from/env")
+
+	if got := Home(); got != "/from/env" {
+		t.Errorf("Home() = %q, want /from/env (env fallback when config unset)", got)
+	}
+}
+
+func TestHome_CLIOverridesEverything(t *testing.T) {
 	withConfigInstallDir(t, "/from/config")
 	withEnv(t, HomeEnvVar, "/from/env")
 	withOverride(t, "/from/cli")
 
 	if got := Home(); got != "/from/cli" {
-		t.Errorf("Home() = %q, want /from/cli (cli > env > config)", got)
+		t.Errorf("Home() = %q, want /from/cli (cli > config > env)", got)
 	}
 }
 
@@ -153,5 +190,59 @@ func TestSetOverride_Sticks(t *testing.T) {
 
 	if got := Home(); got != "/sticky" {
 		t.Errorf("Home() = %q, want /sticky", got)
+	}
+}
+
+// TestSetDisabled_ReturnsEmpty proves that --install-dir= (empty)
+// makes Home() return "" globally — every downstream consumer
+// (filelog, ai-agent hook errors, future files) uniformly skips,
+// not just file logging.
+func TestSetDisabled_ReturnsEmpty(t *testing.T) {
+	withDisabled(t)
+	withEnv(t, HomeEnvVar, "/from/env")
+	withConfigInstallDir(t, "/from/config")
+
+	if got := Home(); got != "" {
+		t.Errorf("Home() = %q, want \"\" (SetDisabled must override every source)", got)
+	}
+}
+
+// TestSetOverride_ClearsDisabled covers the case where a later
+// SetOverride call must un-stick a prior SetDisabled — otherwise tests
+// that exercise both flows in sequence would carry the disable through.
+func TestSetOverride_ClearsDisabled(t *testing.T) {
+	withDisabled(t)
+	SetOverride("/back/on")
+	t.Cleanup(func() { SetOverride("") })
+
+	if got := Home(); got != "/back/on" {
+		t.Errorf("Home() = %q, want /back/on (SetOverride should clear cliDisabled)", got)
+	}
+}
+
+// TestHome_TrailingSlashCanonicalised ensures filepath.Clean normalises
+// the resolved path so the migration warning's equality check (Home()
+// vs LegacyHome()) does not misfire on "/foo/.stepsecurity/" vs
+// "/foo/.stepsecurity".
+func TestHome_TrailingSlashCanonicalised(t *testing.T) {
+	withOverride(t, "")
+	withEnv(t, HomeEnvVar, "")
+	withConfigInstallDir(t, "/opt/stepsecurity/")
+
+	if got := Home(); got != "/opt/stepsecurity" {
+		t.Errorf("Home() = %q, want /opt/stepsecurity (trailing slash must be stripped)", got)
+	}
+}
+
+// TestHome_DotComponentsCanonicalised covers filepath.Clean of internal
+// "./" and "../" tokens — same goal as the trailing-slash case, just a
+// different form of non-canonical input.
+func TestHome_DotComponentsCanonicalised(t *testing.T) {
+	withOverride(t, "")
+	withEnv(t, HomeEnvVar, "")
+	withConfigInstallDir(t, "/opt/./stepsecurity/../sec")
+
+	if got := Home(); got != "/opt/sec" {
+		t.Errorf("Home() = %q, want /opt/sec (Clean must collapse . and ..)", got)
 	}
 }

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -220,16 +220,25 @@ func systemdEscape(path string) string {
 // systemdEnvEscape escapes a value for inclusion inside a double-quoted
 // Environment="VAR=value" assignment. systemd treats the quoted span
 // as a single token but still honours backslash escaping inside it —
-// any literal " or \ in the value must be escaped or the unit file
-// silently parses to garbage (systemd-analyze verify catches it; a
-// daemon-reload of a broken unit does not). Per systemd.exec(5) the
-// shell-style escapes are \", \\, \n, \r, \t. Filesystem paths contain
-// none of these on the happy path, but operators with creative path
-// choices (or attackers who can write to config.json) shouldn't be
-// able to break the unit file.
+// any literal control character or quote in the value must be escaped
+// or the unit file silently parses to garbage (systemd-analyze verify
+// catches it; a daemon-reload of a broken unit does not). Per
+// systemd.exec(5) the shell-style escapes inside the quoted form are
+// \", \\, \n, \r, \t — a raw newline in particular would terminate
+// the directive and let any trailing content land as a new top-level
+// unit-file line. Filesystem paths contain none of these on the happy
+// path, but config.json values are operator-editable (and an attacker
+// with write access there shouldn't be able to inject a new directive
+// into the generated unit).
+//
+// Order matters: replace `\` first so the backslashes we introduce for
+// the other escapes don't get double-escaped.
 func systemdEnvEscape(value string) string {
 	value = strings.ReplaceAll(value, `\`, `\\`)
 	value = strings.ReplaceAll(value, `"`, `\"`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	value = strings.ReplaceAll(value, "\r", `\r`)
+	value = strings.ReplaceAll(value, "\t", `\t`)
 	return value
 }
 

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -31,8 +31,19 @@ func TimerUnitPath() string {
 
 // Install configures a systemd user timer for periodic scanning.
 // If already installed, upgrades by removing and re-creating the units.
+//
+// Only `--user` units are supported. Root install would need a system
+// unit at /etc/systemd/system/, which has different lifecycle and
+// privilege requirements (the timer fires as root, the scanner expects
+// per-user search dirs and HOME). Reject early with a clear message
+// instead of failing opaquely on `systemctl --user` calls that root
+// has no session for.
 func Install(exec executor.Executor, log *progress.Logger) error {
 	ctx := context.Background()
+
+	if exec.IsRoot() {
+		return fmt.Errorf("systemd install as root is not supported — run as the target user (system-wide unit deployment will land in a future release)")
+	}
 
 	// Check for existing installation and upgrade
 	if isConfigured(ctx, exec) {
@@ -68,7 +79,7 @@ func Install(exec executor.Executor, log *progress.Logger) error {
 		BinaryPath:       systemdEscape(binaryPath),
 		LogDir:           systemdEscape(logDir),
 		Hours:            hours,
-		StepSecurityHome: logDir, // unescaped; systemd Environment= handles its own quoting
+		StepSecurityHome: systemdEnvEscape(logDir),
 	}
 
 	// Write service unit
@@ -204,6 +215,22 @@ type unitTemplateData struct {
 // Spaces must be escaped as \x20 in ExecStart and related directives.
 func systemdEscape(path string) string {
 	return strings.ReplaceAll(path, " ", `\x20`)
+}
+
+// systemdEnvEscape escapes a value for inclusion inside a double-quoted
+// Environment="VAR=value" assignment. systemd treats the quoted span
+// as a single token but still honours backslash escaping inside it —
+// any literal " or \ in the value must be escaped or the unit file
+// silently parses to garbage (systemd-analyze verify catches it; a
+// daemon-reload of a broken unit does not). Per systemd.exec(5) the
+// shell-style escapes are \", \\, \n, \r, \t. Filesystem paths contain
+// none of these on the happy path, but operators with creative path
+// choices (or attackers who can write to config.json) shouldn't be
+// able to break the unit file.
+func systemdEnvEscape(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
 }
 
 // Environment="VAR=value" with the value-bearing form quoted so paths

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -37,3 +37,32 @@ func TestStartTimer_PropagatesFailure(t *testing.T) {
 		t.Errorf("error should reference the exit code: %v", err)
 	}
 }
+
+// TestSystemdEnvEscape covers every escape the helper claims to handle.
+// A raw newline is the load-bearing case: without escaping it would
+// terminate the Environment= directive mid-value and let trailing
+// content parse as a new top-level unit-file line.
+func TestSystemdEnvEscape(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain path no-op", "/opt/stepsecurity", "/opt/stepsecurity"},
+		{"backslash doubled", `C:\Step\Security`, `C:\\Step\\Security`},
+		{"double quote escaped", `/opt/"weird"/dir`, `/opt/\"weird\"/dir`},
+		{"newline escaped", "/opt/a\nINJECTED=1", `/opt/a\nINJECTED=1`},
+		{"carriage return escaped", "/opt/a\rb", `/opt/a\rb`},
+		{"tab escaped", "/opt/a\tb", `/opt/a\tb`},
+		// Order matters: the backslash-first pass means \n in input
+		// (literal two-char sequence) becomes \\n, not \n.
+		{"literal backslash-n stays literal", `/opt/a\nb`, `/opt/a\\nb`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := systemdEnvEscape(tc.in); got != tc.want {
+				t.Errorf("systemdEnvEscape(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
