### PR TITLE
chore(mdm): always-skip TCC by default + add PPPC config guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 - [Scan Coverage](SCAN_COVERAGE.md) — full catalog of detections
 - [Release Process](docs/release-process.md) — how releases are signed and verified
 - [Deploying via SCCM](docs/deploying-via-sccm.md) — Windows fleet rollout via Microsoft Configuration Manager (signed MSI, no PowerShell)
+- [macOS TCC Permissions](docs/macos-tcc-permissions.md) — how the agent handles Documents/Downloads/Mail TCC dirs, PPPC profile for MDM-pushed Full Disk Access, and the `include_tcc_protected` config field
 - [Versioning](VERSIONING.md) — why the version starts at 1.8.1
 - [Security Policy](SECURITY.md) — reporting vulnerabilities
 - [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/docs/macos-tcc-permissions.md
+++ b/docs/macos-tcc-permissions.md
@@ -40,18 +40,26 @@ modern macOS (anchored at the logged-in user's `$HOME`):
 ~/Movies                   ~/Library/Reminders
 ~/Music                    ~/Library/HomeKit
 ~/Public                   ~/Library/Suggestions
-~/.Trash                   ~/Library/Application Support/AddressBook
-~/Library/Mobile Documents ~/Library/Application Support/CallHistoryDB
-~/Library/CloudStorage     ~/Library/Application Support/CallHistoryTransactions
-                           ~/Library/IdentityServices
-                           ~/Library/Metadata/CoreSpotlight
-                           ~/Library/PersonalizationPortrait
-                           ~/Library/Containers/com.apple.mail
-                           ~/Library/Group Containers/group.com.apple.calendar
-                           ~/Library/Group Containers/group.com.apple.notes
+~/.Trash                   ~/Library/IdentityServices
+~/Library/Mobile Documents ~/Library/Metadata/CoreSpotlight
+~/Library/CloudStorage     ~/Library/PersonalizationPortrait
+~/Library/Containers       ~/Library/Application Support/AddressBook
+~/Library/Group Containers ~/Library/Application Support/CallHistoryDB
+~/Library/Application      ~/Library/Application Support/CallHistoryTransactions
+  Scripts                  ~/Library/Application Support/com.apple.TCC
 
 /Volumes/.timemachine*     (Time Machine local snapshots, prefix match)
 ```
+
+The two parent skips that look broad (`~/Library/Containers` and
+`~/Library/Group Containers`) collapse per-app sandbox containers in
+one go. Apple gates many of those subtrees behind separate TCC
+services on modern macOS — Photos for `com.apple.Photos`, Media
+Library for `com.apple.Music`, and the Sonoma "App Management" /
+"Data from other apps" prompt for arbitrary `<app>/Data` subdirs. The
+contents (per-app sandbox state) aren't meaningful inventory data for
+the agent's purpose, so the broader skip avoids three distinct popup
+categories without losing useful coverage.
 
 If a search dir is explicitly named (`--search-dirs ~/Documents`) the
 walk root itself is honored — the skip only applies to TCC paths

--- a/docs/macos-tcc-permissions.md
+++ b/docs/macos-tcc-permissions.md
@@ -1,0 +1,296 @@
+# macOS TCC Permissions
+
+This guide covers how Dev Machine Guard handles macOS **Transparency,
+Consent, and Control** (TCC) — Apple's per-app permission system that
+gates access to user data folders (`~/Documents`, `~/Downloads`,
+`~/Desktop`, `~/Pictures`, Mail/Messages/Safari libraries, iCloud
+Drive, removable volumes, etc.) — and what to configure on a fleet
+deployment to scan those folders without prompting users.
+
+## Default behavior — skip everything TCC-protected
+
+The agent ships with **safe defaults**: every scan (`send-telemetry`
+from launchd and direct CLI runs alike) **skips** the well-known
+macOS TCC-protected directories. Two effects:
+
+- The agent **never triggers a TCC permission popup**. End users see no
+  "stepsecurity-dev-machine-guard would like to access files in your
+  Documents folder" dialog.
+- Anything that lives under a TCC-protected path (a Node.js project in
+  `~/Documents/code`, a venv under `~/Desktop/scratch`, an `.npmrc` in
+  `~/Downloads`) is **not scanned**.
+
+For most fleets this is the right trade-off — developer code typically
+lives under `~/code`, `~/src`, `~/work`, etc., not in `~/Documents`.
+Customers who **do** want full coverage should grant the agent Full
+Disk Access via an MDM-pushed PPPC profile (recommended) or via System
+Settings on each machine, then flip the `include_tcc_protected` config
+to `true`.
+
+### What gets skipped
+
+The skip list is hard-coded against the well-known TCC categories on
+modern macOS (anchored at the logged-in user's `$HOME`):
+
+```
+~/Desktop                  ~/Library/Mail
+~/Documents                ~/Library/Messages
+~/Downloads                ~/Library/Safari
+~/Pictures                 ~/Library/Calendars
+~/Movies                   ~/Library/Reminders
+~/Music                    ~/Library/HomeKit
+~/Public                   ~/Library/Suggestions
+~/.Trash                   ~/Library/Application Support/AddressBook
+~/Library/Mobile Documents ~/Library/Application Support/CallHistoryDB
+~/Library/CloudStorage     ~/Library/Application Support/CallHistoryTransactions
+                           ~/Library/IdentityServices
+                           ~/Library/Metadata/CoreSpotlight
+                           ~/Library/PersonalizationPortrait
+                           ~/Library/Containers/com.apple.mail
+                           ~/Library/Group Containers/group.com.apple.calendar
+                           ~/Library/Group Containers/group.com.apple.notes
+
+/Volumes/.timemachine*     (Time Machine local snapshots, prefix match)
+```
+
+If a search dir is explicitly named (`--search-dirs ~/Documents`) the
+walk root itself is honored — the skip only applies to TCC paths
+encountered as descendants of the walked root.
+
+## Toggling the behavior
+
+Three places can set the toggle. CLI flag wins over persistent config
+wins over the default.
+
+### CLI flag (single run)
+
+```bash
+# Default — TCC paths skipped, no popups
+stepsecurity-dev-machine-guard --pretty --enable-npm-scan
+
+# Opt in to scanning TCC paths for this run
+stepsecurity-dev-machine-guard --pretty --enable-npm-scan --include-tcc-protected
+
+# Explicit skip (even if config says otherwise)
+stepsecurity-dev-machine-guard --pretty --enable-npm-scan --no-include-tcc-protected
+```
+
+### Persistent config (`~/.stepsecurity/config.json`)
+
+```json
+{
+  "customer_id": "your-customer-id",
+  "api_endpoint": "https://api.stepsecurity.io",
+  "api_key": "step_…",
+  "scan_frequency_hours": "4",
+  "include_tcc_protected": true
+}
+```
+
+The agent reads this on every run. On an MDM-deployed fleet the loader
+script writes `config.json` on every periodic tick (see the
+`agent-api/scripts/macos-device-agent/stepsecurity-loader.sh` template),
+so to roll out `include_tcc_protected` across a fleet you'd update the
+loader template you serve to customers (or have admins write the field
+directly on each box).
+
+## Granting the agent Full Disk Access (so it can actually scan TCC paths)
+
+Setting `include_tcc_protected: true` only tells the agent **not to
+self-censor**. macOS still enforces TCC: without a grant, reads in
+protected dirs will silently fail with `EACCES`. For the agent to
+actually see the contents, it needs Full Disk Access (FDA).
+
+Two paths to grant FDA:
+
+### Option A — MDM-pushed PPPC profile (recommended for fleets)
+
+Apple's **Privacy Preferences Policy Control (PPPC)** payload lets MDM
+admins pre-approve specific binaries for specific TCC services. The
+end user sees nothing; the grant is in place the moment the device
+checks in with the MDM.
+
+This is the only way to grant FDA at scale without per-user clicks.
+
+#### Inputs you need
+
+- The agent's **bundle/binary identifier**: the loader installs the
+  binary at `~/.stepsecurity/bin/stepsecurity-dev-machine-guard`. PPPC
+  uses the binary path as the identifier when the binary is unsigned
+  CLI; for signed binaries (which Dev Machine Guard releases are) PPPC
+  uses the **code requirement** string derived from the signature.
+- The **code requirement** string. Generate it with:
+
+  ```bash
+  codesign -d -r- /path/to/stepsecurity-dev-machine-guard 2>&1 | sed -n 's/^designated => //p'
+  ```
+
+  You'll get a line like:
+
+  ```
+  identifier "stepsecurity-dev-machine-guard" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "<TEAM_ID>"
+  ```
+
+#### PPPC profile XML
+
+Most MDMs (Jamf Pro, Kandji, Intune for macOS, JumpCloud, Mosyle,
+SimpleMDM, …) accept a `.mobileconfig` profile or a JSON equivalent
+they convert. The relevant payload type is
+`com.apple.TCC.configuration-profile-policy`. A minimal profile
+granting **SystemPolicyAllFiles** (Full Disk Access) to the agent:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+    <key>PayloadIdentifier</key>
+    <string>io.stepsecurity.dmg.tcc</string>
+    <key>PayloadUUID</key>
+    <string>REPLACE-WITH-UUIDGEN-OUTPUT</string>
+    <key>PayloadDisplayName</key>
+    <string>StepSecurity Dev Machine Guard — Full Disk Access</string>
+    <key>PayloadScope</key>
+    <string>System</string>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadType</key>
+            <string>com.apple.TCC.configuration-profile-policy</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>PayloadIdentifier</key>
+            <string>io.stepsecurity.dmg.tcc.pppc</string>
+            <key>PayloadUUID</key>
+            <string>REPLACE-WITH-UUIDGEN-OUTPUT</string>
+            <key>Services</key>
+            <dict>
+                <key>SystemPolicyAllFiles</key>
+                <array>
+                    <dict>
+                        <key>Identifier</key>
+                        <string>stepsecurity-dev-machine-guard</string>
+                        <key>IdentifierType</key>
+                        <string>path</string>
+                        <key>CodeRequirement</key>
+                        <string>identifier "stepsecurity-dev-machine-guard" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "REPLACE_TEAM_ID"</string>
+                        <key>Allowed</key>
+                        <true/>
+                        <key>Comment</key>
+                        <string>Allow Dev Machine Guard to scan all files for dev-tool inventory and supply-chain checks.</string>
+                    </dict>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>
+```
+
+Replace:
+- Both `REPLACE-WITH-UUIDGEN-OUTPUT` values with fresh UUIDs
+  (`uuidgen` on macOS).
+- `REPLACE_TEAM_ID` with the Apple Developer Team ID embedded in
+  the binary's code requirement (the trailing `subject.OU` field
+  from the `codesign -d -r-` output above).
+- The `Identifier` value with the binary's full install path if
+  your MDM requires `IdentifierType=path` to be absolute
+  (typically `/Users/<user>/.stepsecurity/bin/stepsecurity-dev-machine-guard`
+  or wherever your loader installs it).
+
+#### Push the profile
+
+| MDM | Path |
+|---|---|
+| **Jamf Pro** | Computers → Configuration Profiles → New → Upload → select the `.mobileconfig` file. Scope to a Smart Group containing developer machines. |
+| **Kandji** | Library → Add new → Custom Profile → upload `.mobileconfig`. Assign the Blueprint that targets developer devices. |
+| **Intune (Microsoft)** | Devices → Configuration → Create → macOS → Templates → Custom → upload the `.mobileconfig`. Assign to a device group. |
+| **Mosyle** | Management → Profiles → Add → Custom → upload `.mobileconfig`. |
+| **JumpCloud** | MDM → Policies → Custom Mac Profile → upload. |
+
+The profile takes effect on the next MDM check-in (usually within
+minutes). Verify with:
+
+```bash
+# On a managed Mac:
+profiles list -all | grep -i stepsecurity
+# Or open System Settings → Privacy & Security → Full Disk Access
+# and confirm "stepsecurity-dev-machine-guard" is listed and toggled on.
+```
+
+### Option B — Manual grant per machine
+
+For dev-only or single-machine testing, grant FDA manually:
+
+1. System Settings → Privacy & Security → Full Disk Access.
+2. Click `+`, navigate to
+   `~/.stepsecurity/bin/stepsecurity-dev-machine-guard` (use
+   <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>.</kbd> in the file picker to
+   show the `.stepsecurity` dotfolder).
+3. Toggle the entry on.
+
+The grant is tied to the binary's code signature. If you upgrade the
+binary (the loader's auto-update runs on every periodic tick) the
+existing grant carries over as long as the signing identity is
+unchanged — Dev Machine Guard releases are signed by the same Apple
+Developer Team for the life of each major version, so manual grants
+survive upgrades within that line.
+
+## Putting it together — the full rollout
+
+A fleet rollout that scans TCC paths typically looks like:
+
+1. Customer's MDM deploys the loader script (downloaded from the
+   StepSecurity dashboard for that customer).
+2. Customer's MDM **also** deploys the PPPC profile (Option A above)
+   granting the agent Full Disk Access.
+3. The loader's generated `config.json` includes
+   `"include_tcc_protected": true`. Either:
+   - Customer edits the loader script's `write_config()` heredoc to
+     emit the field before deploying via MDM, **or**
+   - Customer pushes a config file alongside the loader (drop into
+     `~/.stepsecurity/config.json` via the MDM's file-deploy
+     mechanism).
+
+After the next periodic fire, the agent runs with full coverage and no
+popups.
+
+## What if I see a popup anyway?
+
+If a popup appears after deploying the PPPC profile and setting
+`include_tcc_protected: true`, the typical causes:
+
+- **Code requirement mismatch.** The PPPC profile's `CodeRequirement`
+  string must match the binary's actual signing. Re-run `codesign -d
+  -r-` against the deployed binary and update the profile.
+- **Binary path mismatch.** If `IdentifierType=path` is used, the
+  `Identifier` must match the absolute path of the binary on disk.
+  Different per-user install dirs can require deploying the profile
+  with a wildcard-friendly identifier (use the code requirement
+  alone, with `IdentifierType=bundleID`-style matching, or push the
+  profile per user).
+- **TCC.db cache.** TCC caches decisions; after changing a profile,
+  reset the relevant service:
+
+  ```bash
+  sudo tccutil reset SystemPolicyAllFiles
+  ```
+
+  This forces re-evaluation against the latest profile on the next
+  access. The agent does not call `tccutil` on its own; this is a
+  diagnostic step only.
+- **`include_tcc_protected` not actually set.** Verify with
+  `cat ~/.stepsecurity/config.json` and re-run the loader's
+  `write_config` step if the field is missing.
+
+## Related
+
+- `internal/tcc/tcc.go` — the skip-list source of truth.
+- `agent-api/scripts/macos-device-agent/stepsecurity-loader.sh` —
+  the customer-side loader that writes `config.json` on each tick.
+- [Apple developer docs on PPPC payload](https://developer.apple.com/documentation/devicemanagement/privacypreferencespolicycontrol)
+  — the full schema for the `com.apple.TCC.configuration-profile-policy` payload.

--- a/docs/macos-tcc-permissions.md
+++ b/docs/macos-tcc-permissions.md
@@ -87,12 +87,14 @@ stepsecurity-dev-machine-guard --pretty --enable-npm-scan --no-include-tcc-prote
 }
 ```
 
-The agent reads this on every run. On an MDM-deployed fleet the loader
-script writes `config.json` on every periodic tick (see the
-`agent-api/scripts/macos-device-agent/stepsecurity-loader.sh` template),
-so to roll out `include_tcc_protected` across a fleet you'd update the
-loader template you serve to customers (or have admins write the field
-directly on each box).
+The agent reads this on every run. On an MDM-deployed fleet the
+StepSecurity loader script (the `.sh` file the dashboard generates for
+each customer) writes `config.json` on every periodic tick, so to roll
+out `include_tcc_protected` across a fleet either edit the loader
+script's `write_config()` heredoc before deploying it via MDM, or have
+admins write the field into `~/.stepsecurity/config.json` directly on
+each box (e.g., via a Configuration Profile or `defaults`-style file
+deployment).
 
 ## Granting the agent Full Disk Access (so it can actually scan TCC paths)
 
@@ -114,12 +116,23 @@ This is the only way to grant FDA at scale without per-user clicks.
 
 #### Inputs you need
 
-- The agent's **bundle/binary identifier**: the loader installs the
-  binary at `~/.stepsecurity/bin/stepsecurity-dev-machine-guard`. PPPC
-  uses the binary path as the identifier when the binary is unsigned
-  CLI; for signed binaries (which Dev Machine Guard releases are) PPPC
-  uses the **code requirement** string derived from the signature.
-- The **code requirement** string. Generate it with:
+- **The install path of the binary.** The loader installs at
+  `~/.stepsecurity/bin/stepsecurity-dev-machine-guard` — that's
+  per-user (`/Users/<username>/.stepsecurity/bin/...`). PPPC's
+  `Identifier` field always takes an absolute filesystem path when
+  `IdentifierType` is `path` (it has no `$HOME`/variable expansion),
+  so you either:
+  - scope a per-user profile that substitutes each user's home path,
+    using your MDM's per-user variables (Jamf's `$HOME`-substituting
+    profile payload variables, Kandji's user-context blueprints,
+    Intune's per-user assignment, etc.), or
+  - have the operator install the binary at a fixed system-wide path
+    (for example `/usr/local/bin/stepsecurity-dev-machine-guard`) so
+    the same profile applies to every user on the device.
+
+- **The code requirement string** derived from the binary's signature.
+  PPPC pairs the install path with this requirement so an impostor
+  binary at the same path can't claim the grant. Generate it with:
 
   ```bash
   codesign -d -r- /path/to/stepsecurity-dev-machine-guard 2>&1 | sed -n 's/^designated => //p'
@@ -173,7 +186,7 @@ granting **SystemPolicyAllFiles** (Full Disk Access) to the agent:
                 <array>
                     <dict>
                         <key>Identifier</key>
-                        <string>stepsecurity-dev-machine-guard</string>
+                        <string>/Users/REPLACE_USERNAME/.stepsecurity/bin/stepsecurity-dev-machine-guard</string>
                         <key>IdentifierType</key>
                         <string>path</string>
                         <key>CodeRequirement</key>
@@ -194,13 +207,16 @@ granting **SystemPolicyAllFiles** (Full Disk Access) to the agent:
 Replace:
 - Both `REPLACE-WITH-UUIDGEN-OUTPUT` values with fresh UUIDs
   (`uuidgen` on macOS).
+- `REPLACE_USERNAME` with the target user's short username so the
+  `Identifier` resolves to the actual on-disk binary path. For
+  per-user MDM scoping, use your MDM's per-user variable instead of a
+  literal username (e.g., Jamf's `$USERNAME`, Kandji's user-context
+  variable). For a fixed system-wide install, replace the whole
+  `Identifier` value with the absolute path you chose
+  (e.g., `/usr/local/bin/stepsecurity-dev-machine-guard`).
 - `REPLACE_TEAM_ID` with the Apple Developer Team ID embedded in
   the binary's code requirement (the trailing `subject.OU` field
   from the `codesign -d -r-` output above).
-- The `Identifier` value with the binary's full install path if
-  your MDM requires `IdentifierType=path` to be absolute
-  (typically `/Users/<user>/.stepsecurity/bin/stepsecurity-dev-machine-guard`
-  or wherever your loader installs it).
 
 #### Push the profile
 
@@ -289,8 +305,11 @@ If a popup appears after deploying the PPPC profile and setting
 
 ## Related
 
-- `internal/tcc/tcc.go` — the skip-list source of truth.
-- `agent-api/scripts/macos-device-agent/stepsecurity-loader.sh` —
-  the customer-side loader that writes `config.json` on each tick.
+- `internal/tcc/tcc.go` — the skip-list source of truth in this repo.
+- The StepSecurity macOS loader script (the `.sh` your dashboard
+  generates for your customer ID) — writes `config.json` on each
+  periodic tick, so the `include_tcc_protected` flag travels with the
+  loader rollout. Source for this loader lives in the StepSecurity
+  agent-api backend, not in this repository.
 - [Apple developer docs on PPPC payload](https://developer.apple.com/documentation/devicemanagement/privacypreferencespolicycontrol)
   — the full schema for the `com.apple.TCC.configuration-profile-policy` payload.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -30,12 +30,12 @@ type Config struct {
 	EnableBrewScan        *bool  // nil=auto, true/false=explicit
 	EnablePythonScan      *bool  // nil=auto, true/false=explicit
 	IncludeBundledPlugins bool   // --include-bundled-plugins: include bundled/platform plugins in output
-	// IncludeTCCProtected is tristate: nil = use the runtime default
-	// (skip only when running under launchd, where TCC prompts actually
-	// fire), true = always include the protected dirs (skipper off),
-	// false = always exclude them (skipper on). Wired via
-	// --include-tcc-protected / --no-include-tcc-protected and the
-	// matching field in config.ConfigFile.
+	// IncludeTCCProtected is tristate: nil or false = skip the macOS
+	// TCC-protected dirs (Documents, Downloads, ~/Library/Mail, ...)
+	// so the agent never triggers permission prompts; true = scan them.
+	// Customers who have granted the agent Full Disk Access (e.g., via
+	// an MDM-pushed PPPC profile) flip this to true to opt back into
+	// full scan coverage. See docs/macos-tcc-permissions.md.
 	IncludeTCCProtected *bool
 	NPMRCOnly           bool     // --npmrc: run only the npmrc audit and render verbose pretty output
 	PipConfigOnly       bool     // --pipconfig: run only the pip config audit and render verbose pretty output
@@ -418,11 +418,12 @@ Options:
   --disable-python-scan         Disable Python package scanning
   --include-bundled-plugins     Include bundled/platform plugins in output (Windows)
   --include-tcc-protected       Scan macOS TCC-protected dirs (Documents, Downloads,
-                                ~/Library/Mail, etc.). Default: skipped only when
-                                running under launchd (where permission prompts
-                                fire); direct CLI runs scan them.
-  --no-include-tcc-protected    Force-skip macOS TCC-protected dirs even on direct
-                                CLI runs.
+                                ~/Library/Mail, etc.). Default: skipped to avoid
+                                permission prompts. Pass after granting the agent
+                                Full Disk Access via PPPC profile or System
+                                Settings — see docs/macos-tcc-permissions.md.
+  --no-include-tcc-protected    Skip macOS TCC-protected dirs even if config has
+                                include_tcc_protected: true.
   --npmrc                       Run ONLY the npm config audit (verbose pretty view; --json supported)
   --pipconfig                   Run ONLY the pip config audit (verbose pretty view; --json supported)
   --log-level=LEVEL      Log level: error | warn | info | debug (default: info)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ var (
 	EnableNPMScan       *bool  // nil=auto
 	EnableBrewScan      *bool  // nil=auto
 	EnablePythonScan    *bool  // nil=auto
-	IncludeTCCProtected *bool  // nil=auto (skip when running under macOS launchd, scan otherwise)
+	IncludeTCCProtected *bool  // nil or false = skip macOS TCC-protected dirs (default); true = scan them. Requires the agent to have Full Disk Access (PPPC or manual grant) for true to actually return results. See docs/macos-tcc-permissions.md.
 	ColorMode           string // "" means auto
 	OutputFormat        string // "" means default (pretty)
 	HTMLOutputFile      string // "" means not set

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ var (
 	EnableNPMScan       *bool  // nil=auto
 	EnableBrewScan      *bool  // nil=auto
 	EnablePythonScan    *bool  // nil=auto
-	IncludeTCCProtected *bool  // nil or false = skip macOS TCC-protected dirs (default); true = scan them. Requires the agent to have Full Disk Access (PPPC or manual grant) for true to actually return results. See docs/macos-tcc-permissions.md.
+	IncludeTCCProtected *bool  // nil or false = skip macOS TCC-protected dirs (default); true = walk them. The scan as a whole runs in both cases; only reads inside the TCC-protected subtrees themselves (Documents, Mail, etc.) need the agent to have Full Disk Access (PPPC or manual grant) — without that, those walks return EACCES per entry while the rest of the scan completes normally. See docs/macos-tcc-permissions.md.
 	ColorMode           string // "" means auto
 	OutputFormat        string // "" means default (pretty)
 	HTMLOutputFile      string // "" means not set

--- a/internal/tcc/tcc.go
+++ b/internal/tcc/tcc.go
@@ -7,45 +7,31 @@
 package tcc
 
 import (
-	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
 )
 
 // Enabled reports whether the TCC skipper should be active for this run.
-// The override is the resolved tri-state cfg/config value: nil to defer to
-// the runtime default, true to explicitly include TCC paths (don't skip),
-// false to explicitly exclude (always skip).
+// The override is the resolved tri-state cfg/config value: nil or false
+// to apply the default (skip TCC-protected dirs), true to include them
+// in the scan.
 //
-// The default (nil override) only skips when the process is running under
-// macOS launchd: that's the context in which TCC permission prompts
-// actually fire and there's nobody at a keyboard to dismiss them. Direct
-// CLI invocations typically inherit Terminal.app's TCC grants and don't
-// see prompts, so they default to full scan coverage.
+// Default behavior is to skip — both community (`scan`) and enterprise
+// (`send-telemetry`) runs avoid TCC-protected paths so the agent never
+// triggers permission prompts. Customers who have granted the agent
+// access (via a PPPC profile pushed by their MDM, or by manually
+// approving "Full Disk Access" in System Settings) flip the bool to
+// `true` to opt those paths back into the scan. See
+// docs/macos-tcc-permissions.md for the configuration recipe.
 func Enabled(override *bool) bool {
-	if override != nil {
-		// Override semantics: true = "include TCC paths" = skipper OFF.
-		return !*override
-	}
-	return IsRunningUnderLaunchd()
-}
-
-// IsRunningUnderLaunchd reports whether the process appears to be running
-// as a macOS launchd-managed daemon or agent. Detection signals (in
-// order): an explicit STEPSEC_VIA_LAUNCHD=1 env var (escape hatch for
-// tests and forward-compat plist changes), then PPID==1 on darwin
-// (launchd is PID 1 and reparents its jobs). Returns false off darwin.
-func IsRunningUnderLaunchd() bool {
-	if os.Getenv("STEPSEC_VIA_LAUNCHD") == "1" {
-		return true
-	}
-	if runtime.GOOS != "darwin" {
+	if override != nil && *override {
+		// Explicit include: skipper OFF.
 		return false
 	}
-	return os.Getppid() == 1
+	// Default and explicit exclude both leave the skipper ON.
+	return true
 }
 
 // Skipper matches TCC-protected directories. Build one per scan via New;

--- a/internal/tcc/tcc_darwin.go
+++ b/internal/tcc/tcc_darwin.go
@@ -31,12 +31,20 @@ var protectedSuffixes = []string{
 	"Library/Application Support/AddressBook",
 	"Library/Application Support/CallHistoryDB",
 	"Library/Application Support/CallHistoryTransactions",
+	"Library/Application Support/com.apple.TCC",
 	"Library/IdentityServices",
 	"Library/Metadata/CoreSpotlight",
 	"Library/PersonalizationPortrait",
-	"Library/Containers/com.apple.mail",
-	"Library/Group Containers/group.com.apple.calendar",
-	"Library/Group Containers/group.com.apple.notes",
+
+	// App sandbox containers — skipped wholesale because any descent into
+	// these triggers per-service prompts (Photos for com.apple.Photos,
+	// Media Library for com.apple.Music, the macOS Sonoma "App Management"
+	// / "Data from other apps" prompt for arbitrary <app>/Data subdirs).
+	// Nothing inside an app's sandbox is meaningful inventory data for
+	// dev-machine-guard's purpose, so the broader skip is a clean win.
+	"Library/Containers",
+	"Library/Group Containers",
+	"Library/Application Scripts",
 
 	"Library/Mobile Documents",
 	"Library/CloudStorage",

--- a/internal/tcc/tcc_darwin_test.go
+++ b/internal/tcc/tcc_darwin_test.go
@@ -67,8 +67,6 @@ func TestSkipper_EmptyHome(t *testing.T) {
 }
 
 func TestEnabled(t *testing.T) {
-	t.Setenv("STEPSEC_VIA_LAUNCHD", "1") // force launchd-context for the nil-override branch
-
 	trueVal := true
 	falseVal := false
 
@@ -77,7 +75,7 @@ func TestEnabled(t *testing.T) {
 		override *bool
 		want     bool
 	}{
-		{"nil override under launchd → skipper on", nil, true},
+		{"nil override → skipper on (default skip)", nil, true},
 		{"explicit include (true) → skipper off", &trueVal, false},
 		{"explicit exclude (false) → skipper on", &falseVal, true},
 	}
@@ -87,14 +85,6 @@ func TestEnabled(t *testing.T) {
 				t.Errorf("Enabled(%v) = %v, want %v", tc.override, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestEnabled_DirectInvocationDefault(t *testing.T) {
-	t.Setenv("STEPSEC_VIA_LAUNCHD", "")
-	// On a test runner PPID is the go test process, not launchd, so IsRunningUnderLaunchd is false.
-	if Enabled(nil) {
-		t.Error("Enabled(nil) should be false when not running under launchd")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
