### PR TITLE
chore(mdm): skip ~/Library wholesale to fix Tahoe Media Library prompt

### DIFF
--- a/docs/macos-tcc-permissions.md
+++ b/docs/macos-tcc-permissions.md
@@ -33,33 +33,29 @@ The skip list is hard-coded against the well-known TCC categories on
 modern macOS (anchored at the logged-in user's `$HOME`):
 
 ```
-~/Desktop                  ~/Library/Mail
-~/Documents                ~/Library/Messages
-~/Downloads                ~/Library/Safari
-~/Pictures                 ~/Library/Calendars
-~/Movies                   ~/Library/Reminders
-~/Music                    ~/Library/HomeKit
-~/Public                   ~/Library/Suggestions
-~/.Trash                   ~/Library/IdentityServices
-~/Library/Mobile Documents ~/Library/Metadata/CoreSpotlight
-~/Library/CloudStorage     ~/Library/PersonalizationPortrait
-~/Library/Containers       ~/Library/Application Support/AddressBook
-~/Library/Group Containers ~/Library/Application Support/CallHistoryDB
-~/Library/Application      ~/Library/Application Support/CallHistoryTransactions
-  Scripts                  ~/Library/Application Support/com.apple.TCC
-
-/Volumes/.timemachine*     (Time Machine local snapshots, prefix match)
+~/Desktop                  ~/Library
+~/Documents                ~/.Trash
+~/Downloads
+~/Pictures                 /Volumes/.timemachine*  (Time Machine local
+~/Movies                                            snapshots, prefix match)
+~/Music
+~/Public
 ```
 
-The two parent skips that look broad (`~/Library/Containers` and
-`~/Library/Group Containers`) collapse per-app sandbox containers in
-one go. Apple gates many of those subtrees behind separate TCC
-services on modern macOS — Photos for `com.apple.Photos`, Media
-Library for `com.apple.Music`, and the Sonoma "App Management" /
-"Data from other apps" prompt for arbitrary `<app>/Data` subdirs. The
-contents (per-app sandbox state) aren't meaningful inventory data for
-the agent's purpose, so the broader skip avoids three distinct popup
-categories without losing useful coverage.
+`~/Library` is skipped wholesale rather than per-subpath. Every macOS
+release adds new Apple-managed subtrees behind new TCC services —
+Sonoma added "App Management" / "Data from other apps" for arbitrary
+`<app>/Data` containers, Sequoia hardened Photos / Media Library /
+Movies, Tahoe expanded Media Library to cover
+`~/Library/Application Support/com.apple.avfoundation/` — so a curated
+allowlist of `Library/X` entries goes stale on every upgrade and
+prompts start firing again at end users. `~/Library` is the wrong
+place for developer projects, lockfiles, or `.npmrc` files anyway. The
+detectors that DO need to read specific paths under `~/Library`
+(JetBrains plugins at `~/Library/Application Support/JetBrains/...`,
+Claude desktop MCP config, pip global config) use targeted
+`ReadDir`/`ReadFile` calls that don't consult the skipper, so they
+keep working unchanged.
 
 If a search dir is explicitly named (`--search-dirs ~/Documents`) the
 walk root itself is honored — the skip only applies to TCC paths

--- a/internal/tcc/tcc_darwin.go
+++ b/internal/tcc/tcc_darwin.go
@@ -9,8 +9,23 @@ import "path/filepath"
 //   - Files & Folders (Catalina+): Desktop, Documents, Downloads
 //   - Removable / Network (Catalina+): handled via opt-in search dirs
 //   - Photos / Music / Movies (Sequoia hardened): Pictures, Movies, Music
-//   - Full Disk Access subtrees: ~/Library/Mail, Messages, Safari, etc.
-//   - Cloud sync (Sonoma+): Mobile Documents, CloudStorage
+//   - Everything under ~/Library: Mail, Messages, Safari, Mobile Documents,
+//     CloudStorage, Containers, plus the long tail of Apple-private
+//     subtrees that gain new TCC services with each macOS release.
+//
+// ~/Library is skipped wholesale rather than per-subpath. Every macOS
+// release adds new Apple-managed subtrees behind new TCC services
+// (Sonoma's App Management, Sequoia's hardened Pictures/Music/Movies,
+// Tahoe's expanded Media Library scope into
+// ~/Library/Application Support/com.apple.avfoundation/, and so on),
+// so a curated allowlist of "Library/X" entries goes stale on every
+// upgrade — at which point a previously-silent walk into one of those
+// subtrees starts firing a prompt at end users. ~/Library is the wrong
+// place for developer projects / lockfiles / npmrc files anyway; the
+// detectors that DO need to read specific paths under ~/Library
+// (JetBrains plugins, Claude desktop MCP config, pip global config)
+// use targeted ReadDir/ReadFile calls that don't consult this skipper,
+// so they're unaffected.
 var protectedSuffixes = []string{
 	"Desktop",
 	"Documents",
@@ -20,34 +35,7 @@ var protectedSuffixes = []string{
 	"Music",
 	"Public",
 	".Trash",
-
-	"Library/Mail",
-	"Library/Messages",
-	"Library/Safari",
-	"Library/Calendars",
-	"Library/Reminders",
-	"Library/HomeKit",
-	"Library/Suggestions",
-	"Library/Application Support/AddressBook",
-	"Library/Application Support/CallHistoryDB",
-	"Library/Application Support/CallHistoryTransactions",
-	"Library/Application Support/com.apple.TCC",
-	"Library/IdentityServices",
-	"Library/Metadata/CoreSpotlight",
-	"Library/PersonalizationPortrait",
-
-	// App sandbox containers — skipped wholesale because any descent into
-	// these triggers per-service prompts (Photos for com.apple.Photos,
-	// Media Library for com.apple.Music, the macOS Sonoma "App Management"
-	// / "Data from other apps" prompt for arbitrary <app>/Data subdirs).
-	// Nothing inside an app's sandbox is meaningful inventory data for
-	// dev-machine-guard's purpose, so the broader skip is a clean win.
-	"Library/Containers",
-	"Library/Group Containers",
-	"Library/Application Scripts",
-
-	"Library/Mobile Documents",
-	"Library/CloudStorage",
+	"Library",
 }
 
 // protectedAbsolutePrefixes are matched with strings.HasPrefix. Time

--- a/internal/tcc/tcc_darwin_test.go
+++ b/internal/tcc/tcc_darwin_test.go
@@ -18,8 +18,7 @@ func TestSkipper_ShouldSkip(t *testing.T) {
 		{"documents trailing slash", "/Users/alice/Documents/", "/Users/alice", true},
 		{"downloads skipped", "/Users/alice/Downloads", "/Users/alice", true},
 		{"desktop skipped", "/Users/alice/Desktop", "/Users/alice", true},
-		{"library mail skipped", "/Users/alice/Library/Mail", "/Users/alice", true},
-		{"icloud drive skipped", "/Users/alice/Library/Mobile Documents", "/Users/alice", true},
+		{"library root skipped", "/Users/alice/Library", "/Users/alice", true},
 		{"trash skipped", "/Users/alice/.Trash", "/Users/alice", true},
 		{"random code dir not skipped", "/Users/alice/code", "/Users/alice", false},
 		{"vscode dotdir not skipped", "/Users/alice/.vscode", "/Users/alice", false},
@@ -85,6 +84,20 @@ func TestEnabled(t *testing.T) {
 				t.Errorf("Enabled(%v) = %v, want %v", tc.override, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSkipper_RegressionAVFoundationMediaLibraryPrompt locks in the fix
+// for the macOS 26.x (Tahoe) "Apple Music, your music and video activity,
+// and your media library" prompt that fired when the project walker
+// descended into ~/Library/Application Support/com.apple.avfoundation/
+// looking for Python venvs / Node projects / .npmrc files. Without ~/Library
+// being skipped wholesale, the walker reaches that subtree and macOS pops
+// the kTCCServiceMediaLibrary prompt at the end user.
+func TestSkipper_RegressionAVFoundationMediaLibraryPrompt(t *testing.T) {
+	s := New("/Users/alice")
+	if !s.ShouldSkip("/Users/alice/Library", "/Users/alice") {
+		t.Fatal("~/Library must be skipped to prevent walker from descending into Apple-managed TCC subtrees (e.g. Library/Application Support/com.apple.avfoundation/ → kTCCServiceMediaLibrary)")
 	}
 }
 


### PR DESCRIPTION
Replace the curated list of ~/Library/X TCC subpaths with a single wholesale skip on ~/Library. On macOS 26.x (Tahoe) the project walker descends into ~/Library/Application Support/com.apple.avfoundation/ looking for venvs/projects/.npmrc files and fires the kTCCServiceMediaLibrary prompt ("Apple Music, your music and video activity, and your media library"). Each macOS release adds new Apple-managed subtrees behind new TCC services, so curating per-path entries goes stale and prompts start firing on user machines after every OS upgrade.

The detectors that read specific paths under ~/Library (JetBrains plugins, Claude desktop MCP config, pip global config) use targeted ReadDir/ReadFile calls that don't consult the skipper, so they keep working unchanged.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
