### PR TITLE
fix(config): normalize api_endpoint to strip trailing slashes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,7 +134,7 @@ func Load() {
 		CustomerID = cfg.CustomerID
 	}
 	if cfg.APIEndpoint != "" && isPlaceholder(APIEndpoint) {
-		APIEndpoint = cfg.APIEndpoint
+		APIEndpoint = NormalizeAPIEndpoint(cfg.APIEndpoint)
 	}
 	if cfg.APIKey != "" && isPlaceholder(APIKey) {
 		APIKey = cfg.APIKey
@@ -397,7 +397,18 @@ func loadExisting() *ConfigFile {
 	return &cfg
 }
 
+// NormalizeAPIEndpoint strips trailing slashes and surrounding whitespace
+// from an API endpoint URL. Every callsite in the agent composes URLs as
+// fmt.Sprintf("%s/v1/...", APIEndpoint, ...) — a trailing slash on the
+// configured value would compose to "//v1/..." and some gateways respond
+// with 403/500 instead of normalizing. Normalising once at the config
+// boundary keeps every consumer simple.
+func NormalizeAPIEndpoint(s string) string {
+	return strings.TrimRight(strings.TrimSpace(s), "/")
+}
+
 func save(cfg *ConfigFile) error {
+	cfg.APIEndpoint = NormalizeAPIEndpoint(cfg.APIEndpoint)
 	dir := writeConfigDir()
 
 	// File-mode bits below ARE meaningful on POSIX (per-user community installs

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,6 +29,27 @@ func TestIsEnterpriseMode_Valid(t *testing.T) {
 	}
 }
 
+func TestNormalizeAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"https://api.example.com", "https://api.example.com"},
+		{"https://api.example.com/", "https://api.example.com"},
+		{"https://api.example.com//", "https://api.example.com"},
+		{"  https://api.example.com/  ", "https://api.example.com"},
+		{"https://api.example.com/v1", "https://api.example.com/v1"},
+		{"https://api.example.com/v1/", "https://api.example.com/v1"},
+		{"", ""},
+		{"   ", ""},
+		{"/", ""},
+	}
+	for _, tt := range tests {
+		if got := NormalizeAPIEndpoint(tt.in); got != tt.want {
+			t.Errorf("NormalizeAPIEndpoint(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestIsPlaceholder(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
Every backend call composes URLs as fmt.Sprintf("%s/v1/...", APIEndpoint, ...). A user-supplied api_endpoint with a trailing slash would compose to "//v1/..." — some gateways tolerate it, others return 403/500. Customers hit this in production with a bootstrap.json that had a trailing slash in the URL; removing the slash made requests start returning 200.

Normalize once at the config boundary (Load() reads, save() writes) so:
- existing config.json files with a trailing slash are forgiven without re-running configure
- new configs written via inline flags or --from-file are sanitised before persistence
- every URL-building callsite in telemetry/run_status/aiagents stays as-is

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
