### PR TITLE
fix(windows): force first run as /ru interactive

### DIFF
--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/schtasks"
 	"github.com/step-security/dev-machine-guard/internal/systemd"
 	"github.com/step-security/dev-machine-guard/internal/telemetry"
+	"github.com/step-security/dev-machine-guard/internal/winproc"
 )
 
 // hookReconcileTimeout caps the entire reconcile step (fetch + cache
@@ -273,6 +274,24 @@ func main() {
 		// means scheduled runs fall back to the binary's built-in default.
 		if err := config.PersistMaxExecutionDuration(os.Getenv(telemetry.EnvMaxExecutionDuration)); err != nil {
 			log.Warn("failed to persist max execution duration to config (%v) — scheduled runs will use the built-in default", err)
+		}
+
+		// MSI deferred custom actions run as NT AUTHORITY\SYSTEM. A scan
+		// from that context sees SYSTEM's profile (no IDEs, no AI agents,
+		// no user dotfiles) and ships a near-empty payload as the first
+		// data point — the symptom customers reported as "first run is
+		// empty, subsequent runs are correct." Instead of scanning inline,
+		// ask the scheduler to fire the just-registered task, which is
+		// bound to /ru INTERACTIVE and runs under the logged-in user.
+		// If no one is logged in (unattended SCCM deploys), the trigger
+		// silently no-ops and the task fires on its next hourly tick;
+		// either way, no SYSTEM-context telemetry ever ships.
+		if runtime.GOOS == "windows" && winproc.IsLocalSystem() {
+			if err := schtasks.RunNow(exec, log); err != nil {
+				log.Warn("could not trigger initial scan (%v) — the scheduled task will fire on its next interval", err)
+			}
+			runHookStateReconcile(exec, log)
+			return
 		}
 
 		log.Progress("Sending initial telemetry...")

--- a/internal/schtasks/schtasks.go
+++ b/internal/schtasks/schtasks.go
@@ -104,6 +104,30 @@ func Install(exec executor.Executor, log *progress.Logger) error {
 	return nil
 }
 
+// RunNow asks Task Scheduler to fire the registered task immediately,
+// using its configured principal (/ru INTERACTIVE for admin installs).
+// Used by the install flow under LocalSystem to surface first-run
+// telemetry under the logged-in user rather than scanning SYSTEM's
+// empty profile inline.
+//
+// schtasks /run returns 0 once the scheduler has accepted the request;
+// it does not wait for the task to complete and does not report whether
+// an interactive session exists. If no user is logged in, the trigger
+// silently no-ops and the task fires on its next hourly tick.
+func RunNow(exec executor.Executor, log *progress.Logger) error {
+	ctx := context.Background()
+	_, stderr, exitCode, err := exec.Run(ctx, "schtasks", "/run", "/tn", taskName)
+	log.Debug("schtasks /run: exit_code=%d err=%v", exitCode, err)
+	if err != nil {
+		return fmt.Errorf("failed to trigger scheduled task: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("failed to trigger scheduled task (exit code %d): %s", exitCode, stderr)
+	}
+	log.Progress("Triggered initial scan under the logged-in user")
+	return nil
+}
+
 // Uninstall removes the scheduled task.
 func Uninstall(exec executor.Executor, log *progress.Logger) error {
 	ctx := context.Background()

--- a/internal/schtasks/schtasks_test.go
+++ b/internal/schtasks/schtasks_test.go
@@ -178,6 +178,30 @@ func TestResolveTaskBinary_NoLauncher(t *testing.T) {
 	}
 }
 
+func TestRunNow_Success(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetCommand("SUCCESS: Attempted to run the scheduled task.", "", 0, "schtasks", "/run", "/tn", taskName)
+
+	if err := RunNow(mock, newTestLogger()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestRunNow_NonZeroExit(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	mock.SetCommand("", "ERROR: The system cannot find the path specified.", 1, "schtasks", "/run", "/tn", taskName)
+
+	err := RunNow(mock, newTestLogger())
+	if err == nil {
+		t.Fatal("expected error when schtasks /run exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "exit code 1") {
+		t.Errorf("expected exit code in error, got %v", err)
+	}
+}
+
 // The task action must invoke the binary directly. A `cmd /c` wrapper
 // (the pre-fix form) spawns a console window every time Task Scheduler
 // fires the task under an interactive user session.

--- a/internal/winproc/winproc.go
+++ b/internal/winproc/winproc.go
@@ -10,3 +10,8 @@ import "os/exec"
 
 // HideWindow is a no-op on non-Windows platforms.
 func HideWindow(_ *exec.Cmd) {}
+
+// IsLocalSystem always returns false on non-Windows platforms. The
+// SYSTEM-context discrimination only matters for MSI deferred custom
+// actions, which are Windows-only.
+func IsLocalSystem() bool { return false }

--- a/internal/winproc/winproc_windows.go
+++ b/internal/winproc/winproc_windows.go
@@ -5,11 +5,19 @@ package winproc
 import (
 	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 // CREATE_NO_WINDOW. Spelled out so callers don't drag in
 // golang.org/x/sys/windows for one constant.
 const createNoWindow uint32 = 0x08000000
+
+// localSystemSID is the well-known SID for NT AUTHORITY\SYSTEM. Used to
+// distinguish MSI deferred custom actions (which run as LocalSystem) from
+// elevated admin invocations — the executor's IsRoot() returns true for
+// both, so we can't reuse it for this discrimination.
+const localSystemSID = "S-1-5-18"
 
 // HideWindow tells the child not to allocate a console. Safe to call
 // twice or on a cmd whose SysProcAttr is already set: HideWindow is
@@ -25,4 +33,15 @@ func HideWindow(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.HideWindow = true
 	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}
+
+// IsLocalSystem reports whether the current process is running as
+// NT AUTHORITY\SYSTEM. Returns false on any error — a misread SID
+// degrades to the inline-install path, which is the existing behavior.
+func IsLocalSystem() bool {
+	tu, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return false
+	}
+	return tu.User.Sid.String() == localSystemSID
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
