### PR TITLE
fix(windows): handle empty payloads when npm is not present

### DIFF
--- a/internal/detector/nodescan.go
+++ b/internal/detector/nodescan.go
@@ -42,11 +42,12 @@ type NodeScanner struct {
 	// PhaseTracker.UpdateDetail so heartbeats surface mid-phase progress.
 	ProgressHook func(detail string)
 	// pmAvailability caches checkPath results per package-manager binary
-	// for the lifetime of a single ScanProjects call. On a device with 700+
+	// for the lifetime of the NodeScanner instance. On a device with 700+
 	// lockfiles, the per-project scan path previously paid a PATH lookup
 	// per project; this cache collapses that to one lookup per distinct
-	// PM. Also avoided: spamming the same "x not found in PATH" warning
-	// hundreds of times when the PM truly isn't installed.
+	// PM. A scanner is created once per telemetry run (see
+	// internal/telemetry/telemetry.go), so the cache's effective scope
+	// matches a single scan even though the map isn't reset.
 	pmAvailability map[string]error
 }
 
@@ -61,7 +62,7 @@ func NewNodeScanner(exec executor.Executor, log *progress.Logger, loggedInUser s
 
 // binaryAvailable returns the cached checkPath result for a package-manager
 // binary, populating the cache on first call. Wraps checkPath so callers in
-// the per-project loop don't pay an LookPath per project on devices that
+// the per-project loop don't pay a LookPath per project on devices that
 // have hundreds of lockfiles for a PM that isn't installed.
 func (s *NodeScanner) binaryAvailable(ctx context.Context, name string) error {
 	if err, ok := s.pmAvailability[name]; ok {
@@ -430,7 +431,7 @@ func (s *NodeScanner) ScanProjects(ctx context.Context, searchDirs []string) []m
 		pm := DetectProjectPM(s.exec, p.dir)
 		s.log.Progress("    Package manager: %s", pm)
 
-		r, ok := s.scanProject(ctx, p.dir)
+		r, ok := s.scanProject(ctx, p.dir, pm)
 		if !ok {
 			// PM not installed on this device — not an error, just nothing
 			// to scan. Skip without emitting a telemetry record.
@@ -457,9 +458,13 @@ func (s *NodeScanner) ScanProjects(ctx context.Context, searchDirs []string) []m
 // the case when the PM binary isn't on PATH, which is a normal "Node not
 // installed on this device" state, not a scan failure. Mirrors the
 // (result, ok) shape of scanNPMGlobal / scanYarnGlobal / scanPnpmGlobal.
-func (s *NodeScanner) scanProject(ctx context.Context, projectDir string) (model.NodeScanResult, bool) {
-	pm := DetectProjectPM(s.exec, projectDir)
-
+//
+// pm is passed in by the caller (ScanProjects already detects it once for
+// the per-project progress log); we accept it as an argument rather than
+// re-running DetectProjectPM here to avoid duplicating the FileExists /
+// DirExists checks per project and to keep the detected value consistent
+// with what the caller logged.
+func (s *NodeScanner) scanProject(ctx context.Context, projectDir, pm string) (model.NodeScanResult, bool) {
 	var cmd string
 	var args []string
 	switch pm {

--- a/internal/detector/nodescan.go
+++ b/internal/detector/nodescan.go
@@ -41,10 +41,35 @@ type NodeScanner struct {
 	// 12 of 47", "scanning yarn", ...). Telemetry plumbs this into
 	// PhaseTracker.UpdateDetail so heartbeats surface mid-phase progress.
 	ProgressHook func(detail string)
+	// pmAvailability caches checkPath results per package-manager binary
+	// for the lifetime of a single ScanProjects call. On a device with 700+
+	// lockfiles, the per-project scan path previously paid a PATH lookup
+	// per project; this cache collapses that to one lookup per distinct
+	// PM. Also avoided: spamming the same "x not found in PATH" warning
+	// hundreds of times when the PM truly isn't installed.
+	pmAvailability map[string]error
 }
 
 func NewNodeScanner(exec executor.Executor, log *progress.Logger, loggedInUser string) *NodeScanner {
-	return &NodeScanner{exec: exec, log: log, loggedInUser: loggedInUser}
+	return &NodeScanner{
+		exec:           exec,
+		log:            log,
+		loggedInUser:   loggedInUser,
+		pmAvailability: make(map[string]error),
+	}
+}
+
+// binaryAvailable returns the cached checkPath result for a package-manager
+// binary, populating the cache on first call. Wraps checkPath so callers in
+// the per-project loop don't pay an LookPath per project on devices that
+// have hundreds of lockfiles for a PM that isn't installed.
+func (s *NodeScanner) binaryAvailable(ctx context.Context, name string) error {
+	if err, ok := s.pmAvailability[name]; ok {
+		return err
+	}
+	err := s.checkPath(ctx, name)
+	s.pmAvailability[name] = err
+	return err
 }
 
 // WithSkipper attaches a TCC skipper so the discovery walk skips
@@ -405,7 +430,12 @@ func (s *NodeScanner) ScanProjects(ctx context.Context, searchDirs []string) []m
 		pm := DetectProjectPM(s.exec, p.dir)
 		s.log.Progress("    Package manager: %s", pm)
 
-		r := s.scanProject(ctx, p.dir)
+		r, ok := s.scanProject(ctx, p.dir)
+		if !ok {
+			// PM not installed on this device — not an error, just nothing
+			// to scan. Skip without emitting a telemetry record.
+			continue
+		}
 		resultSize := int64(len(r.RawStdoutBase64)) + int64(len(r.RawStderrBase64))
 
 		if totalSize+resultSize > maxBytes {
@@ -421,53 +451,79 @@ func (s *NodeScanner) ScanProjects(ctx context.Context, searchDirs []string) []m
 	return results
 }
 
-func (s *NodeScanner) scanProject(ctx context.Context, projectDir string) model.NodeScanResult {
+// scanProject runs the project's detected package manager in the project
+// directory and returns the raw stdout/stderr as a NodeScanResult. The
+// second return is false when no record should be emitted — currently only
+// the case when the PM binary isn't on PATH, which is a normal "Node not
+// installed on this device" state, not a scan failure. Mirrors the
+// (result, ok) shape of scanNPMGlobal / scanYarnGlobal / scanPnpmGlobal.
+func (s *NodeScanner) scanProject(ctx context.Context, projectDir string) (model.NodeScanResult, bool) {
 	pm := DetectProjectPM(s.exec, projectDir)
-	version := ""
 
 	var cmd string
 	var args []string
-
 	switch pm {
 	case "npm":
-		version = s.getVersion(ctx, "npm", "--version")
-		cmd = "npm"
-		args = []string{"ls", "--json", "--depth=3"}
+		cmd, args = "npm", []string{"ls", "--json", "--depth=3"}
 	case "yarn":
-		version = s.getVersion(ctx, "yarn", "--version")
-		cmd = "yarn"
-		args = []string{"list", "--json"}
+		cmd, args = "yarn", []string{"list", "--json"}
 	case "yarn-berry":
-		version = s.getVersion(ctx, "yarn", "--version")
-		cmd = "yarn"
-		args = []string{"info", "--all", "--json"}
+		cmd, args = "yarn", []string{"info", "--all", "--json"}
 	case "pnpm":
-		version = s.getVersion(ctx, "pnpm", "--version")
-		cmd = "pnpm"
-		args = []string{"ls", "--json", "--depth=3"}
+		cmd, args = "pnpm", []string{"ls", "--json", "--depth=3"}
 	case "bun":
-		version = s.getVersion(ctx, "bun", "--version")
-		cmd = "bun"
-		args = []string{"pm", "ls", "--all"}
+		cmd, args = "bun", []string{"pm", "ls", "--all"}
 	default:
+		// "unsupported package manager" is a genuine error state — the
+		// lockfile detector matched something we don't have a scanner for.
+		// Emit so the backend can surface it; this is distinct from the
+		// "PM not installed" case handled below.
 		return model.NodeScanResult{
 			ProjectPath:    projectDir,
 			PackageManager: pm,
 			Error:          "unsupported package manager",
 			ExitCode:       1,
-		}
+		}, true
 	}
+
+	// "PM not installed on this device" is not a scan failure — it's a
+	// normal configuration state (e.g. a Windows machine that hasn't
+	// received the corporate Node.js deployment, scanning vendored
+	// package.json files inside VS Code extensions). Without this guard
+	// the per-project loop fell through to exec.CommandContext, hit ENOENT,
+	// and shipped an empty-RawStdoutBase64 record per project to the
+	// backend. The backend can't tell the difference between "agent
+	// couldn't run npm" and "agent ran npm and got 0 packages", so devices
+	// with hundreds of vendored package.json files dropped off the UI's
+	// "Has npm_packages" view despite the backend running cleanly.
+	//
+	// Symmetric with scanNPMGlobal / scanYarnGlobal / scanPnpmGlobal which
+	// already do this — global scans for missing PMs are dropped from
+	// telemetry rather than emitted as zero-result records.
+	if err := s.binaryAvailable(ctx, cmd); err != nil {
+		return model.NodeScanResult{}, false
+	}
+
+	version := s.getVersion(ctx, cmd, "--version")
 
 	start := time.Now()
 	// Run the package manager command directly in the project directory.
 	// Avoids shell cd + quoting issues on Windows where cmd.exe misinterprets
 	// Go's backslash-escaped quotes in paths.
-	stdout, stderr, exitCode, _ := s.runInDir(ctx, projectDir, 30*time.Second, cmd, args...)
+	stdout, stderr, exitCode, runErr := s.runInDir(ctx, projectDir, 30*time.Second, cmd, args...)
 	duration := time.Since(start).Milliseconds()
 
+	// Capture the real failure reason for the case where the PM IS
+	// available but the run still fails (timeout, mid-run exec error,
+	// non-zero exit). Previously runErr was discarded and errMsg was
+	// derived from exitCode alone, making spawn failure mid-run,
+	// context cancellation, and a genuine non-zero exit indistinguishable.
 	errMsg := ""
-	if exitCode != 0 {
-		errMsg = cmd + " command failed with exit code"
+	switch {
+	case runErr != nil:
+		errMsg = fmt.Sprintf("%s exec failed: %v", cmd, runErr)
+	case exitCode != 0:
+		errMsg = fmt.Sprintf("%s exited with code %d", cmd, exitCode)
 	}
 
 	return model.NodeScanResult{
@@ -480,7 +536,7 @@ func (s *NodeScanner) scanProject(ctx context.Context, projectDir string) model.
 		Error:            errMsg,
 		ExitCode:         exitCode,
 		ScanDurationMs:   duration,
-	}
+	}, true
 }
 
 func (s *NodeScanner) getVersion(ctx context.Context, binary, flag string) string {

--- a/internal/detector/nodescan_test.go
+++ b/internal/detector/nodescan_test.go
@@ -327,7 +327,7 @@ func TestNodeScanner_ScanProject_Windows(t *testing.T) {
 		"npm", "ls", "--json", "--depth=3")
 
 	scanner := newTestScanner(mock)
-	result, ok := scanner.scanProject(context.Background(), `C:\Users\dev\myapp`)
+	result, ok := scanner.scanProject(context.Background(), `C:\Users\dev\myapp`, "npm")
 
 	if !ok {
 		t.Fatal("expected scanProject to emit a result when npm is available")
@@ -364,7 +364,7 @@ func TestNodeScanner_ScanProject_YarnBerry_Windows(t *testing.T) {
 		"yarn", "info", "--all", "--json")
 
 	scanner := newTestScanner(mock)
-	result, ok := scanner.scanProject(context.Background(), projectDir)
+	result, ok := scanner.scanProject(context.Background(), projectDir, "yarn-berry")
 
 	if !ok {
 		t.Fatal("expected scanProject to emit a result when yarn is available")
@@ -380,13 +380,14 @@ func TestNodeScanner_ScanProject_YarnBerry_Windows(t *testing.T) {
 	}
 }
 
-// TestNodeScanner_ScanProject_PMNotInPATH covers the cfacorp regression:
-// a package-lock.json project on a Windows device where Node.js wasn't
-// deployed by IT (npm absent from PATH). Previously this path discarded
-// the exec.CommandContext ENOENT and shipped a NodeScanResult with empty
-// RawStdoutBase64 — indistinguishable on the backend from a successful
-// scan of an empty project. The fix drops the record entirely: "PM not
-// installed" is a normal configuration state, not an error to report.
+// TestNodeScanner_ScanProject_PMNotInPATH covers the empty-payload
+// regression: a package-lock.json project on a Windows device where
+// Node.js isn't deployed (npm absent from PATH). Previously this path
+// discarded the exec.CommandContext ENOENT and shipped a NodeScanResult
+// with empty RawStdoutBase64 — indistinguishable on the backend from a
+// successful scan of an empty project. The fix drops the record entirely:
+// "PM not installed" is a normal configuration state, not an error to
+// report.
 func TestNodeScanner_ScanProject_PMNotInPATH(t *testing.T) {
 	mock := executor.NewMock()
 	mock.SetGOOS("windows")
@@ -396,7 +397,7 @@ func TestNodeScanner_ScanProject_PMNotInPATH(t *testing.T) {
 	mock.SetFile(filepath.Join(projectDir, "package-lock.json"), []byte{})
 
 	scanner := newTestScanner(mock)
-	_, ok := scanner.scanProject(context.Background(), projectDir)
+	_, ok := scanner.scanProject(context.Background(), projectDir, "npm")
 
 	if ok {
 		t.Error("expected scanProject to return ok=false when PM not on PATH (so no record is emitted)")
@@ -406,7 +407,8 @@ func TestNodeScanner_ScanProject_PMNotInPATH(t *testing.T) {
 // TestNodeScanner_ScanProjects_DropsRecordsForMissingPM exercises the
 // loop-level contract end-to-end: a device with multiple package.json
 // files but no installed PM should produce zero records, not zero-result
-// records. This is what cfacorp's broken devices needed.
+// records. Mirrors the field-observed scenario the empty-payload fix
+// addresses.
 func TestNodeScanner_ScanProjects_DropsRecordsForMissingPM(t *testing.T) {
 	mock := executor.NewMock()
 	mock.SetGOOS("windows")
@@ -439,8 +441,8 @@ func TestNodeScanner_ScanProject_BinaryAvailabilityCached(t *testing.T) {
 	mock.SetFile(filepath.Join(dirB, "package-lock.json"), []byte{})
 
 	scanner := newTestScanner(mock)
-	_, firstOK := scanner.scanProject(context.Background(), dirA)
-	_, secondOK := scanner.scanProject(context.Background(), dirB)
+	_, firstOK := scanner.scanProject(context.Background(), dirA, "npm")
+	_, secondOK := scanner.scanProject(context.Background(), dirB, "npm")
 
 	if firstOK || secondOK {
 		t.Errorf("expected both scanProject calls to return ok=false, got firstOK=%v secondOK=%v",

--- a/internal/detector/nodescan_test.go
+++ b/internal/detector/nodescan_test.go
@@ -327,8 +327,11 @@ func TestNodeScanner_ScanProject_Windows(t *testing.T) {
 		"npm", "ls", "--json", "--depth=3")
 
 	scanner := newTestScanner(mock)
-	result := scanner.scanProject(context.Background(), `C:\Users\dev\myapp`)
+	result, ok := scanner.scanProject(context.Background(), `C:\Users\dev\myapp`)
 
+	if !ok {
+		t.Fatal("expected scanProject to emit a result when npm is available")
+	}
 	if result.PackageManager != "npm" {
 		t.Errorf("expected npm, got %s", result.PackageManager)
 	}
@@ -361,8 +364,11 @@ func TestNodeScanner_ScanProject_YarnBerry_Windows(t *testing.T) {
 		"yarn", "info", "--all", "--json")
 
 	scanner := newTestScanner(mock)
-	result := scanner.scanProject(context.Background(), projectDir)
+	result, ok := scanner.scanProject(context.Background(), projectDir)
 
+	if !ok {
+		t.Fatal("expected scanProject to emit a result when yarn is available")
+	}
 	if result.PackageManager != "yarn-berry" {
 		t.Errorf("expected yarn-berry, got %s", result.PackageManager)
 	}
@@ -371,6 +377,80 @@ func TestNodeScanner_ScanProject_YarnBerry_Windows(t *testing.T) {
 	}
 	if result.ExitCode != 0 {
 		t.Errorf("expected ExitCode 0, got %d", result.ExitCode)
+	}
+}
+
+// TestNodeScanner_ScanProject_PMNotInPATH covers the cfacorp regression:
+// a package-lock.json project on a Windows device where Node.js wasn't
+// deployed by IT (npm absent from PATH). Previously this path discarded
+// the exec.CommandContext ENOENT and shipped a NodeScanResult with empty
+// RawStdoutBase64 — indistinguishable on the backend from a successful
+// scan of an empty project. The fix drops the record entirely: "PM not
+// installed" is a normal configuration state, not an error to report.
+func TestNodeScanner_ScanProject_PMNotInPATH(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	// Note: deliberately do NOT call mock.SetPath("npm", ...) — that's the
+	// condition we're regression-testing.
+	projectDir := `C:\Users\dev\myapp`
+	mock.SetFile(filepath.Join(projectDir, "package-lock.json"), []byte{})
+
+	scanner := newTestScanner(mock)
+	_, ok := scanner.scanProject(context.Background(), projectDir)
+
+	if ok {
+		t.Error("expected scanProject to return ok=false when PM not on PATH (so no record is emitted)")
+	}
+}
+
+// TestNodeScanner_ScanProjects_DropsRecordsForMissingPM exercises the
+// loop-level contract end-to-end: a device with multiple package.json
+// files but no installed PM should produce zero records, not zero-result
+// records. This is what cfacorp's broken devices needed.
+func TestNodeScanner_ScanProjects_DropsRecordsForMissingPM(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	// Two real package.json files, no npm on PATH.
+	dirA := `C:\Users\dev\a`
+	dirB := `C:\Users\dev\b`
+	mock.SetFile(filepath.Join(dirA, "package.json"), []byte("{}"))
+	mock.SetFile(filepath.Join(dirA, "package-lock.json"), []byte{})
+	mock.SetFile(filepath.Join(dirB, "package.json"), []byte("{}"))
+	mock.SetFile(filepath.Join(dirB, "package-lock.json"), []byte{})
+
+	scanner := newTestScanner(mock)
+	results := scanner.ScanProjects(context.Background(), []string{`C:\Users\dev`})
+
+	if len(results) != 0 {
+		t.Errorf("expected 0 telemetry records when PM not installed, got %d", len(results))
+	}
+}
+
+// TestNodeScanner_ScanProject_BinaryAvailabilityCached verifies the
+// pmAvailability cache: two scanProject calls for the same PM should
+// trigger exactly one PATH lookup. Important on devices with hundreds
+// of lockfiles — without caching we'd pay a LookPath per project.
+func TestNodeScanner_ScanProject_BinaryAvailabilityCached(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("windows")
+	dirA := `C:\Users\dev\a`
+	dirB := `C:\Users\dev\b`
+	mock.SetFile(filepath.Join(dirA, "package-lock.json"), []byte{})
+	mock.SetFile(filepath.Join(dirB, "package-lock.json"), []byte{})
+
+	scanner := newTestScanner(mock)
+	_, firstOK := scanner.scanProject(context.Background(), dirA)
+	_, secondOK := scanner.scanProject(context.Background(), dirB)
+
+	if firstOK || secondOK {
+		t.Errorf("expected both scanProject calls to return ok=false, got firstOK=%v secondOK=%v",
+			firstOK, secondOK)
+	}
+	if got, want := len(scanner.pmAvailability), 1; got != want {
+		t.Errorf("expected exactly %d cached PM lookup after two scans of same PM, got %d", want, got)
+	}
+	if _, ok := scanner.pmAvailability["npm"]; !ok {
+		t.Error("expected pmAvailability to contain entry for npm")
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -706,14 +706,14 @@ func Run(exec executor.Executor, log *progress.Logger, cfg *cli.Config) (err err
 			log.Progress("  Found: %s v%s at %s", pm.Name, pm.Version, pm.Path)
 		}
 		// Surface the empty-detector case explicitly. Previously this
-		// printed nothing — a 20-minute blank between "Detecting Node.js
+		// printed nothing — a long blank between "Detecting Node.js
 		// package managers..." and the next section, hiding the fact that
-		// the per-project scans about to run would all ENOENT and ship
-		// empty stdout records. Output.log from cfacorp prod showed this
-		// blank on every broken device; the warning makes the root cause
-		// visible at the agent level.
+		// the per-project scans about to run would all ENOENT and produce
+		// empty stdout records. The warning makes the root cause visible
+		// at the agent level rather than requiring a diff of output.log
+		// against a known-working device.
 		if len(pkgManagers) == 0 {
-			log.Warn("No Node.js package managers found on PATH — per-project scans will be skipped")
+			log.Warn("No Node.js package managers found on PATH — project discovery will still run but per-project package listing will be skipped")
 		}
 		fmt.Fprintln(os.Stderr)
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -705,6 +705,16 @@ func Run(exec executor.Executor, log *progress.Logger, cfg *cli.Config) (err err
 		for _, pm := range pkgManagers {
 			log.Progress("  Found: %s v%s at %s", pm.Name, pm.Version, pm.Path)
 		}
+		// Surface the empty-detector case explicitly. Previously this
+		// printed nothing — a 20-minute blank between "Detecting Node.js
+		// package managers..." and the next section, hiding the fact that
+		// the per-project scans about to run would all ENOENT and ship
+		// empty stdout records. Output.log from cfacorp prod showed this
+		// blank on every broken device; the warning makes the root cause
+		// visible at the agent level.
+		if len(pkgManagers) == 0 {
+			log.Warn("No Node.js package managers found on PATH — per-project scans will be skipped")
+		}
 		fmt.Fprintln(os.Stderr)
 
 		log.Progress("Scanning globally installed packages...")


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
