### PR TITLE
fix(scan): resolve package managers under the LaunchAgent's stripped PATH

### DIFF
--- a/internal/detector/nodescan.go
+++ b/internal/detector/nodescan.go
@@ -69,6 +69,13 @@ func (s *NodeScanner) binaryAvailable(ctx context.Context, name string) error {
 		return err
 	}
 	err := s.checkPath(ctx, name)
+	if err != nil {
+		// Logged once per PM (cache miss). "Not on PATH" is a normal
+		// "PM not installed" state — projects using it are silently skipped —
+		// but recording it at Debug makes "device emits no npm data" diagnosable
+		// (send the Debug header) instead of an unexplained absence.
+		s.log.Debug("%s not found in PATH (delegated=%v) — projects using it will be skipped: %v", name, s.shouldRunAsUser(), err)
+	}
 	s.pmAvailability[name] = err
 	return err
 }
@@ -86,10 +93,19 @@ func (s *NodeScanner) emitProgress(detail string) {
 	}
 }
 
-// shouldRunAsUser returns true when commands should be delegated to the logged-in user.
-// Only applies on Unix — RunAsUser uses sudo which is not available on Windows.
+// shouldRunAsUser returns true when package-manager commands should run through
+// the logged-in user's login shell (with rc files sourced for a full PATH)
+// instead of a bare exec. Applies on Unix whenever we have a target user, in
+// both deployment modes:
+//   - root (LaunchDaemon / MDM "Run Script"): RunAsUser sudo's to the console user.
+//   - non-root (LaunchAgent's periodic fire): RunAsUser runs as the current user.
+//
+// launchd hands both a stripped PATH (/usr/bin:/bin:/usr/sbin:/sbin), so a bare
+// exec can't find npm/yarn/pnpm installed via nvm/fnm/homebrew/npm-global —
+// producing exit_code -1, empty output, and version "unknown". Windows is
+// excluded (no sudo / rc-sourcing model).
 func (s *NodeScanner) shouldRunAsUser() bool {
-	return s.exec.GOOS() != model.PlatformWindows && s.exec.IsRoot() && s.loggedInUser != ""
+	return s.exec.GOOS() != model.PlatformWindows && s.loggedInUser != ""
 }
 
 // runCmd runs a command, delegating to the logged-in user when running as root.
@@ -174,8 +190,26 @@ func (s *NodeScanner) ScanGlobalPackages(ctx context.Context) []model.NodeScanRe
 	return results
 }
 
+// pmRunError returns a self-explanatory error string for a failed package-
+// manager run, or "" on success. When runErr is non-nil it carries the user
+// shell's stderr (see executor.RunAsUser), so the message names the real cause
+// — "command not found", an npm ELSPROBLEMS line — rather than a bare exit
+// code. The previous static strings ("npm list -g command failed with exit
+// code") discarded both the code and the reason, which is what made the
+// production failures opaque in telemetry.
+func pmRunError(label string, exitCode int, runErr error) string {
+	switch {
+	case runErr != nil:
+		return fmt.Sprintf("%s exec failed: %v", label, runErr)
+	case exitCode != 0:
+		return fmt.Sprintf("%s exited with code %d", label, exitCode)
+	}
+	return ""
+}
+
 func (s *NodeScanner) scanNPMGlobal(ctx context.Context) (model.NodeScanResult, bool) {
 	if err := s.checkPath(ctx, "npm"); err != nil {
+		s.log.Debug("npm not found on PATH — skipping npm global scan: %v", err)
 		return model.NodeScanResult{}, false
 	}
 
@@ -187,13 +221,12 @@ func (s *NodeScanner) scanNPMGlobal(ctx context.Context) (model.NodeScanResult, 
 	}
 
 	start := time.Now()
-	stdout, stderr, exitCode, _ := s.runCmd(ctx, 60*time.Second, "npm", "list", "-g", "--json", "--depth=3")
+	stdout, stderr, exitCode, runErr := s.runCmd(ctx, 60*time.Second, "npm", "list", "-g", "--json", "--depth=3")
 	duration := time.Since(start).Milliseconds()
 
-	errMsg := ""
-	if exitCode != 0 {
-		errMsg = "npm list -g command failed with exit code"
-		s.log.Warn("npm list -g failed (exit_code=%d, %dms) — results may be incomplete", exitCode, duration)
+	errMsg := pmRunError("npm list -g", exitCode, runErr)
+	if errMsg != "" {
+		s.log.Warn("npm global scan failed (%dms): %s — results may be incomplete", duration, errMsg)
 	}
 	s.log.Debug("npm global scan: version=%s prefix=%s exit_code=%d stdout_bytes=%d duration=%dms", version, prefix, exitCode, len(stdout), duration)
 
@@ -212,24 +245,25 @@ func (s *NodeScanner) scanNPMGlobal(ctx context.Context) (model.NodeScanResult, 
 
 func (s *NodeScanner) scanYarnGlobal(ctx context.Context) (model.NodeScanResult, bool) {
 	if err := s.checkPath(ctx, "yarn"); err != nil {
+		s.log.Debug("yarn not found on PATH — skipping yarn global scan: %v", err)
 		return model.NodeScanResult{}, false
 	}
 
 	version := s.getVersion(ctx, "yarn", "--version")
 	globalDir := s.getOutput(ctx, "yarn", "global", "dir")
 	if globalDir == "" {
+		s.log.Debug("yarn found but `yarn global dir` returned empty — skipping yarn global scan")
 		return model.NodeScanResult{}, false
 	}
 
 	start := time.Now()
 	// Run directly in the global dir instead of shell cd (avoids Windows quoting issues).
-	stdout, stderr, exitCode, _ := s.runInDir(ctx, globalDir, 60*time.Second, "yarn", "list", "--json", "--depth=0")
+	stdout, stderr, exitCode, runErr := s.runInDir(ctx, globalDir, 60*time.Second, "yarn", "list", "--json", "--depth=0")
 	duration := time.Since(start).Milliseconds()
 
-	errMsg := ""
-	if exitCode != 0 {
-		errMsg = "yarn global list command failed"
-		s.log.Warn("yarn global list failed (exit_code=%d, %dms) — results may be incomplete", exitCode, duration)
+	errMsg := pmRunError("yarn global list", exitCode, runErr)
+	if errMsg != "" {
+		s.log.Warn("yarn global scan failed (%dms): %s — results may be incomplete", duration, errMsg)
 	}
 	s.log.Debug("yarn global scan: version=%s global_dir=%s exit_code=%d stdout_bytes=%d duration=%dms", version, globalDir, exitCode, len(stdout), duration)
 
@@ -309,10 +343,9 @@ func (s *NodeScanner) scanPnpmGlobal(ctx context.Context) (model.NodeScanResult,
 	}
 	duration := time.Since(start).Milliseconds()
 
-	errMsg := ""
-	if exitCode != 0 {
-		errMsg = "pnpm list -g command failed"
-		s.log.Warn("pnpm list -g failed (exit_code=%d, %dms) — results may be incomplete", exitCode, duration)
+	errMsg := pmRunError("pnpm list -g", exitCode, err)
+	if errMsg != "" {
+		s.log.Warn("pnpm global scan failed (%dms): %s — results may be incomplete", duration, errMsg)
 	}
 	s.log.Debug("pnpm global scan: version=%s global_dir=%s exit_code=%d stdout_bytes=%d duration=%dms err=%v", version, globalDir, exitCode, len(stdout), duration, err)
 
@@ -523,12 +556,17 @@ func (s *NodeScanner) scanProject(ctx context.Context, projectDir, pm string) (m
 	// non-zero exit). Previously runErr was discarded and errMsg was
 	// derived from exitCode alone, making spawn failure mid-run,
 	// context cancellation, and a genuine non-zero exit indistinguishable.
-	errMsg := ""
-	switch {
-	case runErr != nil:
-		errMsg = fmt.Sprintf("%s exec failed: %v", cmd, runErr)
-	case exitCode != 0:
-		errMsg = fmt.Sprintf("%s exited with code %d", cmd, exitCode)
+	// runErr carries the user shell's stderr (see executor.RunAsUser), so the
+	// message names the real cause instead of a bare exit code.
+	errMsg := pmRunError(cmd, exitCode, runErr)
+
+	// Surface the failure in the agent log, not just the telemetry record.
+	// A recurring failure (e.g. npm unreachable under the LaunchAgent's
+	// stripped PATH) previously left both the log and — on the delegated
+	// path, where stderr is unavailable — the telemetry stderr blank, so the
+	// only signal was an opaque exit code.
+	if errMsg != "" {
+		s.log.Warn("node project scan failed: %s (project=%s, exit=%d)", errMsg, projectDir, exitCode)
 	}
 
 	return model.NodeScanResult{

--- a/internal/detector/nodescan_test.go
+++ b/internal/detector/nodescan_test.go
@@ -3,7 +3,9 @@ package detector
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
@@ -453,6 +455,116 @@ func TestNodeScanner_ScanProject_BinaryAvailabilityCached(t *testing.T) {
 	}
 	if _, ok := scanner.pmAvailability["npm"]; !ok {
 		t.Error("expected pmAvailability to contain entry for npm")
+	}
+}
+
+// TestNodeScanner_ShouldRunAsUser pins the delegation decision. The fix dropped
+// the old IsRoot() requirement: whenever there's a logged-in user on a non-
+// Windows host, package-manager commands run through that user's login shell —
+// in BOTH deployment modes. The non-root row is the LaunchAgent regression:
+// launchd runs the agent as the user with a stripped PATH, and before the fix
+// shouldRunAsUser was false there, so npm/yarn/pnpm fell through to a bare exec
+// and weren't found (exit -1, empty output, version "unknown").
+func TestNodeScanner_ShouldRunAsUser(t *testing.T) {
+	tests := []struct {
+		name         string
+		goos         string
+		isRoot       bool
+		loggedInUser string
+		want         bool
+	}{
+		{"non-root macOS with user (LaunchAgent regression)", "darwin", false, "alice", true},
+		{"root macOS with user (LaunchDaemon)", "darwin", true, "alice", true},
+		{"non-root linux with user", "linux", false, "alice", true},
+		{"no logged-in user", "darwin", false, "", false},
+		{"windows excluded", "windows", false, "alice", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := executor.NewMock()
+			mock.SetGOOS(tc.goos)
+			mock.SetIsRoot(tc.isRoot)
+			scanner := NewNodeScanner(mock, progress.NewLogger(progress.LevelInfo), tc.loggedInUser)
+			if got := scanner.shouldRunAsUser(); got != tc.want {
+				t.Errorf("shouldRunAsUser() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNodeScanner_ScanProject_Delegated_NonRoot is the core LaunchAgent
+// regression: the agent runs as the console user (NOT root) under launchd's
+// stripped PATH. The scanner must still route npm through the user's login
+// shell — the Mock dispatches RunAsUser as `bash -c "<cmd>"` — so an
+// nvm/fnm/homebrew npm is resolved. checkPath (`which npm`), getVersion
+// (`npm --version`) and the scan itself (a cd + single-quoted argv built by
+// platformShellQuote) all flow through that path.
+func TestNodeScanner_ScanProject_Delegated_NonRoot(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("darwin")
+	// Deliberately NOT root — this is the LaunchAgent-as-user deployment that
+	// previously skipped delegation.
+	projectDir := "/Users/testuser/myapp"
+
+	mock.SetCommand("/Users/testuser/.nvm/versions/node/v20.11.0/bin/npm\n", "", 0, "bash", "-c", "which npm")
+	mock.SetCommand("10.9.0\n", "", 0, "bash", "-c", "npm --version")
+	scanCmd := "cd '/Users/testuser/myapp' && 'npm' 'ls' '--json' '--depth=3'"
+	mock.SetCommand(`{"dependencies":{"lodash":{"version":"4.17.21"}}}`, "", 0, "bash", "-c", scanCmd)
+
+	scanner := NewNodeScanner(mock, progress.NewLogger(progress.LevelInfo), "testuser")
+	if !scanner.shouldRunAsUser() {
+		t.Fatal("shouldRunAsUser must be true for a non-root macOS scan with a logged-in user")
+	}
+
+	result, ok := scanner.scanProject(context.Background(), projectDir, "npm")
+	if !ok {
+		t.Fatal("expected scanProject to emit a result (npm resolved via the user's login shell)")
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 — the scan should have run through `bash -c`, not a bare exec", result.ExitCode)
+	}
+	if result.PMVersion != "10.9.0" {
+		t.Errorf("PMVersion = %q, want 10.9.0", result.PMVersion)
+	}
+	decoded, _ := base64.StdEncoding.DecodeString(result.RawStdoutBase64)
+	if len(decoded) == 0 {
+		t.Error("expected non-empty RawStdoutBase64 from the delegated scan")
+	}
+	if result.Error != "" {
+		t.Errorf("Error = %q, want empty on a successful scan", result.Error)
+	}
+}
+
+// TestNodeScanner_ScanProject_Delegated_SurfacesError verifies a delegated
+// failure is captured in the telemetry Error field (and log.Warn'd) rather than
+// reduced to an opaque exit code. When npm IS resolvable but the run itself
+// fails, RunAsUser returns an error carrying the shell's reason; scanProject
+// must fold that into result.Error so the next occurrence is self-explanatory.
+func TestNodeScanner_ScanProject_Delegated_SurfacesError(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetGOOS("darwin")
+	projectDir := "/Users/testuser/broken"
+
+	mock.SetCommand("/opt/homebrew/bin/npm\n", "", 0, "bash", "-c", "which npm")
+	mock.SetCommand("10.9.0\n", "", 0, "bash", "-c", "npm --version")
+	scanCmd := "cd '/Users/testuser/broken' && 'npm' 'ls' '--json' '--depth=3'"
+	// SetCommandError mirrors what executor.RunAsUser returns when the user
+	// shell exits non-zero — now with the stderr folded into the message.
+	mock.SetCommandError(
+		fmt.Errorf("command exited with code 127: zsh: command not found: npm"),
+		"bash", "-c", scanCmd,
+	)
+
+	scanner := NewNodeScanner(mock, progress.NewLogger(progress.LevelInfo), "testuser")
+	result, ok := scanner.scanProject(context.Background(), projectDir, "npm")
+	if !ok {
+		t.Fatal("expected scanProject to still emit a record when the PM is present but the run fails")
+	}
+	if result.Error == "" {
+		t.Fatal("expected a non-empty Error capturing the failure reason (was the runErr discarded?)")
+	}
+	if !strings.Contains(result.Error, "command not found") {
+		t.Errorf("Error = %q, want it to carry the underlying shell reason", result.Error)
 	}
 }
 

--- a/internal/executor/executor_unix.go
+++ b/internal/executor/executor_unix.go
@@ -88,16 +88,6 @@ func (r *Real) resolveUserShell(ctx context.Context, username string) string {
 }
 
 func (r *Real) RunAsUser(ctx context.Context, username, command string) (string, error) {
-	if !r.IsRoot() {
-		stdout, _, exitCode, err := r.Run(ctx, "bash", "-c", command)
-		if err != nil {
-			return strings.TrimSpace(stdout), err
-		}
-		if exitCode != 0 {
-			return strings.TrimSpace(stdout), fmt.Errorf("command exited with code %d", exitCode)
-		}
-		return strings.TrimSpace(stdout), nil
-	}
 	shell := r.resolveUserShell(ctx, username)
 	if shell == "" {
 		shell = "/bin/bash"
@@ -111,12 +101,50 @@ func (r *Real) RunAsUser(ctx context.Context, username, command string) (string,
 		rcSource = "[ -f ~/.zshrc ] && . ~/.zshrc 2>/dev/null; "
 	}
 
-	stdout, _, exitCode, err := r.Run(ctx, "sudo", "-H", "-u", username, shell, "-l", "-c", rcSource+command)
+	var stdout, stderr string
+	var exitCode int
+	var err error
+	if r.IsRoot() {
+		// Running as root (MDM "Run Script" / LaunchDaemon): drop to the target
+		// user via sudo so the command runs in their environment. -H sets HOME so
+		// ~ in rcSource resolves to the target user's home.
+		stdout, stderr, exitCode, err = r.Run(ctx, "sudo", "-H", "-u", username, shell, "-l", "-c", rcSource+command)
+	} else {
+		// Already running as the user (the LaunchAgent's periodic fire). No sudo
+		// needed, but launchd hands user agents a stripped PATH
+		// (/usr/bin:/bin:/usr/sbin:/sbin), so we still go through the user's login
+		// shell with rc sourced — otherwise nvm/fnm/homebrew-installed npm/yarn/pnpm
+		// aren't on PATH and the bare exec fails with "executable not found"
+		// (exit -1, empty output, version "unknown").
+		stdout, stderr, exitCode, err = r.Run(ctx, shell, "-l", "-c", rcSource+command)
+	}
+
 	if err != nil {
 		return strings.TrimSpace(stdout), err
 	}
 	if exitCode != 0 {
+		// Fold the shell's stderr into the error. Callers record this — the
+		// node scanner puts it in the telemetry Error field — so a failure
+		// should explain itself ("zsh: command not found: npm", a missing
+		// lockfile, an npm ELSPROBLEMS line) rather than surfacing as an
+		// opaque "exited with code N". Previously stderr was discarded here
+		// and the real reason was lost.
+		if detail := stderrSnippet(stderr); detail != "" {
+			return strings.TrimSpace(stdout), fmt.Errorf("command exited with code %d: %s", exitCode, detail)
+		}
 		return strings.TrimSpace(stdout), fmt.Errorf("command exited with code %d", exitCode)
 	}
 	return strings.TrimSpace(stdout), nil
+}
+
+// stderrSnippet trims and length-bounds shell stderr for embedding in an error
+// message — enough to explain a failure (e.g. "zsh: command not found: npm")
+// without bloating a telemetry Error field with a full npm/pnpm dependency dump.
+func stderrSnippet(s string) string {
+	s = strings.TrimSpace(s)
+	const max = 200
+	if r := []rune(s); len(r) > max {
+		return string(r[:max]) + "..."
+	}
+	return s
 }

--- a/internal/executor/executor_unix_test.go
+++ b/internal/executor/executor_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -57,4 +58,103 @@ func TestRunWithTimeoutHangsOnUnreapedChild(t *testing.T) {
 			elapsed, timeout,
 		)
 	}
+}
+
+// TestRunAsUser_FoldsStderrIntoError verifies RunAsUser surfaces a failing
+// command's stderr in the returned error rather than a bare "exited with code
+// N". This is what lets the node scanner record a self-explanatory telemetry
+// Error (e.g. "command not found") instead of an opaque exit code when npm/yarn
+// can't be resolved under the LaunchAgent's stripped PATH. Real shell, real
+// exec — consistent with the Antigravity test above.
+func TestRunAsUser_FoldsStderrIntoError(t *testing.T) {
+	r := &Real{}
+	if r.IsRoot() {
+		// The root path shells out via `sudo -H -u <user>`; sudo presence and
+		// policy vary across CI images. The non-root branch — the common case,
+		// and what GitHub-hosted runners use — exercises the same stderr-fold
+		// code, so skip rather than depend on sudo being available here.
+		t.Skip("skipping as root: RunAsUser's root branch depends on sudo")
+	}
+
+	// username "" → resolveUserShell returns "" → shell defaults to /bin/bash;
+	// non-root → `/bin/bash -l -c "<rc-source>; echo ... 1>&2; exit 3"`.
+	_, err := r.RunAsUser(context.Background(), "", "echo 'boom-on-stderr' 1>&2; exit 3")
+	if err == nil {
+		t.Fatal("expected an error for a command that exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "boom-on-stderr") {
+		t.Errorf("error %q does not contain the command's stderr — stderr was discarded", err.Error())
+	}
+	if !strings.Contains(err.Error(), "code 3") {
+		t.Errorf("error %q does not report the exit code", err.Error())
+	}
+}
+
+// TestRunAsUser_RecoversStrippedPATH is the precise reproduction of the
+// production failure and the proof the fix resolves it. Under an MDM
+// LaunchAgent, launchd runs the agent as the console user with a stripped PATH
+// (/usr/bin:/bin:/usr/sbin:/sbin); npm/yarn/pnpm installed via nvm/fnm/homebrew
+// live on a PATH entry that exists only in the user's shell rc file. A bare
+// exec can't find them — the pre-fix non-root behavior, surfacing as exit -1,
+// empty output, version "unknown" — while RunAsUser, which sources the rc file
+// in a login shell, does.
+//
+// The fake binary has a unique name so it is guaranteed absent from the real
+// stripped PATH and reachable only via the temp rc file — exactly like an
+// nvm-managed npm.
+func TestRunAsUser_RecoversStrippedPATH(t *testing.T) {
+	r := &Real{}
+	if r.IsRoot() {
+		t.Skip("skipping as root: this models the non-root LaunchAgent path (no sudo)")
+	}
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "nvm", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A uniquely-named fake "npm" that prints a version — stands in for the
+	// nvm-managed npm that lives outside launchd's stripped PATH.
+	fakeBin := filepath.Join(binDir, "fakenpm-dmgtest")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\necho 10.9.0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// rc files that prepend binDir to PATH — what nvm/fnm/homebrew write. Cover
+	// both bash and zsh so the test is shell-agnostic.
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rc := "export PATH=\"" + binDir + ":$PATH\"\n"
+	for _, name := range []string{".bashrc", ".zshrc"} {
+		if err := os.WriteFile(filepath.Join(home, name), []byte(rc), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Recreate launchd's environment: a stripped PATH, and HOME pointing at the
+	// temp rc files so RunAsUser's `~` resolves there. t.Setenv restores both
+	// after the test.
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+	t.Setenv("HOME", home)
+
+	// 1) RECREATE — a bare exec of the binary fails: it is not on the stripped
+	//    PATH. This is the pre-fix non-root path (Real.Run returns exit -1).
+	_, _, bareCode, bareErr := r.Run(context.Background(), "fakenpm-dmgtest", "--version")
+	if bareErr == nil {
+		t.Fatalf("bare exec unexpectedly succeeded (exit=%d) — premise broken: the fake binary must be off the stripped PATH", bareCode)
+	}
+	t.Logf("RECREATE: bare exec under launchd's stripped PATH → exit=%d, err=%v (matches the production -1/not-found)", bareCode, bareErr)
+
+	// 2) RESOLVE — RunAsUser sources the rc file in a login shell, so the binary
+	//    is found and runs. This is the fix.
+	out, err := r.RunAsUser(context.Background(), "", "fakenpm-dmgtest --version")
+	if err != nil {
+		t.Fatalf("RunAsUser failed to resolve a binary the rc file adds to PATH: %v", err)
+	}
+	if strings.TrimSpace(out) != "10.9.0" {
+		t.Errorf("RunAsUser output = %q, want 10.9.0 — rc-sourced PATH not applied", out)
+	}
+	t.Logf("RESOLVE: RunAsUser (login shell + rc source) → output=%q (binary found via the rc-file PATH)", strings.TrimSpace(out))
 }

--- a/internal/executor/user_aware.go
+++ b/internal/executor/user_aware.go
@@ -9,11 +9,13 @@ import (
 	"time"
 )
 
-// UserAwareExecutor wraps an Executor and delegates LookPath and RunWithTimeout
-// to the logged-in user when the process is running as root. This ensures that
-// commands like "brew list", "pip3 list", "npm --version" etc. execute in the
-// correct user context, since many tools refuse to run as root or return
-// different results for different users.
+// UserAwareExecutor wraps an Executor and delegates LookPath/Run/RunWithTimeout/
+// RunInDir to the logged-in user's login shell (with rc files sourced for a full
+// PATH). This ensures commands like "brew list", "pip3 list", "npm --version"
+// execute in the user's context with their real PATH — whether the agent runs
+// as root (sudo to the user) or as the user itself under a LaunchAgent. launchd
+// strips PATH in both cases, so package managers installed via nvm/fnm/homebrew
+// aren't found by a bare exec.
 //
 // All other Executor methods are forwarded unchanged.
 type UserAwareExecutor struct {
@@ -21,11 +23,17 @@ type UserAwareExecutor struct {
 	username string // logged-in user to delegate to; empty = no delegation
 }
 
-// NewUserAwareExecutor returns a wrapped executor that delegates command execution
-// to the given user when running as root on Unix. If username is empty or the
-// process is not root, all calls pass through to the inner executor unchanged.
+// NewUserAwareExecutor returns a wrapped executor that runs commands through the
+// given user's login shell (rc files sourced for a full PATH) on Unix, in both
+// deployment modes:
+//   - root (LaunchDaemon / MDM "Run Script"): RunAsUser sudo's to the user.
+//   - non-root (LaunchAgent's periodic fire): RunAsUser runs as the current user.
+//
+// launchd hands both a stripped PATH, so package managers (brew/pip3/npm via
+// nvm/fnm/homebrew/npm-global) need the user's rc-sourced shell to be resolved.
+// Passes through to the inner executor unchanged when username is empty or on Windows.
 func NewUserAwareExecutor(inner Executor, username string) Executor {
-	if username == "" || !inner.IsRoot() || inner.GOOS() == "windows" {
+	if username == "" || inner.GOOS() == "windows" {
 		return inner // no wrapping needed
 	}
 	return &UserAwareExecutor{inner: inner, username: username}

--- a/internal/executor/user_aware.go
+++ b/internal/executor/user_aware.go
@@ -39,10 +39,22 @@ func NewUserAwareExecutor(inner Executor, username string) Executor {
 	return &UserAwareExecutor{inner: inner, username: username}
 }
 
+// posixShellQuote wraps s in single quotes so it survives the shell's word-
+// splitting and globbing when embedded in a command string for RunAsUser,
+// escaping any embedded single quote (POSIX close-quote, escaped quote, reopen). Every command name, argument and
+// path handed to RunAsUser must be quoted — otherwise an argument containing
+// spaces (a "/Applications/LM Studio.app/..." path, a multi-word PlistBuddy
+// "-c" expression) is split into multiple argv entries and the command fails.
+// UserAwareExecutor never wraps on Windows (NewUserAwareExecutor passes through
+// there), so POSIX single-quote quoting is sufficient.
+func posixShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 func (e *UserAwareExecutor) Run(ctx context.Context, name string, args ...string) (string, string, int, error) {
-	cmd := name
+	cmd := posixShellQuote(name)
 	for _, a := range args {
-		cmd += " " + a
+		cmd += " " + posixShellQuote(a)
 	}
 	stdout, err := e.inner.RunAsUser(ctx, e.username, cmd)
 	if err != nil {
@@ -66,10 +78,12 @@ func (e *UserAwareExecutor) RunWithTimeout(ctx context.Context, timeout time.Dur
 func (e *UserAwareExecutor) RunInDir(ctx context.Context, dir string, timeout time.Duration, name string, args ...string) (string, string, int, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	// For user-aware execution, use cd + command via RunAsUser
-	cmd := "cd " + dir + " && " + name
+	// For user-aware execution, use cd + command via RunAsUser. Quote the dir,
+	// command and every arg so paths with spaces (e.g. "/Users/me/My App")
+	// survive the shell's word-splitting as single argv entries.
+	cmd := "cd " + posixShellQuote(dir) + " && " + posixShellQuote(name)
 	for _, a := range args {
-		cmd += " " + a
+		cmd += " " + posixShellQuote(a)
 	}
 	stdout, err := e.inner.RunAsUser(ctx, e.username, cmd)
 	if err != nil {
@@ -86,7 +100,7 @@ func (e *UserAwareExecutor) RunAsUser(ctx context.Context, username, command str
 }
 
 func (e *UserAwareExecutor) LookPath(name string) (string, error) {
-	stdout, err := e.inner.RunAsUser(context.Background(), e.username, "which "+name)
+	stdout, err := e.inner.RunAsUser(context.Background(), e.username, "which "+posixShellQuote(name))
 	path := strings.TrimSpace(stdout)
 	if err != nil || path == "" || !strings.HasPrefix(path, "/") {
 		return "", fmt.Errorf("%s not found in user PATH", name)

--- a/internal/executor/user_aware_test.go
+++ b/internal/executor/user_aware_test.go
@@ -1,0 +1,64 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestNewUserAwareExecutor_Wrapping pins the wrapping decision. The fix dropped
+// the old `!inner.IsRoot()` gate so the wrapper also applies under a LaunchAgent
+// (the agent running as the user, not root). launchd strips PATH in both modes,
+// so brew/pip3/npm must run through the user's rc-sourced login shell either
+// way — the non-root row is the regression this change fixes.
+func TestNewUserAwareExecutor_Wrapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		goos     string
+		isRoot   bool
+		username string
+		wantWrap bool
+	}{
+		{"non-root macOS with user (LaunchAgent regression)", "darwin", false, "alice", true},
+		{"root macOS with user (LaunchDaemon)", "darwin", true, "alice", true},
+		{"non-root linux with user", "linux", false, "alice", true},
+		{"empty username → passthrough", "darwin", false, "", false},
+		{"windows → passthrough", "windows", false, "alice", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := NewMock()
+			mock.SetGOOS(tc.goos)
+			mock.SetIsRoot(tc.isRoot)
+
+			got := NewUserAwareExecutor(mock, tc.username)
+			_, wrapped := got.(*UserAwareExecutor)
+			if wrapped != tc.wantWrap {
+				t.Errorf("NewUserAwareExecutor wrapped=%v, want %v", wrapped, tc.wantWrap)
+			}
+		})
+	}
+}
+
+// TestUserAwareExecutor_RunDelegatesNonRoot confirms a wrapped Run is routed
+// through the inner RunAsUser (which the Mock dispatches as `bash -c`) even when
+// not root — i.e. the command actually reaches the user's shell, where PATH is
+// resolved, rather than a bare exec.
+func TestUserAwareExecutor_RunDelegatesNonRoot(t *testing.T) {
+	mock := NewMock()
+	mock.SetGOOS("darwin")
+	mock.SetIsRoot(false) // LaunchAgent: running as the user, not root
+	mock.SetCommand("/opt/homebrew/bin/brew\n", "", 0, "bash", "-c", "which brew")
+
+	exec := NewUserAwareExecutor(mock, "alice")
+	stdout, _, code, err := exec.Run(context.Background(), "which", "brew")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if got := strings.TrimSpace(stdout); got != "/opt/homebrew/bin/brew" {
+		t.Errorf("stdout = %q, want /opt/homebrew/bin/brew (Run should delegate to RunAsUser)", got)
+	}
+}

--- a/internal/executor/user_aware_test.go
+++ b/internal/executor/user_aware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestNewUserAwareExecutor_Wrapping pins the wrapping decision. The fix dropped
@@ -48,7 +49,9 @@ func TestUserAwareExecutor_RunDelegatesNonRoot(t *testing.T) {
 	mock := NewMock()
 	mock.SetGOOS("darwin")
 	mock.SetIsRoot(false) // LaunchAgent: running as the user, not root
-	mock.SetCommand("/opt/homebrew/bin/brew\n", "", 0, "bash", "-c", "which brew")
+	// Args are individually shell-quoted before being joined into the RunAsUser
+	// command string, so the stub is keyed on the quoted form.
+	mock.SetCommand("/opt/homebrew/bin/brew\n", "", 0, "bash", "-c", "'which' 'brew'")
 
 	exec := NewUserAwareExecutor(mock, "alice")
 	stdout, _, code, err := exec.Run(context.Background(), "which", "brew")
@@ -60,5 +63,60 @@ func TestUserAwareExecutor_RunDelegatesNonRoot(t *testing.T) {
 	}
 	if got := strings.TrimSpace(stdout); got != "/opt/homebrew/bin/brew" {
 		t.Errorf("stdout = %q, want /opt/homebrew/bin/brew (Run should delegate to RunAsUser)", got)
+	}
+}
+
+// TestUserAwareExecutor_RunQuotesArgsWithSpaces is the regression for the
+// argv-splitting bug: now that the wrapper applies on the non-root LaunchAgent
+// path, Run must shell-quote each token so an argument containing spaces
+// survives as a single argv entry. Models the real LM Studio version probe
+// (FrameworkDetector → readPlistVersion → PlistBuddy) where both the "-c"
+// expression and the ".app" path contain spaces. The stub matches only if the
+// command string is correctly quoted.
+func TestUserAwareExecutor_RunQuotesArgsWithSpaces(t *testing.T) {
+	mock := NewMock()
+	mock.SetGOOS("darwin")
+	mock.SetIsRoot(false)
+	want := `'/usr/libexec/PlistBuddy' '-c' 'Print :CFBundleShortVersionString' '/Applications/LM Studio.app/Contents/Info.plist'`
+	mock.SetCommand("0.3.45\n", "", 0, "bash", "-c", want)
+
+	exec := NewUserAwareExecutor(mock, "alice")
+	stdout, _, code, err := exec.Run(
+		context.Background(),
+		"/usr/libexec/PlistBuddy",
+		"-c", "Print :CFBundleShortVersionString",
+		"/Applications/LM Studio.app/Contents/Info.plist",
+	)
+	if err != nil {
+		t.Fatalf("Run returned error — args likely not quoted, so the shell split the path/expression: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if strings.TrimSpace(stdout) != "0.3.45" {
+		t.Errorf("stdout = %q, want 0.3.45", stdout)
+	}
+}
+
+// TestUserAwareExecutor_RunInDirQuotesDirAndArgs verifies RunInDir quotes the
+// working directory too — a project under a path with spaces ("My Projects")
+// must cd correctly before the command runs.
+func TestUserAwareExecutor_RunInDirQuotesDirAndArgs(t *testing.T) {
+	mock := NewMock()
+	mock.SetGOOS("darwin")
+	mock.SetIsRoot(false)
+	want := `cd '/Users/alice/My Projects/app' && 'npm' 'ls' '--json'`
+	mock.SetCommand(`{"ok":true}`, "", 0, "bash", "-c", want)
+
+	exec := NewUserAwareExecutor(mock, "alice")
+	stdout, _, code, err := exec.RunInDir(context.Background(), "/Users/alice/My Projects/app", 10*time.Second, "npm", "ls", "--json")
+	if err != nil {
+		t.Fatalf("RunInDir returned error — dir/args likely not quoted: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if strings.TrimSpace(stdout) != `{"ok":true}` {
+		t.Errorf("stdout = %q, want {\"ok\":true}", stdout)
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -398,24 +398,30 @@ func Run(exec executor.Executor, log *progress.Logger, cfg *cli.Config) (err err
 		<-phaseDone
 	}()
 
-	// Detect logged-in user for running commands as the real user when root.
-	// Skip "root" — if LoggedInUser() fell back to CurrentUser(), delegating
-	// via sudo -H -u root is pointless and changes PATH/env behavior.
+	// Detect the logged-in user so package-manager commands run with that
+	// user's PATH/env in both deployment modes: as root (LaunchDaemon / MDM
+	// "Run Script") we sudo to them; as the user (LaunchAgent's periodic fire)
+	// we already are them but still go through their login shell because
+	// launchd hands a stripped PATH either way. Skip "root" — if LoggedInUser()
+	// fell back to CurrentUser() and that is root, there's no user context to
+	// adopt and delegating is pointless.
 	loggedInUsername := ""
 	if u, err := exec.LoggedInUser(); err == nil && u.Username != "root" {
 		loggedInUsername = u.Username
-		log.Debug("logged-in user detected: username=%q home=%q — commands will delegate via sudo", u.Username, u.HomeDir)
+		log.Debug("logged-in user detected: username=%q home=%q — commands will run through the user's login shell", u.Username, u.HomeDir)
 	} else if err != nil {
 		log.Warn("could not detect logged-in user (%v) — package manager commands will run as current user and may return different results", err)
 	} else {
 		log.Debug("LoggedInUser() returned root — not delegating")
 	}
 
-	// Create a user-aware executor that delegates commands to the logged-in user
-	// when running as root. This ensures tools like brew, pip3, npm etc. execute
-	// in the correct user context (many refuse to run as root or return different
-	// results). File-based detectors (IDE, extensions, MCP) use the original exec
-	// since file operations don't need user delegation.
+	// Create a user-aware executor that runs commands through the logged-in
+	// user's login shell (rc files sourced for a full PATH). This ensures tools
+	// like brew, pip3, npm etc. execute in the correct user context — launchd
+	// strips PATH whether the agent runs as root or as the user, and many tools
+	// refuse to run as root or return different results. File-based detectors
+	// (IDE, extensions, MCP) use the original exec since file operations don't
+	// need user delegation.
 	userExec := executor.NewUserAwareExecutor(exec, loggedInUsername)
 
 	// Resolve search dirs


### PR DESCRIPTION


## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
