### PR TITLE
chore(rc-config): enable pnpm/bun/yarn audits by default

### DIFF
--- a/internal/featuregate/featuregate.go
+++ b/internal/featuregate/featuregate.go
@@ -29,11 +29,11 @@ const (
 // backend support has merged.
 var enabled = map[Feature]bool{
 	// FeatureAIAgentHooks:    true,
-	FeatureNPMRCAudit:     true,
-	FeaturePipConfigAudit: true,
-	// FeaturePnpmConfigAudit: true,
-	// FeatureBunConfigAudit:  true,
-	// FeatureYarnConfigAudit: true,
+	FeatureNPMRCAudit:      true,
+	FeaturePipConfigAudit:  true,
+	FeaturePnpmConfigAudit: true,
+	FeatureBunConfigAudit:  true,
+	FeatureYarnConfigAudit: true,
 }
 
 var override bool

--- a/internal/featuregate/featuregate_test.go
+++ b/internal/featuregate/featuregate_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestIsEnabled_DefaultDeny(t *testing.T) {
 	resetOverride(t)
-	for _, f := range []Feature{FeatureAIAgentHooks, FeaturePnpmConfigAudit, FeatureBunConfigAudit, FeatureYarnConfigAudit} {
+	for _, f := range []Feature{FeatureAIAgentHooks} {
 		if IsEnabled(f) {
 			t.Errorf("%s should be gated by default", f)
 		}


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
