### PR TITLE
fix(node): discover pnpm globals (v10+ layout + store lockfile fallback)

### DIFF
--- a/internal/detector/nodedist_global.go
+++ b/internal/detector/nodedist_global.go
@@ -65,9 +65,14 @@ func NodeGlobalRoots(exec executor.Executor) []nodeGlobalRoot {
 		}
 	}
 
-	// --- pnpm: <pnpm-home>/global/<n>/node_modules (the <n> is a store-format id). ---
+	// --- pnpm globals. Layout varies by pnpm major:
+	//   - pnpm <=9: <pnpm-home>/global/<n>/node_modules       (<n> is a store-format id)
+	//   - pnpm v10+: <pnpm-home>/global/v<major>/<hash>/node_modules
+	//     (each `pnpm add -g` gets its own hashed install dir under global/v<major>)
+	// Match both so a modern pnpm's globals aren't silently missed.
 	for _, pnpmHome := range pnpmGlobalHomes(exec, home) {
 		addGlob("pnpm", filepath.Join(pnpmHome, "global", "*", "node_modules"))
+		addGlob("pnpm", filepath.Join(pnpmHome, "global", "*", "*", "node_modules"))
 	}
 
 	// --- yarn classic: ~/.config/yarn/global/node_modules. ---

--- a/internal/detector/nodescan.go
+++ b/internal/detector/nodescan.go
@@ -796,7 +796,16 @@ func (s *NodeScanner) scanGlobalPackagesFromDisk() []model.NodeScanResult {
 		if _, seen := byPM[r.pm]; !seen {
 			order = append(order, r.pm)
 		}
-		byPM[r.pm] = append(byPM[r.pm], s.dist.ScanGlobalModules(r.dir)...)
+		pkgs := s.dist.ScanGlobalModules(r.dir)
+		if len(pkgs) == 0 {
+			// pnpm (and other store-based managers) symlink the global
+			// node_modules into a content-addressed store the walk can't
+			// traverse, so it comes back empty. The install dir (parent of
+			// node_modules) carries the lockfile + package.json with the full
+			// resolved graph — parse that instead, keyed on the root's PM.
+			pkgs = s.dist.ScanProject(filepath.Dir(r.dir), r.pm)
+		}
+		byPM[r.pm] = append(byPM[r.pm], pkgs...)
 	}
 	results := make([]model.NodeScanResult, 0, len(order))
 	for _, pm := range order {


### PR DESCRIPTION
The disk-based global scan discovered **zero pnpm globals** (webpack/jest missing from device inventory). Two bugs:

1. **pnpm v10+ layout not enumerated.** `NodeGlobalRoots` only globbed `<pnpm-home>/global/*/node_modules` (pnpm <=9). pnpm v10+ nests each global install under `global/v<major>/<hash>/node_modules`, so the glob matched nothing. Added the extra-level glob.
2. **pnpm's node_modules is a symlinked content-addressed store**, so walking it yields nothing even once found. Added a fallback: when `ScanGlobalModules` returns empty, parse the install dir's lockfile (`pnpm-lock.yaml` + `package.json`, parent of node_modules) via the existing `ScanProject` path, keyed on the root's PM.

Verified in integration-test (linux dev_testing against this commit): `node global disk scan: pnpm -> 353 packages` (was 0); `jest` and `webpack` now resolve as pnpm globals. npm/yarn walk paths unchanged.