### PR TITLE
fix(node): enumerate yarn classic globals on Windows

### DIFF
--- a/internal/detector/nodedist_global.go
+++ b/internal/detector/nodedist_global.go
@@ -75,9 +75,22 @@ func NodeGlobalRoots(exec executor.Executor) []nodeGlobalRoot {
 		addGlob("pnpm", filepath.Join(pnpmHome, "global", "*", "*", "node_modules"))
 	}
 
-	// --- yarn classic: ~/.config/yarn/global/node_modules. ---
-	if home != "" {
-		add("yarn", filepath.Join(home, ".config", "yarn", "global", "node_modules"))
+	// --- yarn classic globals. Location differs by OS:
+	//   - POSIX:   ~/.config/yarn/global/node_modules
+	//   - Windows: %LOCALAPPDATA%\Yarn\Data\global\node_modules (yarn 1.x
+	//     `yarn global dir`); older builds used %LOCALAPPDATA%\Yarn\global.
+	// The POSIX path uses HOME/USERPROFILE, which never resolves the Windows
+	// yarn prefix, so yarn globals were invisible on Windows.
+	switch exec.GOOS() {
+	case model.PlatformWindows:
+		if localAppData := exec.Getenv("LOCALAPPDATA"); localAppData != "" {
+			add("yarn", filepath.Join(localAppData, "Yarn", "Data", "global", "node_modules"))
+			add("yarn", filepath.Join(localAppData, "Yarn", "global", "node_modules"))
+		}
+	default:
+		if home != "" {
+			add("yarn", filepath.Join(home, ".config", "yarn", "global", "node_modules"))
+		}
 	}
 
 	return roots


### PR DESCRIPTION
Follow-up to #159. `NodeGlobalRoots` only had the **POSIX** yarn global path (`~/.config/yarn/global/node_modules`), which never resolves on Windows — yarn 1.x installs globals to `%LOCALAPPDATA%\Yarn\Data\global`. So on Windows the disk scan found npm and pnpm globals but **not yarn** (`gulp`/`grunt-cli` missing), failing the pre-release global-discovery check on Windows while mac/linux passed.

Adds the Windows yarn global location(s). Verified in integration-test (Windows dev_testing): `node global disk scan: yarn -> 157 packages`, `global npm/pnpm/yarn — all 9 expected found`, `SUCCESS 18/0`.