### PR TITLE
feat(featuregate): enable device-policy enforcement by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ See [VERSIONING.md](VERSIONING.md) for why the version starts at 1.8.1.
 
 ### Added
 
-- **Device policy enforcement**: the agent now applies device policy profiles fetched from run-config, including OS-native enforcement of a VS Code extension allowlist. Policy identity is target-aware (category + target) and on-device state is keyed by category; state files written by a newer schema version are rejected.
+- **Device policy enforcement**: the agent now applies device policy profiles fetched from run-config, including OS-native enforcement of a VS Code extension allowlist. Policy identity is target-aware (category + target) and on-device state is keyed by category; state files written by a newer schema version are rejected. Generally available and enabled by default for all enterprise customers.
 - **Classic Visual Studio detection**: scans now discover classic Visual Studio installs and their extensions.
 - **Disk-based package scanning**: npm packages are discovered by parsing lockfiles and Python packages by reading `dist-info` metadata on disk, so package inventory no longer depends solely on invoking the package manager.
 - **Run-on-login scheduling and scheduler diagnostics**: scans can be scheduled to run on login, Windows Task Scheduler history is enabled, and a new scheduler-info subsystem reports cross-platform scheduling state for troubleshooting.

--- a/internal/featuregate/featuregate.go
+++ b/internal/featuregate/featuregate.go
@@ -35,11 +35,7 @@ var enabled = map[Feature]bool{
 	FeaturePnpmConfigAudit: true,
 	FeatureBunConfigAudit:  true,
 	FeatureYarnConfigAudit: true,
-	// FeatureDevicePolicy stays gated until GA: the backend's
-	// MinEnforcementAgentVersion is still a placeholder (1.13.0) and the agent
-	// version floor has not been finalized. Enable via --override-gate /
-	// STEPSECURITY_OVERRIDE_GATE=1 for dogfooding.
-	// FeatureDevicePolicy: true,
+	FeatureDevicePolicy:    true,
 }
 
 var override bool


### PR DESCRIPTION
## What

Turns on the `device-policy` feature gate by default, so Developer MDM
IDE-extension policy enforcement runs for all enterprise customers instead of
staying behind the beta gate.

## Why now

All enforcement code is already merged to `main`:

- run-config policy fetch with target-aware identity (`category` + `target`)
- user-scope `settings.json` convergence for the VS Code `extensions.allowed` allowlist
- compliance reporting
- the Windows-SYSTEM inline-enforce guard

The capability has been dormant behind `FeatureDevicePolicy`. The agent-api
backend's `MinEnforcementAgentVersion` is now **1.13.0**, matching this build's
version floor, so enabling enforcement is safe.

## Changes

- `internal/featuregate/featuregate.go` — set `FeatureDevicePolicy: true` (drop the stale gate comment).
- `CHANGELOG.md` — note general availability + enabled-by-default on the existing 1.13.0 entry.

## Verification

- `go build ./...`
- `go test ./internal/featuregate/... ./internal/devicepolicy/...` — green
- No test asserts the gate is disabled.

## Safety

- Community-mode installs (no enterprise config) remain a silent no-op.
- A device already governed by a real MDM policy is reported `mdm_managed`, not overwritten.
