### PR TITLE
fix(ci): wait for release-list propagation before resolving draft tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,13 @@ jobs:
           # GoReleaser creates draft releases under an "untagged-*" slug,
           # so gh release upload by version tag returns 404. Look up the
           # actual tag GitHub assigned to the draft.
+          #
+          # The release list endpoint lags the write by a few seconds when
+          # the release is tied to a tag pushed earlier in this same job
+          # (GitHub hasn't finished indexing the tag yet) — querying
+          # immediately can return an empty list even though the release
+          # exists. Give it a moment before looking it up.
+          sleep 30
           release_tag=$(gh api "repos/${{ github.repository }}/releases" \
             --jq '[.[] | select(.draft and .tag_name == "${{ steps.version.outputs.tag }}")] | first | .tag_name')
           if [ -z "$release_tag" ] || [ "$release_tag" = "null" ]; then


### PR DESCRIPTION
GoReleaser creates the draft release for a tag pushed earlier in the same job, and GitHub can take a few seconds to index that tag before the new release shows up in the releases-list API. Querying immediately can return an empty list and fail with "Could not find draft release", even though the release was created successfully.

Add a fixed 30s sleep before the lookup to give GitHub's API time to catch up.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
