### PR TITLE
fix(ci): pin repo target for gh release upload/delete-asset in macOS …

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -214,6 +214,7 @@ jobs:
           set -euo pipefail
           version="${{ steps.version.outputs.version }}"
           gh release upload "${{ inputs.tag }}" \
+            -R "${{ github.repository }}" \
             "dist/stepsecurity-dev-machine-guard-${version}-darwin" \
             "dist/stepsecurity-dev-machine-guard-darwin.bundle" \
             --clobber
@@ -221,6 +222,7 @@ jobs:
           # The unsigned binary should not remain on the release; best-effort
           # cleanup so users only see the notarized artifact.
           gh release delete-asset "${{ inputs.tag }}" \
+            -R "${{ github.repository }}" \
             "stepsecurity-dev-machine-guard-${version}-darwin_unnotarized" -y || true
 
       - name: Attest darwin build provenance


### PR DESCRIPTION
…notarize job

This job never checks out the repo, so gh has no git remote to infer the target repository from. The upload/cleanup step omitted -R and failed with "not a git repository", unlike the earlier download step which already passes -R.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
