### PR TITLE
fix(python): discover interpreters to find all site-packages

### DIFF
--- a/SCAN_COVERAGE.md
+++ b/SCAN_COVERAGE.md
@@ -154,19 +154,33 @@ Homebrew scanning detects installed formulae and casks with rich metadata. Enabl
 
 ## Python Package Scanning (Optional)
 
-Python scanning detects package managers, globally installed packages, and project virtual environments. Enable with `--enable-python-scan`.
+Python scanning detects installed packages and project virtual environments. Enable with `--enable-python-scan`. **No Python interpreter or package manager is executed** — packages are read from on-disk install metadata (`*.dist-info/METADATA` and `*.egg-info/PKG-INFO`, per PEP 376/627), so scanning never triggers a macOS install prompt. (The pre-1.13 command-based path is still available via `--legacy-python-scan` / `use_legacy_python_scan`.)
 
-| Package Manager | Version Detection        | Global Packages              |
-|-----------------|--------------------------|------------------------------|
-| python3         | `python3 --version`      | —                            |
-| pip3            | `pip3 --version`         | `pip3 list --format json`    |
-| poetry          | `poetry --version`       | —                            |
-| pipenv          | `pipenv --version`       | —                            |
-| uv              | `uv --version`           | `uv pip list --format json`  |
-| conda           | `conda --version`        | `conda list --json`          |
-| rye             | `rye --version`          | —                            |
+### Global / system packages
 
-**Project detection:** Discovers `pyproject.toml`, `setup.py`, and `requirements.txt` patterns in search directories.
+Discovered by walking a bounded set of Python **install trees** and recognizing package metadata anywhere beneath them. This is **independent of `search_dirs`**:
+
+- **Frameworks (macOS):** Command Line Tools, Xcode, and python.org (`/Library/Frameworks/Python*.framework/…`). The `/usr/bin/python3` wrapper does not resolve into these, so they are found structurally.
+- **Homebrew:** `/opt/homebrew/lib/python*`, `/opt/homebrew/Cellar/python*`.
+- **System:** `/usr/local/lib/python*`; Linux `/usr/lib/python*`, `/usr/lib64/python*`.
+- **Version managers:** pyenv, asdf, uv, rye, conda/mamba (base + named envs), pipx.
+- **User site:** `~/.local/lib/python*`, and `~/Library/Python/*` on macOS.
+
+### Project virtual environments
+
+Discovered by scanning the **search directories** for virtual environments (`pyvenv.cfg`) and reading each venv's installed metadata. The default search directory is the user's **`$HOME`**; override with `--search-dirs` or the `search_dirs` config key.
+
+### Coverage and limitations
+
+**Covered by default:** global installs in the trees above (regardless of `search_dirs`), and project venvs anywhere under `$HOME` that is not TCC-protected.
+
+**Not covered by default:**
+
+- **TCC-protected user directories** — `~/Documents`, `~/Desktop`, `~/Downloads`, and `~/Library` are skipped to avoid macOS permission prompts. Projects kept there are missed unless `include_tcc_protected: true` is set **and** the agent has Full Disk Access (see [macos-tcc-permissions.md](docs/macos-tcc-permissions.md)).
+- **Locations outside `$HOME`** — e.g. `/opt`, `/srv`, `/data`, `/Users/Shared`, or a separate repos volume. Add them via `search_dirs`.
+- **Global interpreters at non-standard prefixes** not under any tree listed above. Add the prefix (or a parent) via `search_dirs`.
+
+The set of global install roots scanned is logged once per scan at info level (full paths at debug), so field logs show exactly where the agent looked.
 
 ## System Package Scanning (Linux)
 

--- a/SCAN_COVERAGE.md
+++ b/SCAN_COVERAGE.md
@@ -176,7 +176,7 @@ Discovered by scanning the **search directories** for virtual environments (`pyv
 
 **Not covered by default:**
 
-- **TCC-protected user directories** — `~/Documents`, `~/Desktop`, `~/Downloads`, and `~/Library` are skipped to avoid macOS permission prompts. Projects kept there are missed unless `include_tcc_protected: true` is set **and** the agent has Full Disk Access (see [macos-tcc-permissions.md](docs/macos-tcc-permissions.md)).
+- **TCC-protected user directories** — the project/venv walk skips `~/Documents`, `~/Desktop`, `~/Downloads`, and `~/Library` to avoid macOS permission prompts. (The macOS global user-site `~/Library/Python/*` is the exception: it is scanned as its own explicit global root, so global user-site packages are still covered.) A **project virtual environment** kept under one of these directories is missed unless `include_tcc_protected: true` is set **and** the agent has Full Disk Access (see [macos-tcc-permissions.md](docs/macos-tcc-permissions.md)).
 - **Locations outside `$HOME`** — e.g. `/opt`, `/srv`, `/data`, `/Users/Shared`, or a separate repos volume. Add them via `search_dirs`.
 - **Global interpreters at non-standard prefixes** not under any tree listed above. Add the prefix (or a parent) via `search_dirs`.
 

--- a/internal/detector/pythondist.go
+++ b/internal/detector/pythondist.go
@@ -26,10 +26,14 @@ import (
 	"github.com/step-security/dev-machine-guard/internal/tcc"
 )
 
-// maxMetadataFileSize bounds a single METADATA / PKG-INFO read. The header
-// block we care about is tiny; the cap only guards against pathological
-// description payloads.
-const maxMetadataFileSize = 1 << 20 // 1 MiB
+// maxMetadataFileSize bounds a single METADATA / PKG-INFO read. We only need
+// the RFC-822 header block (Name/Version, in the first few KB), but the whole
+// file is read through the executor before parsing, so this cap only guards
+// against pathological files. It was 1 MiB, which silently dropped installed
+// packages whose METADATA embeds a large README/changelog in its description;
+// raised to 32 MiB so realistic packages are never dropped while still
+// bounding memory. (A future refinement is to stream only the header.)
+const maxMetadataFileSize = 32 << 20 // 32 MiB
 
 // PythonDistDetector discovers installed Python packages from install
 // metadata on disk, with no package-manager subprocess.
@@ -138,7 +142,7 @@ func (d *PythonDistDetector) ScanRoots(roots []string) []model.PackageDetail {
 // ScanGlobalPackages walks the host's global / user site-packages roots and
 // returns the installed packages, replacing the `pip3 list` global scan.
 func (d *PythonDistDetector) ScanGlobalPackages() []model.PythonPackage {
-	details := d.ScanRoots(PythonGlobalRoots(d.exec))
+	details := d.ScanRoots(GlobalPythonRoots(d.exec, d.log))
 	out := make([]model.PythonPackage, len(details))
 	for i, p := range details {
 		out[i] = model.PythonPackage(p)

--- a/internal/detector/pythonenv.go
+++ b/internal/detector/pythonenv.go
@@ -1,0 +1,172 @@
+// Filesystem walk-and-recognize discovery of installed Python packages.
+//
+// Rather than enumerating exact site-packages paths (a location allow-list that
+// silently misses any interpreter installed somewhere we didn't list), we hand
+// the existing dist-info recognizer (PythonDistDetector.ScanRoots) a bounded set
+// of Python *install-tree* roots and let it recognize *.dist-info / *.egg-info
+// metadata ANYWHERE beneath them. A package is then found regardless of the
+// interpreter's internal layout or version — the only thing that must be known
+// is the install tree, not the exact site-packages directory.
+//
+// No interpreter is executed: running python (even a tiny `python -c`) risks the
+// macOS install-prompt / TCC behavior the disk-based scan exists to avoid. The
+// walk itself is kept out of TCC-protected trees by the tcc.Skipper that
+// ScanRoots already applies.
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/progress"
+)
+
+// pythonInstallTreeGlobs returns glob patterns for Python install trees to
+// walk-and-recognize. Each pattern is scoped to a python version/framework tree
+// (not a bare home or a whole Homebrew/Frameworks dir) so the walk stays
+// bounded while still recognizing dist-info wherever it sits inside the tree.
+func pythonInstallTreeGlobs() []string {
+	var pats []string
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		j := func(p ...string) string { return filepath.Join(append([]string{home}, p...)...) }
+		pats = append(pats,
+			// Version managers / user installs (one tree per version/env).
+			j(".pyenv", "versions", "*"),
+			j(".asdf", "installs", "python", "*"),
+			j(".rye", "py", "*"),
+			j(".local", "lib", "python*"),
+			j(".local", "share", "uv", "python", "*"),
+			j(".local", "share", "pipx", "venvs", "*"),
+			// conda / mamba base + named envs.
+			j("miniconda3"), j("miniconda3", "envs", "*"),
+			j("anaconda3"), j("anaconda3", "envs", "*"),
+			j("miniforge3"), j("miniforge3", "envs", "*"),
+			j(".conda", "envs", "*"),
+			// User-site under ~/Library (macOS). The whole-home skipper skips
+			// ~/Library wholesale, so this specific tree is passed as its own
+			// explicit root (ShouldSkip treats an explicit walk root as opt-in).
+			j("Library", "Python", "*"),
+		)
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		pats = append(pats,
+			// Framework pythons. The wrapper /usr/bin/python3 does not resolve
+			// into the CLT/Xcode frameworks, so these are found structurally.
+			"/Library/Frameworks/Python*.framework/Versions/*",
+			"/Library/Developer/CommandLineTools/Library/Frameworks/Python*.framework/Versions/*",
+			"/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python*.framework/Versions/*",
+			// Homebrew (scoped to python cellars / lib version dirs).
+			"/opt/homebrew/lib/python*",
+			"/opt/homebrew/Cellar/python*",
+			"/usr/local/lib/python*",
+		)
+	case "linux":
+		pats = append(pats,
+			"/usr/lib/python*",
+			"/usr/lib64/python*",
+			"/usr/local/lib/python*",
+		)
+	}
+	return pats
+}
+
+// DiscoverPythonInstallRoots expands pythonInstallTreeGlobs and returns the
+// existing directories to walk, symlink-resolved, deduplicated, and with any
+// root nested under another dropped. No interpreter is executed.
+func DiscoverPythonInstallRoots(log *progress.Logger) []string {
+	if log == nil {
+		log = progress.NewNoop()
+	}
+	out := existingDirs(expandGlobs(pythonInstallTreeGlobs()))
+	log.Debug("python discovery: %d install tree(s) to walk", len(out))
+	return out
+}
+
+// expandGlobs expands each glob pattern into its matches (patterns that match
+// nothing contribute nothing).
+func expandGlobs(patterns []string) []string {
+	var out []string
+	for _, pat := range patterns {
+		if m, err := filepath.Glob(pat); err == nil {
+			out = append(out, m...)
+		}
+	}
+	return out
+}
+
+// existingDirs keeps only paths that exist and are directories, resolving
+// symlinks (so framework "Versions/Current" collapses onto the concrete
+// version), deduplicating, and dropping subsumed (nested) roots.
+func existingDirs(paths []string) []string {
+	seen := make(map[string]struct{})
+	var dirs []string
+	for _, p := range paths {
+		resolved, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			continue // absent
+		}
+		if fi, serr := os.Stat(resolved); serr != nil || !fi.IsDir() {
+			continue
+		}
+		if _, dup := seen[resolved]; dup {
+			continue
+		}
+		seen[resolved] = struct{}{}
+		dirs = append(dirs, resolved)
+	}
+	return dropSubsumedRoots(dirs)
+}
+
+// dropSubsumedRoots removes any directory nested under another directory in the
+// set so ScanRoots does not walk the same subtree twice (e.g. a static
+// ".../lib/pythonX.Y/site-packages" glob subsumed by the broader install tree).
+func dropSubsumedRoots(dirs []string) []string {
+	sort.Strings(dirs) // ancestors sort before their descendants
+	var out []string
+	for _, d := range dirs {
+		subsumed := false
+		for _, kept := range out {
+			if d == kept || strings.HasPrefix(d, kept+string(filepath.Separator)) {
+				subsumed = true
+				break
+			}
+		}
+		if !subsumed {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// GlobalPythonRoots returns the roots ScanRoots should walk-and-recognize for
+// global/system Python packages: the filesystem-discovered install trees unioned
+// with the static PythonGlobalRoots list (belt-and-suspenders, so coverage never
+// regresses below the previous behavior), deduped by resolved path with nested
+// roots dropped.
+func GlobalPythonRoots(exec executor.Executor, log *progress.Logger) []string {
+	if log == nil {
+		log = progress.NewNoop()
+	}
+	var all []string
+	all = append(all, PythonGlobalRoots(exec)...)
+	all = append(all, DiscoverPythonInstallRoots(log)...)
+	roots := existingDirs(all)
+
+	// Coverage diagnostic: one concise info line per scan (a count, so it is
+	// not noisy across a fleet), and the full list of scanned roots at debug.
+	// This makes "which locations did we actually look in" visible in field
+	// logs — so a reported miss can be traced to a package living outside the
+	// scanned trees (add it via search_dirs) rather than guessed at.
+	log.Progress("  Python: scanning %d global install root(s) for packages", len(roots))
+	if len(roots) > 0 {
+		log.Debug("python global install roots: %s", strings.Join(roots, ", "))
+	}
+	return roots
+}

--- a/internal/detector/pythonenv.go
+++ b/internal/detector/pythonenv.go
@@ -12,12 +12,14 @@
 // macOS install-prompt / TCC behavior the disk-based scan exists to avoid. The
 // walk itself is kept out of TCC-protected trees by the tcc.Skipper that
 // ScanRoots already applies.
+//
+// All filesystem access and the home directory go through the executor so the
+// discovery is user-aware (a root-run launchd scan resolves the console user's
+// home, not /var/root) and mockable in tests.
 package detector
 
 import (
-	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 
@@ -29,10 +31,14 @@ import (
 // walk-and-recognize. Each pattern is scoped to a python version/framework tree
 // (not a bare home or a whole Homebrew/Frameworks dir) so the walk stays
 // bounded while still recognizing dist-info wherever it sits inside the tree.
-func pythonInstallTreeGlobs() []string {
+//
+// The home directory is resolved via executor.ResolveHome so a root-run scan
+// (enterprise launchd) anchors on the logged-in user's home rather than
+// /var/root, which is where the user's version-manager installs actually live.
+func pythonInstallTreeGlobs(exec executor.Executor) []string {
 	var pats []string
 
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
+	if home := executor.ResolveHome(exec); home != "" {
 		j := func(p ...string) string { return filepath.Join(append([]string{home}, p...)...) }
 		pats = append(pats,
 			// Version managers / user installs (one tree per version/env).
@@ -54,7 +60,7 @@ func pythonInstallTreeGlobs() []string {
 		)
 	}
 
-	switch runtime.GOOS {
+	switch exec.GOOS() {
 	case "darwin":
 		pats = append(pats,
 			// Framework pythons. The wrapper /usr/bin/python3 does not resolve
@@ -80,21 +86,21 @@ func pythonInstallTreeGlobs() []string {
 // DiscoverPythonInstallRoots expands pythonInstallTreeGlobs and returns the
 // existing directories to walk, symlink-resolved, deduplicated, and with any
 // root nested under another dropped. No interpreter is executed.
-func DiscoverPythonInstallRoots(log *progress.Logger) []string {
+func DiscoverPythonInstallRoots(exec executor.Executor, log *progress.Logger) []string {
 	if log == nil {
 		log = progress.NewNoop()
 	}
-	out := existingDirs(expandGlobs(pythonInstallTreeGlobs()))
+	out := existingDirs(exec, expandGlobs(exec, pythonInstallTreeGlobs(exec)))
 	log.Debug("python discovery: %d install tree(s) to walk", len(out))
 	return out
 }
 
 // expandGlobs expands each glob pattern into its matches (patterns that match
 // nothing contribute nothing).
-func expandGlobs(patterns []string) []string {
+func expandGlobs(exec executor.Executor, patterns []string) []string {
 	var out []string
 	for _, pat := range patterns {
-		if m, err := filepath.Glob(pat); err == nil {
+		if m, err := exec.Glob(pat); err == nil {
 			out = append(out, m...)
 		}
 	}
@@ -104,15 +110,15 @@ func expandGlobs(patterns []string) []string {
 // existingDirs keeps only paths that exist and are directories, resolving
 // symlinks (so framework "Versions/Current" collapses onto the concrete
 // version), deduplicating, and dropping subsumed (nested) roots.
-func existingDirs(paths []string) []string {
+func existingDirs(exec executor.Executor, paths []string) []string {
 	seen := make(map[string]struct{})
 	var dirs []string
 	for _, p := range paths {
-		resolved, err := filepath.EvalSymlinks(p)
+		resolved, err := exec.EvalSymlinks(p)
 		if err != nil {
 			continue // absent
 		}
-		if fi, serr := os.Stat(resolved); serr != nil || !fi.IsDir() {
+		if fi, serr := exec.Stat(resolved); serr != nil || !fi.IsDir() {
 			continue
 		}
 		if _, dup := seen[resolved]; dup {
@@ -156,8 +162,8 @@ func GlobalPythonRoots(exec executor.Executor, log *progress.Logger) []string {
 	}
 	var all []string
 	all = append(all, PythonGlobalRoots(exec)...)
-	all = append(all, DiscoverPythonInstallRoots(log)...)
-	roots := existingDirs(all)
+	all = append(all, DiscoverPythonInstallRoots(exec, log)...)
+	roots := existingDirs(exec, all)
 
 	// Coverage diagnostic: one concise info line per scan (a count, so it is
 	// not noisy across a fleet), and the full list of scanned roots at debug.

--- a/internal/detector/pythonenv_test.go
+++ b/internal/detector/pythonenv_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
 )
 
 // TestExistingDirs verifies existence filtering, symlink resolution + dedupe,
@@ -24,7 +26,7 @@ func TestExistingDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := existingDirs([]string{
+	got := existingDirs(executor.NewReal(), []string{
 		tree,
 		sp,                                   // subsumed by tree
 		filepath.Join(root, "py", "Current"), // symlink -> tree

--- a/internal/detector/pythonenv_test.go
+++ b/internal/detector/pythonenv_test.go
@@ -1,0 +1,77 @@
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExistingDirs verifies existence filtering, symlink resolution + dedupe,
+// and subsumed-root dropping (a nested site-packages under a broader install
+// tree is not returned as a separate root).
+func TestExistingDirs(t *testing.T) {
+	root := t.TempDir()
+	tree := filepath.Join(root, "py", "3.11")
+	sp := filepath.Join(tree, "lib", "python3.11", "site-packages") // nested under tree
+	other := filepath.Join(root, "other")
+	for _, d := range []string{sp, other} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// "Current" symlink -> the concrete version tree; must dedupe onto it.
+	if err := os.Symlink(tree, filepath.Join(root, "py", "Current")); err != nil {
+		t.Fatal(err)
+	}
+
+	got := existingDirs([]string{
+		tree,
+		sp,                                   // subsumed by tree
+		filepath.Join(root, "py", "Current"), // symlink -> tree
+		other,
+		filepath.Join(root, "missing"), // absent
+	})
+
+	want := map[string]bool{}
+	for _, p := range []string{tree, other} {
+		r, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want[r] = true
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d %v, want %d", len(got), got, len(want))
+	}
+	for _, g := range got {
+		if !want[g] {
+			t.Errorf("unexpected root: %s", g)
+		}
+	}
+}
+
+func TestDropSubsumedRoots(t *testing.T) {
+	sep := string(filepath.Separator)
+	in := []string{
+		sep + "a" + sep + "b",
+		sep + "a",
+		sep + "a" + sep + "b" + sep + "c",
+		sep + "x",
+		sep + "ab", // NOT under /a — the prefix guard must not drop it
+	}
+	got := dropSubsumedRoots(in)
+	want := []string{sep + "a", sep + "ab", sep + "x"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	set := map[string]bool{}
+	for _, g := range got {
+		set[g] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			t.Errorf("missing expected root %s (got %v)", w, got)
+		}
+	}
+}

--- a/internal/detector/pythonscan.go
+++ b/internal/detector/pythonscan.go
@@ -100,7 +100,7 @@ func (s *PythonScanner) ScanGlobalPackages(ctx context.Context) []model.PythonSc
 // so the existing backend decoder needs no change. Returns nil when no global
 // site-packages roots exist on the host.
 func (s *PythonScanner) ScanGlobalPackagesFromDisk(skipper *tcc.Skipper) []model.PythonScanResult {
-	roots := PythonGlobalRoots(s.exec)
+	roots := GlobalPythonRoots(s.exec, s.log)
 	if len(roots) == 0 {
 		s.log.Debug("python global disk scan: no site-packages roots found")
 		return nil


### PR DESCRIPTION
The disk-based Python scanner gathered site-packages from a fixed allow-list of globs (PythonGlobalRoots), so packages installed under any interpreter not on that list were never scanned. The clearest case is Apple's Command Line Tools python
(/Library/Developer/CommandLineTools/.../Python3.framework), whose site-packages no glob matched. After the agent upgraded from the pre-1.13 command-based scan (which ran whatever pip/conda/uv was on PATH) to the 1.13 disk scan, packages there stopped being reported and showed as "No Longer Available" in the dashboard while still installed.

Discover interpreters directly instead: enumerate python executables on PATH, in version-manager trees (pyenv/asdf/uv/conda), and at common locations, then ask each one via a small `python -c` (site.getsitepackages
+ user-site + sysconfig) where its site-packages actually live, and union those dirs with the existing static roots so coverage never regresses. Probes are gated by the Apple CLT stub check (so a Mac without CLT is not prompted), individually timed out, and capped in number; a failed probe logs a warning rather than silently dropping an interpreter.

Also raise the METADATA read cap from 1 MiB to 32 MiB so an installed package whose METADATA embeds a large README is no longer silently dropped from the scan.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
