### PR TITLE
fix(macos): read AI tool versions from package.json to avoid Gatekeeper malware prompt

### DIFF
--- a/internal/detector/agent.go
+++ b/internal/detector/agent.go
@@ -125,6 +125,13 @@ func (d *AgentDetector) findConfigDir(spec agentSpec, homeDir string) string {
 }
 
 func (d *AgentDetector) getVersion(ctx context.Context, binaryPath string) string {
+	// Static-first: read the npm package.json version rather than executing the
+	// agent binary, which on macOS can trigger a Gatekeeper malware prompt when
+	// a Node CLI dlopen's a quarantined native addon — see versionFromPackageJSON.
+	if v := versionFromPackageJSON(d.exec, binaryPath); v != "" {
+		return v
+	}
+	// Fallback: standalone (non-npm) binaries have no package.json; exec them.
 	stdout, _, _, err := d.exec.RunWithTimeout(ctx, 10*time.Second, binaryPath, "--version")
 	if err != nil {
 		return "unknown"

--- a/internal/detector/agent_test.go
+++ b/internal/detector/agent_test.go
@@ -233,3 +233,42 @@ func TestAgentDetector_Windows_ClaudeCowork(t *testing.T) {
 		t.Error("claude-cowork not found")
 	}
 }
+
+// TestAgentDetector_VersionFromPackageJSON asserts an npm-packaged agent's
+// version is read from package.json rather than by executing the binary — the
+// macOS Gatekeeper fix (see versionFromPackageJSON). The stubbed `--version`
+// output differs so a regression to the exec path would flip the assertion.
+func TestAgentDetector_VersionFromPackageJSON(t *testing.T) {
+	mock := executor.NewMock()
+	shim := "/usr/local/bin/openclaw"
+	target := "/usr/local/lib/node_modules/openclaw/bin/openclaw.js"
+	pkgRoot := "/usr/local/lib/node_modules/openclaw"
+	mock.SetPath("openclaw", shim)
+	mock.SetSymlink(shim, target)
+	mock.SetFile(pkgRoot+"/package.json", []byte(`{"name":"openclaw","version":"3.4.5"}`))
+	mock.SetCommand("0.0.0-exec-should-not-run\n", "", 0, shim, "--version")
+	mock.SetDir("/Users/testuser/.openclaw")
+	mock.SetDirEntries("/Users/testuser/.openclaw", []os.DirEntry{
+		executor.MockDirEntry("config.toml", false),
+	})
+
+	det := NewAgentDetector(mock)
+	results := det.Detect(context.Background(), []string{"/Users/testuser"})
+
+	var got *agentResult
+	for i, r := range results {
+		if r.Name == "openclaw" {
+			got = &agentResult{r}
+			_ = i
+		}
+	}
+	if got == nil {
+		t.Fatal("openclaw not found")
+	}
+	if got.Version != "3.4.5" {
+		t.Errorf("expected version 3.4.5 (read from package.json), got %s — exec fallback may have run", got.Version)
+	}
+	if got.InstallPath != pkgRoot {
+		t.Errorf("expected install_path %s (npm package root), got %s", pkgRoot, got.InstallPath)
+	}
+}

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -160,20 +160,63 @@ func resolveInstallPath(exec executor.Executor, binaryPath string) string {
 	if binaryPath == "" {
 		return ""
 	}
-	resolved, err := exec.EvalSymlinks(binaryPath)
-	if err != nil || resolved == "" {
-		resolved = binaryPath
+	resolved := resolveRealPath(exec, binaryPath)
+	if pkgRoot := nodePackageRoot(exec, resolved); pkgRoot != "" {
+		return pkgRoot
 	}
-	if pkgRoot := nodeModulesPackageRoot(resolved); pkgRoot != "" {
+	return resolved
+}
+
+// resolveRealPath follows symlinks, returning the resolved real path — or the
+// original path unchanged when resolution fails or yields nothing.
+func resolveRealPath(exec executor.Executor, path string) string {
+	if resolved, err := exec.EvalSymlinks(path); err == nil && resolved != "" {
+		return resolved
+	}
+	return path
+}
+
+// nodePackageRoot returns the npm package root that owns resolvedPath (already
+// symlink-resolved), or "" when the path isn't inside a node_modules tree.
+// Handles both the Unix symlink layout (target lives under node_modules) and
+// the Windows shim layout (a `.cmd`/`.ps1`/`.bat` shim that references
+// node_modules in its body). Shared by resolveInstallPath (install location)
+// and versionFromPackageJSON (static version read).
+func nodePackageRoot(exec executor.Executor, resolvedPath string) string {
+	if pkgRoot := nodeModulesPackageRoot(resolvedPath); pkgRoot != "" {
 		return pkgRoot
 	}
 	// Windows: npm publishes a `.cmd` (and `.ps1`) shim instead of a symlink,
 	// so the resolved path points at the shim itself, not the package. Parse
 	// the shim to recover the node_modules package root.
-	if pkgRoot := npmShimPackageRoot(exec, resolved); pkgRoot != "" {
-		return pkgRoot
+	return npmShimPackageRoot(exec, resolvedPath)
+}
+
+// versionFromPackageJSON returns the version recorded in the npm package.json
+// of the package that owns binaryPath, or "" when the binary isn't an
+// npm-installed package (a standalone binary, symlink resolution that lands
+// outside node_modules, or no parseable package.json).
+//
+// Reading the version statically lets the AI-tool detectors avoid launching
+// the CLI. On macOS, executing a Node-based CLI boots Node, which dlopen's the
+// tool's native .node addons during module init — before argv is even parsed —
+// so a quarantined addon (e.g. merkle-tree-napi.darwin-arm64.node) makes
+// Gatekeeper pop an "Apple could not verify … is free of malware" prompt at
+// the end user. npm's "version" is a required, canonical package.json field
+// (semver), so this is authoritative rather than a heuristic. Mirrors the
+// static-first version resolution already used for IDEs in resolveDarwinVersion.
+func versionFromPackageJSON(exec executor.Executor, binaryPath string) string {
+	if binaryPath == "" {
+		return ""
 	}
-	return resolved
+	pkgRoot := nodePackageRoot(exec, resolveRealPath(exec, binaryPath))
+	if pkgRoot == "" {
+		return ""
+	}
+	if v := readJSONVersion(exec, filepath.Join(pkgRoot, "package.json")); v != "unknown" {
+		return v
+	}
+	return ""
 }
 
 // npmShimPackageRoot reads a Windows-style npm shim (`<bin>.cmd`,
@@ -290,6 +333,15 @@ func (d *AICLIDetector) findBinary(ctx context.Context, spec cliToolSpec, homeDi
 }
 
 func (d *AICLIDetector) getVersion(ctx context.Context, spec cliToolSpec, binaryPath string) string {
+	// Static-first: npm-packaged CLIs carry their version in package.json, so
+	// read it rather than executing the CLI. This avoids the macOS Gatekeeper
+	// malware prompt that launching a Node CLI can trigger — see
+	// versionFromPackageJSON.
+	if v := versionFromPackageJSON(d.exec, binaryPath); v != "" {
+		return v
+	}
+	// Fallback: standalone (non-npm) binaries have no package.json to read, so
+	// exec them for their version. These are typically notarized, so no prompt.
 	flag := "--version"
 	if spec.VersionFlag != "" {
 		flag = spec.VersionFlag

--- a/internal/detector/aicli_test.go
+++ b/internal/detector/aicli_test.go
@@ -381,3 +381,81 @@ func TestAICLIDetector_FindsCursorAgentInLocalBin(t *testing.T) {
 		t.Error("cursor-agent not found via ~/.local/bin fallback")
 	}
 }
+
+// TestAICLIDetector_VersionFromPackageJSON asserts the detector reads the
+// version from the npm package.json when the binary resolves into a
+// node_modules tree, and does NOT fall back to executing the CLI. This is the
+// macOS Gatekeeper fix: launching a Node CLI can dlopen a quarantined native
+// addon and pop a malware prompt, so the static read must win. The stubbed
+// `--version` output is deliberately different so a regression that re-enables
+// the exec path would change the asserted version.
+func TestAICLIDetector_VersionFromPackageJSON(t *testing.T) {
+	mock := executor.NewMock()
+	shim := "/usr/local/bin/claude"
+	target := "/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+	pkgRoot := "/usr/local/lib/node_modules/@anthropic-ai/claude-code"
+	mock.SetPath("claude", shim)
+	mock.SetSymlink(shim, target)
+	mock.SetFile(pkgRoot+"/package.json", []byte(`{"name":"@anthropic-ai/claude-code","version":"2.1.209"}`))
+	// If the exec fallback ever runs, the version would be this instead.
+	mock.SetCommand("0.0.0-exec-should-not-run\n", "", 0, shim, "--version")
+	mock.SetDir("/Users/testuser/.claude")
+
+	det := NewAICLIDetector(mock)
+	results := det.Detect(context.Background())
+
+	var got *model.AITool
+	for i, r := range results {
+		if r.Name == "claude-code" {
+			got = &results[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("claude-code not found")
+	}
+	if got.Version != "2.1.209" {
+		t.Errorf("expected version 2.1.209 (read from package.json), got %s — exec fallback may have run", got.Version)
+	}
+}
+
+// TestVersionFromPackageJSON exercises the shared helper directly across the
+// layouts the three AI-tool detectors feed it.
+func TestVersionFromPackageJSON(t *testing.T) {
+	shim := "/usr/local/bin/claude"
+	target := "/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+	pkgRoot := "/usr/local/lib/node_modules/@anthropic-ai/claude-code"
+
+	t.Run("npm package with package.json", func(t *testing.T) {
+		mock := executor.NewMock()
+		mock.SetSymlink(shim, target)
+		mock.SetFile(pkgRoot+"/package.json", []byte(`{"version":"1.2.3"}`))
+		if v := versionFromPackageJSON(mock, shim); v != "1.2.3" {
+			t.Errorf("want 1.2.3, got %q", v)
+		}
+	})
+
+	t.Run("npm package without package.json falls through to empty", func(t *testing.T) {
+		mock := executor.NewMock()
+		mock.SetSymlink(shim, target)
+		// No package.json registered.
+		if v := versionFromPackageJSON(mock, shim); v != "" {
+			t.Errorf("want empty (caller should exec-fallback), got %q", v)
+		}
+	})
+
+	t.Run("standalone binary is empty", func(t *testing.T) {
+		mock := executor.NewMock()
+		// No symlink: EvalSymlinks returns the path unchanged; not under node_modules.
+		if v := versionFromPackageJSON(mock, "/usr/bin/ollama"); v != "" {
+			t.Errorf("want empty for non-npm binary, got %q", v)
+		}
+	})
+
+	t.Run("empty path is empty", func(t *testing.T) {
+		mock := executor.NewMock()
+		if v := versionFromPackageJSON(mock, ""); v != "" {
+			t.Errorf("want empty for empty path, got %q", v)
+		}
+	})
+}

--- a/internal/detector/framework.go
+++ b/internal/detector/framework.go
@@ -72,6 +72,14 @@ func (d *FrameworkDetector) Detect(ctx context.Context) []model.AITool {
 }
 
 func (d *FrameworkDetector) getVersion(ctx context.Context, binaryPath string) string {
+	// Static-first: read the npm package.json version when the binary is an
+	// npm-installed package, avoiding the macOS Gatekeeper malware prompt that
+	// launching a Node CLI can trigger — see versionFromPackageJSON. Most
+	// frameworks (ollama, local-ai) are standalone binaries and fall through.
+	if v := versionFromPackageJSON(d.exec, binaryPath); v != "" {
+		return v
+	}
+	// Fallback: standalone (non-npm) binaries have no package.json; exec them.
 	stdout, _, _, err := d.exec.RunWithTimeout(ctx, 10*time.Second, binaryPath, "--version")
 	if err != nil {
 		return "unknown"


### PR DESCRIPTION
## Problem

Users on macOS see a Gatekeeper dialog during a scan:

> **"merkle-tree-napi.darwin-arm64.node" Not Opened** — Apple could not verify "merkle-tree-napi.darwin-arm64.node" is free of malware that may harm your Mac or compromise your privacy.

`merkle-tree-napi.darwin-arm64.node` is a **native Node addon** (a Mach-O dylib) bundled as a transitive dependency of one of the AI CLIs on the machine. A security tool triggering a malware warning is exactly the wrong impression.

## Root cause

The AI CLI / agent / framework detectors read each tool's version by **executing it** with `--version` (`aicli.go` `getVersion`, `agent.go` `getVersion`, `framework.go` `getVersion`). These AI CLIs are npm-installed **Node** programs. Launching one boots Node, which `dlopen`s the tool's native `.node` addons during module init — *before argv is even parsed*, so the flag is irrelevant. When a quarantined addon (`com.apple.quarantine`, never cleared after npm download) is loaded, Gatekeeper on recent macOS assesses it and blocks with the popup.

Merely reading a file's bytes never triggers this; only loading/executing does.

## Fix

Move version detection to **file-based (static-first)**: read the version from the npm `package.json` when the binary resolves into a `node_modules` tree, and only fall back to executing `--version` for standalone (non-npm) binaries (which are typically notarized, so no prompt).

- `package.json`'s `version` is npm's **required, canonical** field (semver) — authoritative, not a heuristic. Verified it matches `--version` output for the affected tools (e.g. `claude`: `package.json` `2.1.209` == `claude --version` `2.1.209 (Claude Code)`).
- Mirrors the existing static-first approach for IDEs in `resolveDarwinVersion` (which was added to dodge an analogous exec hazard — the "Coveo incident").
- Reuses the `node_modules` root resolution already in `resolveInstallPath` (factored into shared `nodePackageRoot` / `resolveRealPath` helpers) and the existing `readJSONVersion` helper. Handles both the Unix symlink layout and the Windows `.cmd`/`.ps1` shim layout.

`detectClaudeCowork` and `detectLMStudioApp` already read versions from `Info.plist`/registry, so they were already safe and are unchanged.

## Tests

- `TestVersionFromPackageJSON` — unit coverage of the shared helper (npm package w/ and w/o `package.json`, standalone binary, empty path).
- `TestAICLIDetector_VersionFromPackageJSON` / `TestAgentDetector_VersionFromPackageJSON` — end-to-end: the detected version comes from `package.json` and the exec fallback (stubbed with a deliberately different value) does **not** run.
- Existing install-path tests unchanged and passing (`resolveInstallPath` behavior preserved).

`go build ./...`, `go vet ./internal/detector/`, and `go test ./...` all green.