### PR TITLE
fix(mdm): show telemetry-upload lines in downloaded logs; stop double-capturing Claude Desktop

### DIFF
--- a/internal/detector/ide.go
+++ b/internal/detector/ide.go
@@ -101,11 +101,6 @@ var ideDefinitions = []ideSpec{
 		LinuxBinary: "zed",
 	},
 	{
-		AppName: "Claude", IDEType: "claude_desktop", Vendor: "Anthropic",
-		AppPath:  "/Applications/Claude.app",
-		WinPaths: []string{`%LOCALAPPDATA%\Programs\Claude`},
-	},
-	{
 		AppName: "Microsoft Copilot", IDEType: "microsoft_copilot_desktop", Vendor: "Microsoft",
 		AppPath:  "/Applications/Copilot.app",
 		WinPaths: []string{`%LOCALAPPDATA%\Programs\Copilot`},

--- a/internal/detector/ide_test.go
+++ b/internal/detector/ide_test.go
@@ -68,9 +68,9 @@ func TestIDEDetector_MultipleIDEs(t *testing.T) {
 	mock.SetFile("/Applications/Visual Studio Code.app/Contents/Info.plist", []byte{})
 	mock.SetCommand("1.96.0", "", 0, "/usr/libexec/PlistBuddy", "-c", "Print :CFBundleShortVersionString", "/Applications/Visual Studio Code.app/Contents/Info.plist")
 
-	mock.SetDir("/Applications/Claude.app")
-	mock.SetFile("/Applications/Claude.app/Contents/Info.plist", []byte{})
-	mock.SetCommand("0.7.1", "", 0, "/usr/libexec/PlistBuddy", "-c", "Print :CFBundleShortVersionString", "/Applications/Claude.app/Contents/Info.plist")
+	mock.SetDir("/Applications/Copilot.app")
+	mock.SetFile("/Applications/Copilot.app/Contents/Info.plist", []byte{})
+	mock.SetCommand("1.0.0", "", 0, "/usr/libexec/PlistBuddy", "-c", "Print :CFBundleShortVersionString", "/Applications/Copilot.app/Contents/Info.plist")
 
 	det := NewIDEDetector(mock)
 	results := det.Detect(context.Background())
@@ -119,7 +119,7 @@ func TestIDEDetector_Windows_FindsVSCode(t *testing.T) {
 	}
 }
 
-func TestIDEDetector_Windows_FindsClaude(t *testing.T) {
+func TestIDEDetector_Windows_ClaudeNotAnIDE(t *testing.T) {
 	mock := executor.NewMock()
 	mock.SetGOOS("windows")
 	mock.SetEnv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
@@ -141,20 +141,10 @@ func TestIDEDetector_Windows_FindsClaude(t *testing.T) {
 	det := NewIDEDetector(mock)
 	results := det.Detect(context.Background())
 
-	if len(results) != 1 {
-		t.Fatalf("expected 1 IDE, got %d", len(results))
-	}
-	if results[0].IDEType != "claude_desktop" {
-		t.Errorf("expected claude_desktop, got %s", results[0].IDEType)
-	}
-	if results[0].Version != "0.8.2" {
-		t.Errorf("expected 0.8.2, got %s", results[0].Version)
-	}
-	if results[0].Vendor != "Anthropic" {
-		t.Errorf("expected Anthropic, got %s", results[0].Vendor)
-	}
-	if !results[0].IsInstalled {
-		t.Error("expected is_installed=true")
+	// Claude Desktop is intentionally NOT in the IDE catalog: it is reported
+	// once as the "claude-cowork" AI agent (see AgentDetector), never as an IDE.
+	if len(results) != 0 {
+		t.Errorf("expected Claude Desktop to NOT be detected as an IDE, got %d: %+v", len(results), results)
 	}
 }
 

--- a/internal/telemetry/logcapture.go
+++ b/internal/telemetry/logcapture.go
@@ -1,11 +1,13 @@
 package telemetry
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
 	"sync"
+	"time"
 )
 
 // captureRingCapacity bounds the in-memory log buffer. Older bytes are
@@ -13,6 +15,17 @@ import (
 // stuck runs while still preserving enough recent context for diagnosis:
 // 1 MB ≈ several thousand lines of typical agent output.
 const captureRingCapacity = 1 << 20 // 1 MB
+
+// captureSyncMarker is a unique in-band sentinel that Sync() writes to the
+// capture pipe to learn the tee goroutine has drained every byte written before
+// it. The tee strips it, so it is never stored in the ring or echoed to stderr.
+// The NUL/RS control bytes make an accidental match in real log text effectively
+// impossible.
+const captureSyncMarker = "\x00\x1eSTEPSEC_LOGCAPTURE_SYNC\x1e\x00"
+
+// captureSyncTimeout bounds Sync() so a dead or absent tee goroutine can never
+// wedge the caller.
+const captureSyncTimeout = 2 * time.Second
 
 // LogCapture captures all stderr output during telemetry execution into a
 // bounded ring buffer. The buffer's contents are exposed two ways:
@@ -43,6 +56,7 @@ type LogCapture struct {
 	pipeRead  *os.File
 	pipeWrite *os.File
 	done      chan struct{}
+	syncCh    chan struct{} // tee signals here once a Sync() marker is drained
 }
 
 // ringBuffer is a fixed-capacity append-only byte sink. Once full, writes
@@ -117,6 +131,7 @@ func StartCapture() *LogCapture {
 		ring:    newRingBuffer(captureRingCapacity),
 		origErr: os.Stderr,
 		done:    make(chan struct{}),
+		syncCh:  make(chan struct{}, 1),
 	}
 
 	r, w, err := os.Pipe()
@@ -129,25 +144,62 @@ func StartCapture() *LogCapture {
 	// Redirect stderr to the pipe
 	os.Stderr = w
 
-	// Tee: read from pipe, write to both original stderr and ring buffer
+	// Tee: read from pipe, write to both original stderr and ring buffer.
+	// Sync() markers are detected here, stripped (never teed onward), and
+	// acknowledged via syncCh; a carry of marker-1 bytes handles a marker that
+	// straddles two reads.
 	go func() {
 		defer close(lc.done)
+		marker := []byte(captureSyncMarker)
 		buf := make([]byte, 4096)
+		var carry []byte
 		for {
 			n, err := r.Read(buf)
 			if n > 0 {
-				lc.mu.Lock()
-				lc.ring.Write(buf[:n])
-				lc.mu.Unlock()
-				_, _ = lc.origErr.Write(buf[:n])
+				data := buf[:n]
+				if len(carry) > 0 {
+					data = append(carry, data...)
+				}
+				for {
+					i := bytes.Index(data, marker)
+					if i < 0 {
+						break
+					}
+					lc.teeWrite(data[:i])
+					data = data[i+len(marker):]
+					select {
+					case lc.syncCh <- struct{}{}:
+					default:
+					}
+				}
+				// Hold back a possible partial marker at the tail for the next read.
+				if keep := len(marker) - 1; len(data) > keep {
+					lc.teeWrite(data[:len(data)-keep])
+					carry = append([]byte(nil), data[len(data)-keep:]...)
+				} else {
+					carry = append([]byte(nil), data...)
+				}
 			}
 			if err != nil {
+				lc.teeWrite(carry) // flush any held-back tail before exiting
 				break
 			}
 		}
 	}()
 
 	return lc
+}
+
+// teeWrite fans a slice out to the ring buffer and the original stderr. Empty
+// input is a no-op so the marker-stripping loop can call it unconditionally.
+func (lc *LogCapture) teeWrite(p []byte) {
+	if len(p) == 0 {
+		return
+	}
+	lc.mu.Lock()
+	lc.ring.Write(p)
+	lc.mu.Unlock()
+	_, _ = lc.origErr.Write(p)
 }
 
 // Finalize stops capture and returns the base64-encoded output.
@@ -184,6 +236,38 @@ func (lc *LogCapture) SnapshotBase64() string {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 	return base64.StdEncoding.EncodeToString(lc.ringBytesLocked())
+}
+
+// Sync blocks until the tee goroutine has drained every byte written to the
+// capture pipe before this call — i.e. everything logged so far is now in the
+// ring and visible to a following SnapshotBase64/Tail. Unlike Finalize it does
+// NOT stop capture: the pipe stays open, so later output (the upload result, the
+// completion line) keeps being recorded for the run-status tail. It works by
+// writing a unique marker to the pipe and waiting for the tee to read past it,
+// which is the only reliable way to flush an asynchronous reader short of
+// closing the pipe. Bounded by captureSyncTimeout so an absent or stuck tee
+// cannot wedge the caller; on timeout the following snapshot simply reflects
+// whatever had drained. No-op before StartCapture or after Finalize.
+func (lc *LogCapture) Sync() {
+	lc.mu.Lock()
+	pw := lc.pipeWrite
+	ch := lc.syncCh
+	lc.mu.Unlock()
+	if pw == nil || ch == nil {
+		return
+	}
+	// Clear any stale ack from a previous Sync so we wait on our own marker.
+	select {
+	case <-ch:
+	default:
+	}
+	if _, err := pw.WriteString(captureSyncMarker); err != nil {
+		return // pipe closed concurrently (Finalize) — nothing left to drain
+	}
+	select {
+	case <-ch:
+	case <-time.After(captureSyncTimeout):
+	}
 }
 
 // Tail returns the last n captured bytes as a fresh slice. Safe to call

--- a/internal/telemetry/logcapture_test.go
+++ b/internal/telemetry/logcapture_test.go
@@ -1,0 +1,57 @@
+package telemetry
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLogCaptureSyncFlushesRecentWrites drives real writes through StartCapture
+// (os.Stderr -> pipe -> async tee -> ring), NOT ring.Write directly, and asserts
+// that Sync() makes the most-recently-written line visible to SnapshotBase64.
+//
+// This is the case that regressed: on a fast run the tee has not yet copied the
+// final line into the ring when the snapshot is taken, so the downloadable log
+// cut off early. Sync() must guarantee that line is present. It also asserts the
+// in-band sync marker never leaks into the captured output.
+func TestLogCaptureSyncFlushesRecentWrites(t *testing.T) {
+	lc := StartCapture()
+	defer lc.Finalize()
+
+	fmt.Fprintln(os.Stderr, "line one")
+	const last = "Uploading telemetry to S3 (70583 bytes)..."
+	fmt.Fprint(os.Stderr, last)
+
+	lc.Sync()
+
+	decoded, err := base64.StdEncoding.DecodeString(lc.SnapshotBase64())
+	if err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	got := string(decoded)
+	if !strings.Contains(got, last) {
+		t.Errorf("snapshot after Sync() is missing the final line\n want substring: %q\n got: %q", last, got)
+	}
+	if strings.Contains(got, "STEPSEC_LOGCAPTURE_SYNC") {
+		t.Errorf("sync marker leaked into captured output: %q", got)
+	}
+}
+
+// TestLogCaptureFinalizeReturnsAllWithoutSync guards that the marker-stripping
+// tee (which holds back a partial-marker tail between reads) still flushes that
+// tail on Finalize, so a run that never calls Sync loses no output.
+func TestLogCaptureFinalizeReturnsAllWithoutSync(t *testing.T) {
+	lc := StartCapture()
+	const msg = "alpha beta gamma delta epsilon"
+	fmt.Fprint(os.Stderr, msg)
+
+	decoded, err := base64.StdEncoding.DecodeString(lc.Finalize())
+	if err != nil {
+		t.Fatalf("decode finalize: %v", err)
+	}
+	if !strings.Contains(string(decoded), msg) {
+		t.Errorf("Finalize dropped trailing output\n want substring: %q\n got: %q", msg, decoded)
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1011,6 +1011,13 @@ func Run(exec executor.Executor, log *progress.Logger, cfg *cli.Config) (err err
 	// payload itself can't contain the log of its own upload, so this snapshot
 	// is "session so far" by design. The deferred capture.Finalize() does the
 	// real teardown (restores os.Stderr) on return.
+	//
+	// Sync() first so lines logged right before this snapshot (the config-audit
+	// block, ending at the yarn audit) are already in the ring — a fast run
+	// otherwise outruns the async capture tee and truncates this log. The upload
+	// path re-snapshots after the upload-intent lines (see uploadToS3); this drain
+	// also covers the --telemetry-out dev dump below, which skips that re-snapshot.
+	capture.Sync()
 	execLogsBase64 := capture.SnapshotBase64()
 	endTime := time.Now()
 
@@ -1163,7 +1170,7 @@ func Run(exec executor.Executor, log *progress.Logger, cfg *cli.Config) (err err
 	// itself cannot wedge the agent indefinitely.
 	phaseCtx, phaseCancel = startPhase(runCtx, tracker, "telemetry_upload")
 	log.Progress("Requesting upload URL from backend...")
-	if err := uploadToS3(phaseCtx, log, payload, executionID, tracker); err != nil {
+	if err := uploadToS3(phaseCtx, log, payload, executionID, tracker, capture); err != nil {
 		endPhase(phaseCtx, phaseCancel, tracker, log, "telemetry_upload")
 		// Force-attach a final tail capturing the upload-failure output before
 		// returning. The deferred failure report carries no status_info (and so
@@ -1277,7 +1284,7 @@ func collectProjectRoots(nodeProjects []model.NodeScanResult, pythonProjects []m
 	return out
 }
 
-func uploadToS3(ctx context.Context, log *progress.Logger, payload *Payload, executionID string, tracker *PhaseTracker) error {
+func uploadToS3(ctx context.Context, log *progress.Logger, payload *Payload, executionID string, tracker *PhaseTracker, capture *LogCapture) error {
 	// updateDetail forwards sub-progress to the heartbeat goroutine via the
 	// tracker. Tolerates nil so the function stays callable from tests that
 	// don't supply a tracker.
@@ -1343,6 +1350,32 @@ func uploadToS3(ctx context.Context, log *progress.Logger, payload *Payload, exe
 	// Upload payload to S3 with retry. Content-Type stays application/json to
 	// match the presigned URL's signed headers — the body is gzipped JSON bytes.
 	log.Progress("Uploading telemetry to S3 (%d bytes)...", len(compressedPayload))
+
+	// Re-capture execution logs so the downloadable payload log includes the
+	// upload-intent lines just logged ("Requesting upload URL...", "Uploading
+	// telemetry to S3 (N bytes)..."). These are the last lines before the PUT;
+	// the payload can't record its own PUT result, so capture stops here. Sync()
+	// drains the async capture tee so those lines are already in the buffer when
+	// we snapshot — a fast (disk-scan) run otherwise outruns the tee and the log
+	// cuts off at the previous phase. Best-effort: a re-marshal error keeps the
+	// original body so log capture never blocks the upload. The re-marshalled
+	// body is a hair larger than the N just logged, which is cosmetic.
+	if capture != nil && payload.ExecutionLogs != nil {
+		capture.Sync()
+		payload.ExecutionLogs.OutputBase64 = capture.SnapshotBase64()
+		// The re-snapshot extends the log past the original end time (set at the
+		// pre-upload payload build), so bump EndTime to match the last captured
+		// byte — keeps execution_logs.end_time consistent with the embedded log
+		// instead of trailing it by the upload-prep window.
+		payload.ExecutionLogs.EndTime = time.Now().Unix()
+		if rebuilt, mErr := json.Marshal(payload); mErr == nil {
+			if regz, zErr := gzipBytes(rebuilt); zErr == nil {
+				payloadJSON = rebuilt
+				compressedPayload = regz
+			}
+		}
+	}
+
 	s3Client := &http.Client{Timeout: 10 * time.Minute}
 	const maxRetries = 3
 	backoffUnit := s3UploadBackoffUnit

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -98,7 +98,7 @@ func TestUploadToS3_SendsCompressedBodyAndIsCompressedFlag(t *testing.T) {
 	payload := &Payload{CustomerID: "test-customer", DeviceID: "dev-1"}
 
 	const testExecutionID = "11111111-2222-4333-8444-555555555555"
-	if err := uploadToS3(context.Background(), progress.NewLogger(progress.LevelInfo), payload, testExecutionID, nil); err != nil {
+	if err := uploadToS3(context.Background(), progress.NewLogger(progress.LevelInfo), payload, testExecutionID, nil, nil); err != nil {
 		t.Fatalf("uploadToS3 failed: %v", err)
 	}
 
@@ -198,7 +198,7 @@ func TestUploadToS3_Synthetic200ConfirmedByBackend(t *testing.T) {
 
 	err := uploadToS3(context.Background(), progress.NewLogger(progress.LevelInfo),
 		&Payload{CustomerID: "test-customer", DeviceID: "dev-1"},
-		"11111111-2222-4333-8444-555555555555", nil)
+		"11111111-2222-4333-8444-555555555555", nil, nil)
 	if err != nil {
 		t.Fatalf("uploadToS3 must succeed when backend confirms uploaded=true, got: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestUploadToS3_Synthetic200MissingExhaustsRetries(t *testing.T) {
 
 	err := uploadToS3(context.Background(), progress.NewLogger(progress.LevelInfo),
 		&Payload{CustomerID: "test-customer", DeviceID: "dev-1"},
-		"11111111-2222-4333-8444-555555555555", nil)
+		"11111111-2222-4333-8444-555555555555", nil, nil)
 	if err == nil {
 		t.Fatal("uploadToS3 must fail when every confirm reports the object missing")
 	}
@@ -313,7 +313,7 @@ func TestUploadToS3_Synthetic200UnsupportedBackendTrustsPUT(t *testing.T) {
 
 	err := uploadToS3(context.Background(), progress.NewLogger(progress.LevelInfo),
 		&Payload{CustomerID: "test-customer", DeviceID: "dev-1"},
-		"11111111-2222-4333-8444-555555555555", nil)
+		"11111111-2222-4333-8444-555555555555", nil, nil)
 	if err != nil {
 		t.Fatalf("uploadToS3 must succeed when confirm-upload is unsupported (404), got: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestUploadToS3_Synthetic200IndeterminateExhausts(t *testing.T) {
 
 	err := uploadToS3(context.Background(), progress.NewLogger(progress.LevelInfo),
 		&Payload{CustomerID: "test-customer", DeviceID: "dev-1"},
-		"11111111-2222-4333-8444-555555555555", nil)
+		"11111111-2222-4333-8444-555555555555", nil, nil)
 	if err == nil {
 		t.Fatal("uploadToS3 must fail when every confirm is indeterminate")
 	}
@@ -432,7 +432,7 @@ func TestUploadToS3_Synthetic200ThenRealAWSHeaders(t *testing.T) {
 
 	err := uploadToS3(context.Background(), progress.NewLogger(progress.LevelInfo),
 		&Payload{CustomerID: "test-customer", DeviceID: "dev-1"},
-		"11111111-2222-4333-8444-555555555555", nil)
+		"11111111-2222-4333-8444-555555555555", nil, nil)
 	if err != nil {
 		t.Fatalf("uploadToS3 must recover when a later attempt reaches real S3, got: %v", err)
 	}


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
