### PR TITLE
fix(configaudit): mask full userinfo in malformed multi-@ index URLs

### DIFF
--- a/internal/detector/configaudit/pipconfig_helpers.go
+++ b/internal/detector/configaudit/pipconfig_helpers.go
@@ -51,34 +51,54 @@ func urlIsHTTP(s string) bool {
 // embedded URL credentials reduced to `user:****@host` form. Non-URL
 // inputs (and URLs without credentials) are returned unchanged.
 //
-// We avoid url.URL.String() for the rewritten URL because it
-// percent-encodes the asterisks back to %2A. Since we already validated
-// the structure via net/url, we can splice the original string between
-// the scheme and the `@` and recompose the credential portion ourselves.
+// We work directly on the string (not url.URL.String()) because the latter
+// percent-encodes the asterisks back to %2A. Credentials live in the URL
+// authority — everything between `://` and the first `/`, `?`, or `#` — and
+// the userinfo is everything up to the *last* `@` in that authority. A
+// well-formed URL has at most one unencoded `@`, so when a user-typed value
+// concatenates several `user:pass@host` runs (e.g. a mangled index-url), the
+// only real host is what follows the final `@`; everything before it is
+// credential material and gets masked whole. Splitting on the first `@`
+// instead would preserve the trailing runs — including a live token — in the
+// "safe" output, which is exactly the leak this guards against.
 func redactCredsInValue(s string) string {
-	u, has := urlHasEmbeddedCreds(s)
-	if !has {
+	if !looksLikeURL(s) {
 		return s
 	}
 	trimmed := strings.TrimSpace(s)
-	// Find the `://` and the `@` that terminates userinfo. A URL with
-	// userinfo always has the form "scheme://userinfo@host[/path]".
 	schemeIdx := strings.Index(trimmed, "://")
 	if schemeIdx < 0 {
 		return s
 	}
+	prefix := trimmed[:schemeIdx+3] // includes "://"
 	rest := trimmed[schemeIdx+3:]
-	atIdx := strings.IndexByte(rest, '@')
-	if atIdx < 0 {
-		return s
+
+	// The authority ends at the first path/query/fragment delimiter; an `@`
+	// past that point belongs to the path or query, not to userinfo.
+	authEnd := strings.IndexAny(rest, "/?#")
+	if authEnd < 0 {
+		authEnd = len(rest)
 	}
-	prefix := trimmed[:schemeIdx+3]
-	tail := rest[atIdx:] // includes the '@'
-	username := u.User.Username()
-	if _, hasPassword := u.User.Password(); hasPassword {
-		return prefix + username + ":****" + tail
+	authority := rest[:authEnd]
+	after := rest[authEnd:] // path/query/fragment, possibly empty
+
+	lastAt := strings.LastIndexByte(authority, '@')
+	if lastAt < 0 {
+		return s // no embedded credentials
 	}
-	return prefix + "****" + tail
+	userinfo := authority[:lastAt]
+	host := authority[lastAt+1:]
+
+	// Preserve the username only when the userinfo is a single, well-formed
+	// `user:pass` pair. Any extra `@` means we can't safely tell which run is
+	// the username, so mask the whole thing.
+	masked := "****"
+	if !strings.ContainsRune(userinfo, '@') {
+		if colon := strings.IndexByte(userinfo, ':'); colon >= 0 {
+			masked = userinfo[:colon] + ":****"
+		}
+	}
+	return prefix + masked + "@" + host + after
 }
 
 // hashCredential returns a stable short identifier for a credential value

--- a/internal/detector/configaudit/pipconfig_parse_test.go
+++ b/internal/detector/configaudit/pipconfig_parse_test.go
@@ -127,6 +127,16 @@ func TestRedactCredsInValue(t *testing.T) {
 		{"https://alice" + at + "internal.example.com/simple", "https://****" + at + "internal.example.com/simple"},
 		{"https://alice:secret" + at + "internal.example.com/simple", "https://alice:****" + at + "internal.example.com/simple"},
 		{"http://__token__:pypi-AgEI..." + at + "upload.pypi.org/", "http://__token__:****" + at + "upload.pypi.org/"},
+		// Malformed value with several user:pass@host runs concatenated
+		// before the real host (a real customer had this shape in a pip
+		// index-url, with a live Azure DevOps PAT as the last segment). The
+		// userinfo is everything up to the *last* @, and because it contains
+		// extra @s we can't safely pick out a username, so the whole run is
+		// masked — no segment survives into the output.
+		{"https://user" + at + "corp.com:pass1" + at + "corp.com:TOKENabc123" + at + "corp.pkgs.visualstudio.com/_packaging/feed/pypi/simple/",
+			"https://****" + at + "corp.pkgs.visualstudio.com/_packaging/feed/pypi/simple/"},
+		// An @ in the path or query is not userinfo and must be left alone.
+		{"https://pypi.org/simple?contact=me" + at + "corp.com", "https://pypi.org/simple?contact=me" + at + "corp.com"},
 		{"not-a-url", "not-a-url"},
 	}
 	for _, c := range cases {
@@ -134,6 +144,24 @@ func TestRedactCredsInValue(t *testing.T) {
 		if got != c.want {
 			t.Errorf("redactCredsInValue(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestRedactCredsInValue_MultiAtNoLeak is a focused regression guard for the
+// credential leak where a malformed multi-@ authority left every segment after
+// the first @ verbatim in the "safe" output. No credential run may appear
+// anywhere in the redacted string.
+func TestRedactCredsInValue_MultiAtNoLeak(t *testing.T) {
+	const at = "@"
+	in := "https://user" + at + "corp.com:pass1" + at + "corp.com:TOKENabc123" + at + "corp.pkgs.visualstudio.com/_packaging/feed/pypi/simple/"
+	got := redactCredsInValue(in)
+	for _, secret := range []string{"pass1", "TOKENabc123"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("redacted value leaks %q: got %q", secret, got)
+		}
+	}
+	if !strings.HasPrefix(got, "https://****"+at+"corp.pkgs.visualstudio.com/") {
+		t.Errorf("real host not preserved after redaction: got %q", got)
 	}
 }
 


### PR DESCRIPTION
redactCredsInValue split userinfo at the first `@`, so a user-typed value with several `user:pass@host` runs concatenated before the real host (e.g. a mangled pip index-url) had everything after the first `@` treated as host and shipped verbatim — leaking the trailing credential, in one real case a live Azure DevOps PAT, into the effective-config telemetry.

Key off the URL authority (up to the first /?#) and take userinfo as everything up to its *last* `@`. When the userinfo itself contains an extra `@` it's malformed and can't be safely parsed into user/pass, so mask the whole run. Well-formed single user:pass@host is unchanged.

## What does this PR do?

<!-- Brief description of the changes -->

## Type of change

- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Testing

- [ ] Tested on macOS (version: ___)
- [ ] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [ ] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [ ] No secrets or credentials included
- [ ] Lint passes: `make lint`
- [ ] Tests pass: `make test`

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
