### PR TITLE
feat(release): gate publishing on verification and cover .intunewin artifacts

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,49 @@
+name: Publish Release
+# Publishes a draft release, but only after the full Verify Release suite
+# (signed checksums, Windows Authenticode, macOS notarization) passes. This
+# replaces the manual:
+#   gh release edit vX.Y.Z --repo <repo> --draft=false --latest
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Draft release tag to verify and publish, e.g. v1.12.0.'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  # Runs every check from verify-release.yml. Its `gate` job fails the whole
+  # workflow if any requirement is not met, so `publish` below only runs when
+  # the release is verified safe.
+  verify:
+    name: Verify release
+    uses: ./.github/workflows/verify-release.yml
+    permissions:
+      contents: write # required to see DRAFT releases; verification only downloads assets
+    with:
+      tag: ${{ inputs.tag }}
+
+  publish:
+    name: Publish release
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release edit needs push access to flip draft -> published
+    env:
+      TAG: ${{ inputs.tag }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Make draft release public and mark as latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+          echo "Release ${TAG} is now public and marked as latest."
+          echo "✅ Release \`${TAG}\` verified and published as latest." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,4 +1,8 @@
 name: Verify Release
+# Two entry points share the same verification jobs:
+#   - workflow_dispatch: manually verify a release is good and healthy.
+#   - workflow_call: reused by publish-release.yml, which publishes the draft
+#     only after every check here passes.
 on:
   workflow_dispatch:
     inputs:
@@ -13,6 +17,17 @@ on:
           an upstream PUBLISHED release (handy for confirming this workflow
           works before opening a PR — draft releases in another repo are not
           visible to this repo's token, so only published upstream releases work).
+        required: false
+        type: string
+        default: ''
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to verify, e.g. v1.11.6 (draft or published).'
+        required: true
+        type: string
+      repository:
+        description: 'Repo to verify, as owner/name. Blank = the calling repo.'
         required: false
         type: string
         default: ''
@@ -89,6 +104,8 @@ jobs:
             "stepsecurity-dev-machine-guard-task-${VERSION}-windows_arm64.exe"
             "stepsecurity-dev-machine-guard-${VERSION}-x64.msi"
             "stepsecurity-dev-machine-guard-${VERSION}-arm64.msi"
+            "stepsecurity-dev-machine-guard-${VERSION}-x64.intunewin"
+            "stepsecurity-dev-machine-guard-${VERSION}-arm64.intunewin"
           )
 
           fail=0

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -12,7 +12,7 @@ Releases are a three-phase process, where each phase is its own GitHub Actions w
 
 1. **Build and draft (`release.yml`)**: builds binaries for all platforms, Authenticode-signs the Windows `.exe`s and `.msi`s via Azure Trusted Signing, Sigstore-signs the Linux and Windows artifacts (after Authenticode for Windows, so cosign bundles match the bytes users download), creates a **draft** release with the unsigned macOS binary, and emits SLSA build provenance attestations for every artifact except macOS. The Windows signing job runs in the `release` GitHub Environment, which requires two reviewers and is restricted to `main`.
 2. **Sign and notarize macOS (`release-macos.yml`)**: a dispatch-only workflow that downloads the unsigned macOS binary from the draft release, codesigns it with the Apple Developer ID certificate, notarizes it with Apple, then Sigstore-signs and attests the final notarized bytes and uploads them to the draft release. It runs in the `release` environment as well. Because Apple notarization can hang, this is kept separate from `release.yml` so it can be re-run on its own without repeating the build. A companion workflow, `check-notarization-status.yml`, inspects a notarization submission that did not finish in time.
-3. **Publish**: mark the draft release as published.
+3. **Verify and publish (`verify-release.yml` + `publish-release.yml`)**: `verify-release.yml` checks that every distributable binary has a valid out-of-band signed checksum (`.sha256.sig`), that the Windows `.exe`s and `.msi`s are Authenticode-signed and timestamped, and that the macOS binary is codesigned and notarized. It can be dispatched on its own to check that a draft (or published) release is healthy. `publish-release.yml` calls it as a reusable workflow and, only if every check passes, marks the draft release as published and latest.
 
 macOS signing runs entirely in GitHub Actions; no local Mac is required. The signing credentials are stored as encrypted secrets in the `release` environment (see [Signing credentials](#signing-credentials-one-time-setup)).
 
@@ -70,12 +70,36 @@ The workflow will:
 2. Click **Run workflow** and enter the submission id from the failed run. It reports the current status and the notary log.
 3. Once the status is `Accepted`, re-run the Release macOS workflow for the same tag. Apple keeps processing server-side, so no resubmission is needed.
 
-### 4. Publish the release
+### 4. (Optional) Verify the draft release
+
+To check that a draft is good and healthy without publishing it:
+
+1. Go to [Actions > Verify Release](https://github.com/step-security/dev-machine-guard/actions/workflows/verify-release.yml)
+2. Click **Run workflow** and enter the release tag (e.g. `v1.9.1`)
+
+The workflow verifies, for every distributable binary (macOS, Linux, Windows `.exe`s, MSIs, and `.intunewin` packages):
+
+- **Signed checksums**: each artifact has a `<artifact>.sha256.sig` asset — an Ed25519 (SSH) signature over the artifact's SHA-256, created with a key held **outside this repository** — and the signature verifies against the artifact's actual bytes. This is the gate that prevents a repository compromise alone from producing a release that passes verification.
+- **Windows Authenticode**: every `.exe` and `.msi` has a valid signature with an RFC3161 timestamp.
+- **macOS notarization**: the darwin binary is codesigned with the Step Security Developer ID and hardened runtime, and Gatekeeper reports it as notarized.
+
+A final `gate` job gives a single pass/fail status for the release.
+
+> The signed checksums are produced and uploaded out-of-band; make sure the `.sha256.sig` assets are attached to the draft before running verification, or the run will fail.
+
+### 5. Publish the release
+
+1. Go to [Actions > Publish Release](https://github.com/step-security/dev-machine-guard/actions/workflows/publish-release.yml)
+2. Click **Run workflow** and enter the release tag (e.g. `v1.9.1`)
+
+The workflow re-runs the entire Verify Release suite above (it calls `verify-release.yml` as a reusable workflow), and only if every check passes runs the equivalent of:
 
 ```bash
 gh release edit "v${VERSION}" --repo step-security/dev-machine-guard \
   --draft=false --latest
 ```
+
+so a draft can never be published without passing verification.
 
 ---
 
@@ -121,6 +145,10 @@ Each release includes:
 | `stepsecurity-dev-machine-guard-VERSION-x64.msi.bundle` | Sigstore cosign bundle for the MSI |
 | `stepsecurity-dev-machine-guard-VERSION-arm64.msi` | Authenticode-signed Windows ARM64 MSI installer |
 | `stepsecurity-dev-machine-guard-VERSION-arm64.msi.bundle` | Sigstore cosign bundle for the MSI |
+| `stepsecurity-dev-machine-guard-VERSION-x64.intunewin` | Intune Win32 package (x64) wrapping the signed MSI |
+| `stepsecurity-dev-machine-guard-VERSION-x64.intunewin.bundle` | Sigstore cosign bundle for the Intune x64 package |
+| `stepsecurity-dev-machine-guard-VERSION-arm64.intunewin` | Intune Win32 package (ARM64) wrapping the signed MSI |
+| `stepsecurity-dev-machine-guard-VERSION-arm64.intunewin.bundle` | Sigstore cosign bundle for the Intune ARM64 package |
 | `stepsecurity-dev-machine-guard-VERSION-linux_amd64` | Linux 64-bit binary |
 | `stepsecurity-dev-machine-guard-linux_amd64.bundle` | Sigstore cosign bundle for the Linux amd64 binary |
 | `stepsecurity-dev-machine-guard-VERSION-linux_arm64` | Linux ARM64 binary |
@@ -135,6 +163,8 @@ Each release includes:
 | `stepsecurity-dev-machine-guard-VERSION-arm64.rpm.bundle` | Sigstore cosign bundle for the RPM arm64 package |
 | `stepsecurity-dev-machine-guard.sh` | Legacy shell script |
 | `stepsecurity-dev-machine-guard.sh.bundle` | Sigstore cosign bundle for the shell script |
+
+In addition, every distributable binary (the darwin, `linux_*`, `.exe`, `.msi`, and `.intunewin` artifacts) has a `<artifact>.sha256.sig` asset: a base64-wrapped SSH (Ed25519) signature over the artifact's SHA-256, created with a key held outside this repository and uploaded out-of-band. `verify-release.yml` — and the loader on customer machines — verify these against the artifact's actual bytes.
 
 ---
 
@@ -264,12 +294,13 @@ gh attestation verify "stepsecurity-dev-machine-guard-${VERSION}-linux_${ARCH}" 
 
 ## Immutability Guarantees
 
-1. **Draft then publish flow**: binaries are uploaded to a draft release, the macOS binary is signed and notarized by the gated `release-macos.yml` workflow, then the release is published. Once published, the release is immutable.
+1. **Draft then publish flow**: binaries are uploaded to a draft release, the macOS binary is signed and notarized by the gated `release-macos.yml` workflow, then the release is published via `publish-release.yml`, which refuses to publish unless the full Verify Release suite passes. Once published, the release is immutable.
 2. **Sigstore transparency log**: every artifact's signature is recorded in the public [Rekor](https://rekor.sigstore.dev/) transparency log. The Windows cosign bundles cover the post-Authenticode bytes and the macOS bundle covers the post-notarization bytes, so they match what users download.
 3. **SLSA build provenance** — attestation links the artifact to the exact workflow run, commit SHA, and build environment.
 4. **Authenticode + RFC3161 timestamp** — Windows `.exe` and `.msi` signatures from Azure Trusted Signing are timestamped by Microsoft's RFC3161 timestamp server, so they remain verifiable on Windows after the signing certificate expires.
 5. **Release environment gate**: the Windows and macOS signing jobs won't run without approval from two reviewers, and only from `main`.
-6. **Duplicate tag check** — the release workflow fails if the tag already exists.
+6. **Out-of-band signed checksums** — every distributable binary ships a `.sha256.sig` signed with an Ed25519 key held outside the repository, so compromising the repository alone is not enough to publish a release that passes verification. `verify-release.yml` and the publish gate check these signatures against the artifacts' actual bytes.
+7. **Duplicate tag check** — the release workflow fails if the tag already exists.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`verify-release.yml`**: add the `x64`/`arm64` `.intunewin` packages to the signed-checksum verification list, so every distributable binary now requires a valid out-of-band Ed25519 `.sha256.sig` (darwin, linux_amd64/arm64, both agent and task `.exe`s, both MSIs, and both Intune packages).
- **`verify-release.yml`**: add a `workflow_call` trigger so the verification suite is reusable. The existing manual `workflow_dispatch` entry point is unchanged — it can still be run on its own to check that a draft release is good and healthy.
- **`publish-release.yml`** (new): second entry point that calls the verification suite as a reusable workflow and, only if every check passes (signed checksums, Windows Authenticode, macOS notarization), publishes the draft release and marks it latest — replacing the manual `gh release edit vX.Y.Z --draft=false --latest` step.
- **`docs/release-process.md`**: document the verify and publish workflows, the `.intunewin` artifacts and their cosign bundles in the artifacts table, and the out-of-band signed-checksum guarantee.

## Why

The signed checksums are created outside the repository, so requiring them on every distributable binary — and gating publish on that verification — means a compromised repository alone cannot ship a release that customers' loaders will accept.

## Test plan

- [ ] Run **Verify Release** against a recent draft release tag and confirm all four jobs pass (requires the `.intunewin` `.sha256.sig` assets to be attached).
- [ ] Run **Publish Release** on the next release to confirm the verify → publish flow end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)