### PR TITLE
feat(mcp): collect OpenCode MCP server configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ See [SCAN_COVERAGE.md](SCAN_COVERAGE.md) for the full catalog of supported detec
 | AI CLI Tools         | Claude Code, Codex, Gemini CLI, Kiro, GitHub Copilot CLI, Aider, OpenCode, Cursor Agent, Pi, Factory Droid, Amp |
 | AI Agents            | Claude Cowork, OpenClaw, ClawdBot, GPT-Engineer                                          |
 | AI Frameworks        | Ollama, LM Studio, LocalAI, Text Generation WebUI                                        |
-| MCP Server Configs   | Claude Desktop, Claude Code, Cursor, Windsurf, Antigravity, Zed, Open Interpreter, Codex |
+| MCP Server Configs   | Claude Desktop, Claude Code, Cursor, Windsurf, Antigravity, Zed, Open Interpreter, Codex, OpenCode |
 | IDE Extensions       | VS Code, Cursor, Windsurf, Antigravity, JetBrains, Eclipse, Xcode, Android Studio        |
 | Node.js Packages     | npm, yarn, pnpm, bun (opt-in)                                                            |
 | Homebrew Packages    | Formulae and casks with rich metadata (opt-in)                                            |

--- a/SCAN_COVERAGE.md
+++ b/SCAN_COVERAGE.md
@@ -81,17 +81,19 @@ Binaries are found via `$PATH` lookup (cross-platform). LM Studio is additionall
 
 On Windows, `~` refers to the user's home directory (`%USERPROFILE%`). Claude Desktop uses a Windows-specific path via `%APPDATA%`.
 
-| Source           | macOS / Linux Path                                               | Windows Path (if different)                    | Vendor    |
-|------------------|------------------------------------------------------------------|------------------------------------------------|-----------|
-| Claude Desktop   | `~/Library/Application Support/Claude/claude_desktop_config.json`| `%APPDATA%/Claude/claude_desktop_config.json`  | Anthropic |
-| Claude Code      | `~/.claude/settings.json`                                        | _(same)_                                       | Anthropic |
-| Claude Code      | `~/.claude.json`                                                 | _(same)_                                       | Anthropic |
-| Cursor           | `~/.cursor/mcp.json`                                             | _(same)_                                       | Cursor    |
-| Windsurf         | `~/.codeium/windsurf/mcp_config.json`                            | _(same)_                                       | Codeium   |
-| Antigravity      | `~/.gemini/antigravity/mcp_config.json`                          | _(same)_                                       | Google    |
-| Zed              | `~/.config/zed/settings.json`                                    | _(same)_                                       | Zed       |
-| Open Interpreter | `~/.config/open-interpreter/config.yaml`                         | _(same)_                                       | OpenSource|
-| Codex            | `~/.codex/config.toml`                                           | _(same)_                                       | OpenAI    |
+| Source             | macOS / Linux Path                                               | Windows Path (if different)                    | Vendor    |
+|--------------------|------------------------------------------------------------------|------------------------------------------------|-----------|
+| Claude Desktop     | `~/Library/Application Support/Claude/claude_desktop_config.json`| `%APPDATA%/Claude/claude_desktop_config.json`  | Anthropic |
+| Claude Code        | `~/.claude/settings.json`                                        | _(same)_                                       | Anthropic |
+| Claude Code        | `~/.claude.json`                                                 | _(same)_                                       | Anthropic |
+| Cursor             | `~/.cursor/mcp.json`                                             | _(same)_                                       | Cursor    |
+| Windsurf           | `~/.codeium/windsurf/mcp_config.json`                            | _(same)_                                       | Codeium   |
+| Antigravity        | `~/.gemini/antigravity/mcp_config.json`                          | _(same)_                                       | Google    |
+| Zed                | `~/.config/zed/settings.json`                                    | _(same)_                                       | Zed       |
+| Open Interpreter   | `~/.config/open-interpreter/config.yaml`                         | _(same)_                                       | OpenSource|
+| Codex              | `~/.codex/config.toml`                                           | _(same)_                                       | OpenAI    |
+| OpenCode           | `~/.config/opencode/opencode.json` (and `.jsonc`)                | _(same)_                                       | OpenCode  |
+| OpenCode (project) | `opencode.json` / `opencode.jsonc` in a project directory        | _(same)_                                       | OpenCode  |
 
 ## AI Agent Skills
 

--- a/docs/mcp-audit.md
+++ b/docs/mcp-audit.md
@@ -49,6 +49,8 @@ Dev Machine Guard scans MCP configuration files for the following tools:
 | Zed | `~/.config/zed/settings.json` | _(same)_ | Zed |
 | Open Interpreter | `~/.config/open-interpreter/config.yaml` | _(same)_ | Open Source |
 | Codex | `~/.codex/config.toml` | _(same)_ | OpenAI |
+| OpenCode | `~/.config/opencode/opencode.json` (and `.jsonc`) | _(same)_ | OpenCode |
+| OpenCode (project) | `opencode.json` / `opencode.jsonc` in a project directory | _(same)_ | OpenCode |
 
 ---
 
@@ -66,11 +68,11 @@ The MCP audit is designed to provide **visibility without exposing secrets**.
 
 ### What is NOT collected
 
-- **Environment variables** (`env` blocks in MCP configs often contain API keys and tokens -- these are stripped before collection)
+- **Environment variables** (`env` blocks -- and OpenCode's `environment` blocks -- in MCP configs often contain API keys and tokens; these are stripped before collection)
 - **HTTP headers** (may contain authentication tokens)
 - **Any other sensitive fields** that are not directly related to server identification
 
-In the enterprise agent, a Go-native filter extracts only the fields listed above before base64-encoding the config. For JSON configs, only `mcpServers` / `context_servers` entries are kept, and within each server only `command`, `args`, `serverUrl`, and `url` fields are retained. Non-JSON configs (TOML, YAML) are included as-is.
+In the enterprise agent, a Go-native filter extracts only the fields listed above before base64-encoding the config. For JSON configs, only `mcpServers` / `context_servers` / `servers` / `mcp` entries are kept, and within each server only `command`, `args`, `serverUrl`, and `url` fields are retained. Each vendor's own key is preserved as written — the filter strips fields, it never rewrites one schema into another. Non-JSON configs (TOML, YAML) are included as-is.
 
 ---
 

--- a/docs/mcp-audit.md
+++ b/docs/mcp-audit.md
@@ -72,7 +72,7 @@ The MCP audit is designed to provide **visibility without exposing secrets**.
 - **HTTP headers** (may contain authentication tokens)
 - **Any other sensitive fields** that are not directly related to server identification
 
-In the enterprise agent, a Go-native filter extracts only the fields listed above before base64-encoding the config. For JSON configs, only `mcpServers` / `context_servers` / `servers` / `mcp` entries are kept, and within each server only `command`, `args`, `serverUrl`, and `url` fields are retained. Each vendor's own key is preserved as written — the filter strips fields, it never rewrites one schema into another. Non-JSON configs (TOML, YAML) are included as-is.
+In the enterprise agent, a Go-native filter extracts only the fields listed above before base64-encoding the config. For JSON configs, only `mcpServers` / `context_servers` / `servers` / `mcp` entries are kept, and within each server only `command`, `args`, `serverUrl`, and `url` fields are retained. Each vendor's own key is preserved as written — the filter strips fields, it never rewrites one schema into another. Non-JSON configs (TOML, YAML) cannot be filtered safely, so the config's location is still reported but its contents are never collected. The same applies to a JSON config that fails to parse, or one with no recognized server key: the location is reported and the content is dropped rather than sent raw.
 
 ---
 

--- a/internal/detector/mcp.go
+++ b/internal/detector/mcp.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tailscale/hujson"
+
 	"github.com/step-security/dev-machine-guard/internal/executor"
 	"github.com/step-security/dev-machine-guard/internal/model"
 	"github.com/step-security/dev-machine-guard/internal/tcc"
@@ -38,6 +40,12 @@ var mcpConfigDefinitions = []mcpConfigSpec{
 	{"cursor_user", "~/Library/Application Support/Cursor/User/mcp.json", "%APPDATA%/Cursor/User/mcp.json", "~/.config/Cursor/User/mcp.json", "Cursor"},
 	{"windsurf_user", "~/Library/Application Support/Windsurf/User/mcp.json", "%APPDATA%/Windsurf/User/mcp.json", "~/.config/Windsurf/User/mcp.json", "Codeium"},
 	{"vscodium", "~/Library/Application Support/VSCodium/User/mcp.json", "%APPDATA%/VSCodium/User/mcp.json", "~/.config/VSCodium/User/mcp.json", "VSCodium"},
+	// OpenCode uses the same ~/.config/opencode layout on every platform, so the
+	// Windows and Linux fields stay empty and resolveConfigPath expands
+	// ConfigPath against the resolved home. Both spellings are accepted by the
+	// tool, so both are listed.
+	{"opencode", "~/.config/opencode/opencode.json", "", "", "OpenCode"},
+	{"opencode", "~/.config/opencode/opencode.jsonc", "", "", "OpenCode"},
 }
 
 // MCPDetector collects MCP configuration files.
@@ -148,7 +156,7 @@ func (d *MCPDetector) resolveConfigPath(spec mcpConfigSpec, homeDir string) stri
 // Returns the filtered content and true on success, or nil and false if
 // filtering failed (to avoid leaking secrets from raw fallback).
 func (d *MCPDetector) filterMCPContent(sourceName, configPath string, content []byte) ([]byte, bool) {
-	if !strings.HasSuffix(configPath, ".json") {
+	if !strings.HasSuffix(configPath, ".json") && !strings.HasSuffix(configPath, ".jsonc") {
 		return nil, false // Non-JSON formats cannot be safely filtered
 	}
 
@@ -157,6 +165,19 @@ func (d *MCPDetector) filterMCPContent(sourceName, configPath string, content []
 	// Strip JSONC comments for Zed
 	if sourceName == "zed" {
 		jsonInput = stripJSONCComments(jsonInput)
+	}
+
+	// OpenCode accepts JSONC under either spelling, and its own documented
+	// examples carry trailing commas as well as comments. stripJSONCComments
+	// removes the comments but leaves the commas, which json.Unmarshal then
+	// rejects — dropping the content and losing the servers. hujson handles
+	// both, and is already this repo's front door for real-world JSONC.
+	if isOpenCodeConfigPath(configPath) {
+		standard, err := hujson.Standardize(jsonInput)
+		if err != nil {
+			return nil, false
+		}
+		jsonInput = standard
 	}
 
 	var raw map[string]json.RawMessage
@@ -176,7 +197,20 @@ func (d *MCPDetector) filterMCPContent(sourceName, configPath string, content []
 	return out, true
 }
 
-// extractMCPServers extracts mcpServers/context_servers/servers, keeping only command/args/serverUrl/url.
+// isOpenCodeConfigPath reports whether a path is an OpenCode config, in either
+// spelling. It tests the basename rather than the whole path on purpose: a
+// substring test would relabel an ordinary .mcp.json as OpenCode merely because
+// some ancestor directory is named "opencode" — a checkout of the tool itself,
+// say — while claiming nothing the basename does not already name.
+func isOpenCodeConfigPath(configPath string) bool {
+	switch strings.ToLower(filepath.Base(configPath)) {
+	case "opencode.json", "opencode.jsonc":
+		return true
+	}
+	return false
+}
+
+// extractMCPServers extracts mcpServers/context_servers/servers/mcp, keeping only command/args/serverUrl/url.
 // Also handles Claude Code's project-scoped mcpServers nested under projects → <path> → mcpServers.
 func (d *MCPDetector) extractMCPServers(raw map[string]json.RawMessage) map[string]any {
 	result := make(map[string]any)
@@ -196,6 +230,21 @@ func (d *MCPDetector) extractMCPServers(raw map[string]json.RawMessage) map[stri
 	if servers, ok := raw["servers"]; ok {
 		result["servers"] = filterServerFields(servers)
 		found = true
+	}
+	// Try mcp (OpenCode), entries tagged local or remote. The vendor's own key
+	// is preserved on the wire: this pipeline filters fields, it never rewrites
+	// another vendor's schema into mcpServers.
+	//
+	// Unlike the keys above, "mcp" is an ordinary enough word to show up as a
+	// scalar flag in a config that keeps its real servers elsewhere. Emitting a
+	// null for it would make the backend reject the whole document and drop the
+	// valid mcpServers sitting beside it, so a value that isn't a map of servers
+	// is skipped rather than emitted empty.
+	if servers, ok := raw["mcp"]; ok {
+		if filtered := filterServerFields(servers); filtered != nil {
+			result["mcp"] = filtered
+			found = true
+		}
 	}
 	// Try project-scoped mcpServers (Claude Code ~/.claude.json)
 	// Structure: { "projects": { "<path>": { "mcpServers": { ... } } } }

--- a/internal/detector/mcp_discovery.go
+++ b/internal/detector/mcp_discovery.go
@@ -20,6 +20,12 @@ var mcpConfigBasenames = map[string]bool{
 	"mcp_settings.json":          true,
 	"cline_mcp_settings.json":    true,
 	"claude_desktop_config.json": true,
+	// OpenCode's project config sits in the working directory and is searched
+	// upward to the nearest Git directory. Recognizing the two basenames covers
+	// every project-level config under the search dirs without any project-root
+	// logic of its own.
+	"opencode.json":  true,
+	"opencode.jsonc": true,
 }
 
 // mcpWalkExcludeDirs are directory names never descended during the MCP walk:
@@ -176,6 +182,11 @@ func mcpVendorForPath(p string) string {
 	lp := strings.ToLower(p)
 	sep := string(filepath.Separator)
 	switch {
+	// Basename match, and deliberately first: the substring cases below match on
+	// any ancestor directory, so ~/dev/cursor-tools/opencode.json would otherwise
+	// be labelled Cursor. The filename is the stronger signal, so it wins.
+	case isOpenCodeConfigPath(p):
+		return "OpenCode"
 	case strings.Contains(lp, "vscodium"):
 		return "VSCodium"
 	case strings.Contains(lp, "cursor"):

--- a/internal/detector/mcp_discovery_test.go
+++ b/internal/detector/mcp_discovery_test.go
@@ -77,6 +77,74 @@ func TestMCPVendorForPath(t *testing.T) {
 	}
 }
 
+// TestMCPVendorForPath_OpenCode: the OpenCode case matches the basename, so it
+// claims exactly the two files this detector knows and nothing else. A path
+// test would be wrong in both directions — it would relabel an ordinary
+// .mcp.json sitting inside a checkout of the tool itself.
+func TestMCPVendorForPath_OpenCode(t *testing.T) {
+	sep := string(filepath.Separator)
+	cases := map[string]string{
+		filepath.Join(sep+"Users", "x", ".config", "opencode", "opencode.json"):  "OpenCode",
+		filepath.Join(sep+"Users", "x", ".config", "opencode", "opencode.jsonc"): "OpenCode",
+		filepath.Join(sep+"Users", "x", "proj", "opencode.json"):                 "OpenCode",
+		// The labeller folds case, but note it is not what decides whether a file
+		// is walked at all: discoverWalkedMCPConfigs gates on a case-sensitive
+		// mcpConfigBasenames lookup, so a project file actually named
+		// OpenCode.JSONC is never offered to this function in the first place.
+		// That predates OpenCode and holds for every basename; folding here just
+		// means the label is right whenever a path does arrive spelled oddly.
+		filepath.Join(sep+"Users", "x", "proj", "OpenCode.JSONC"): "OpenCode",
+		// Ordering is load-bearing: the substring cases match on any ancestor
+		// directory, so each of these would be claimed by a case below if the
+		// basename case did not come first.
+		filepath.Join(sep+"Users", "x", "dev", "cursor-tools", "opencode.json"):  "OpenCode", // else Cursor
+		filepath.Join(sep+"Users", "x", "dev", "claude-tools", "opencode.jsonc"): "OpenCode", // else Anthropic
+		filepath.Join(sep+"Users", "x", ".vscode", "opencode.json"):              "OpenCode", // else Microsoft
+		// An unrelated config that merely lives inside an opencode checkout.
+		filepath.Join(sep+"Users", "x", "src", "opencode", "example", ".mcp.json"): "Discovered",
+		// A file whose name only starts with the prefix.
+		filepath.Join(sep+"Users", "x", "proj", "opencode.json.bak"): "Discovered",
+	}
+	for p, want := range cases {
+		if got := mcpVendorForPath(p); got != want {
+			t.Errorf("mcpVendorForPath(%q) = %q, want %q", p, got, want)
+		}
+	}
+}
+
+// TestDiscoverWalkedMCPConfigs_OpenCode: a project-level OpenCode config in
+// either spelling is found by the ordinary basename walk — no project-root
+// logic and no new walk root — and is reported as discovered_mcp / OpenCode.
+func TestDiscoverWalkedMCPConfigs_OpenCode(t *testing.T) {
+	root := t.TempDir()
+	wantJSON := writeFile(t, root, "proj-a/opencode.json")
+	wantJSONC := writeFile(t, root, "proj-b/nested/opencode.jsonc")
+	writeFile(t, root, "proj-c/node_modules/pkg/opencode.json") // excluded dir
+	writeFile(t, root, "proj-d/opencode.json.bak")              // not a config
+
+	d := &MCPDetector{} // no skipper
+	specs := d.discoverWalkedMCPConfigs([]string{root}, "")
+	got := gotPathSet(specs)
+
+	if !got[wantJSON] {
+		t.Errorf("did not find %s", wantJSON)
+	}
+	if !got[wantJSONC] {
+		t.Errorf("did not find %s", wantJSONC)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 configs, got %d: %v", len(got), got)
+	}
+	for _, s := range specs {
+		if s.SourceName != "discovered_mcp" {
+			t.Errorf("%s: source = %q, want discovered_mcp", s.ConfigPath, s.SourceName)
+		}
+		if s.Vendor != "OpenCode" {
+			t.Errorf("%s: vendor = %q, want OpenCode", s.ConfigPath, s.Vendor)
+		}
+	}
+}
+
 // TestDiscoverWalkedMCPConfigs_TCCSkip: a config inside a TCC-protected subtree
 // (~/Library) is never walked, while one outside it is found. macOS-only,
 // since the TCC skipper is a no-op on other platforms.

--- a/internal/detector/mcp_test.go
+++ b/internal/detector/mcp_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -370,5 +372,478 @@ func TestMCPDetector_Windows_FindsConfigs(t *testing.T) {
 	}
 	if results[0].Vendor != "Anthropic" {
 		t.Errorf("expected Anthropic, got %s", results[0].Vendor)
+	}
+}
+
+// --------------------------------------------------------------------------
+// OpenCode
+//
+// OpenCode keeps its MCP servers under a top-level "mcp" map, in either
+// opencode.json or opencode.jsonc, and its own documented examples carry both
+// comments and trailing commas.
+// --------------------------------------------------------------------------
+
+// openCodeGoldenConfig and openCodeGoldenEmitted are the wire contract, byte
+// for byte. The backend parser is built in another repo against these same two
+// literals, and no unit test on either side can catch a discrepancy between
+// them — so they are copied verbatim rather than constructed, and a change to
+// either is a change to the contract.
+const openCodeGoldenConfig = `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "widgets-local": {
+      "type": "local",
+      "command": ["npx", "-y", "widgets-mcp-server@1.2.3"],
+      "cwd": "packages/widgets",
+      "environment": { "WIDGETS_TOKEN": "s3cr3t" },
+      "enabled": true,
+      "timeout": 5000
+    },
+    "widgets-remote": {
+      "type": "remote",
+      "url": "https://mcp.example-org.test/mcp",
+      "headers": { "Authorization": "Bearer s3cr3t" },
+      "enabled": false
+    }
+  }
+}`
+
+const openCodeGoldenEmitted = `{"mcp":{"widgets-local":{"command":["npx","-y","widgets-mcp-server@1.2.3"]},"widgets-remote":{"url":"https://mcp.example-org.test/mcp"}}}`
+
+const openCodeGlobalDir = "/Users/testuser/.config/opencode/"
+
+// TestMCPDetector_OpenCode_KnownPaths: both spellings of the global config are
+// known paths, reported under source "opencode" and vendor "OpenCode", and a
+// home holding both yields both — one entry each, deduped by path.
+func TestMCPDetector_OpenCode_KnownPaths(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+		want  []string
+	}{
+		{"json", []string{"opencode.json"}, []string{openCodeGlobalDir + "opencode.json"}},
+		{"jsonc", []string{"opencode.jsonc"}, []string{openCodeGlobalDir + "opencode.jsonc"}},
+		{
+			"both spellings",
+			[]string{"opencode.json", "opencode.jsonc"},
+			[]string{openCodeGlobalDir + "opencode.json", openCodeGlobalDir + "opencode.jsonc"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := executor.NewMock()
+			for _, f := range tc.files {
+				mock.SetFile(openCodeGlobalDir+f, []byte(openCodeGoldenConfig))
+			}
+
+			results := NewMCPDetector(mock).Detect(context.Background(), "testuser", nil, false)
+
+			if len(results) != len(tc.want) {
+				t.Fatalf("expected %d configs, got %d: %+v", len(tc.want), len(results), results)
+			}
+			for i, want := range tc.want {
+				if results[i].ConfigPath != want {
+					t.Errorf("config %d: path = %q, want %q", i, results[i].ConfigPath, want)
+				}
+				if results[i].ConfigSource != "opencode" {
+					t.Errorf("config %d: source = %q, want opencode", i, results[i].ConfigSource)
+				}
+				if results[i].Vendor != "OpenCode" {
+					t.Errorf("config %d: vendor = %q, want OpenCode", i, results[i].Vendor)
+				}
+			}
+		})
+	}
+}
+
+// TestMCPDetector_OpenCode_GoldenPayload: the golden config on disk emits the
+// golden string byte for byte. encoding/json sorts map keys, so this is a
+// stable literal comparison rather than a structural one — which is what lets
+// the backend assert on the same string.
+func TestMCPDetector_OpenCode_GoldenPayload(t *testing.T) {
+	mock := executor.NewMock()
+	mock.SetFile(openCodeGlobalDir+"opencode.json", []byte(openCodeGoldenConfig))
+
+	results := NewMCPDetector(mock).DetectEnterprise(context.Background(), nil)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 enterprise config, got %d", len(results))
+	}
+	decoded, err := base64.StdEncoding.DecodeString(results[0].ConfigContentBase64)
+	if err != nil {
+		t.Fatalf("failed to decode base64: %v", err)
+	}
+	if got := string(decoded); got != openCodeGoldenEmitted {
+		t.Errorf("emitted content mismatch\n got: %s\nwant: %s", got, openCodeGoldenEmitted)
+	}
+}
+
+// TestFilterMCPContent_OpenCode_DropsSecretBearingFields: environment, headers
+// and oauth all carry live credentials and are outside the allowlist, so none
+// of them — nor their values — reach the wire.
+func TestFilterMCPContent_OpenCode_DropsSecretBearingFields(t *testing.T) {
+	det := &MCPDetector{}
+
+	input := []byte(`{
+	  "mcp": {
+	    "local": {
+	      "type": "local",
+	      "command": ["npx", "-y", "widgets-mcp-server"],
+	      "environment": {"WIDGETS_TOKEN": "env-s3cr3t"}
+	    },
+	    "remote": {
+	      "type": "remote",
+	      "url": "https://mcp.example-org.test/mcp",
+	      "headers": {"Authorization": "Bearer hdr-s3cr3t"},
+	      "oauth": {"clientSecret": "oauth-s3cr3t"}
+	    }
+	  }
+	}`)
+
+	filtered, ok := det.filterMCPContent("opencode", openCodeGlobalDir+"opencode.json", input)
+	if !ok {
+		t.Fatal("expected filtering to succeed")
+	}
+
+	content := string(filtered)
+	for _, forbidden := range []string{
+		"environment", "headers", "oauth",
+		"env-s3cr3t", "hdr-s3cr3t", "oauth-s3cr3t",
+		"WIDGETS_TOKEN", "Authorization", "clientSecret",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Errorf("filtered content must not contain %q: %s", forbidden, content)
+		}
+	}
+	if !strings.Contains(content, `"command":["npx","-y","widgets-mcp-server"]`) {
+		t.Errorf("filtered content should preserve the argv array: %s", content)
+	}
+	if !strings.Contains(content, `"url":"https://mcp.example-org.test/mcp"`) {
+		t.Errorf("filtered content should preserve the remote url: %s", content)
+	}
+}
+
+// TestFilterMCPContent_OpenCode_JSONC: comments and trailing commas both parse.
+// The trailing-comma case is the one stripJSONCComments cannot handle — it
+// removes the comment and leaves the comma, and json.Unmarshal then rejects the
+// document — which is why OpenCode is normalized with hujson instead.
+func TestFilterMCPContent_OpenCode_JSONC(t *testing.T) {
+	// Copied from the vendor's own MCP documentation, which prints
+	// `"enabled": true,` immediately before a closing brace.
+	const trailingComma = `{
+	  "mcp": {
+	    "widgets": {
+	      "type": "local",
+	      "command": ["npx", "-y", "widgets-mcp-server@1.2.3"],
+	      "enabled": true,
+	    },
+	  },
+	}`
+
+	const comments = `{
+	  // the servers this project may talk to
+	  "mcp": {
+	    /* launched over stdio */
+	    "widgets": {
+	      "type": "local",
+	      "command": ["npx", "-y", "widgets-mcp-server@1.2.3"]
+	    }
+	  }
+	}`
+
+	const both = `{
+	  // the servers this project may talk to
+	  "mcp": {
+	    /* launched over stdio */
+	    "widgets": {
+	      "type": "local",
+	      "command": ["npx", "-y", "widgets-mcp-server@1.2.3"],
+	      "enabled": true,
+	    },
+	  },
+	}`
+
+	const wantEmitted = `{"mcp":{"widgets":{"command":["npx","-y","widgets-mcp-server@1.2.3"]}}}`
+
+	cases := []struct {
+		name  string
+		path  string
+		input string
+	}{
+		{"trailing comma", openCodeGlobalDir + "opencode.json", trailingComma},
+		{"comments", openCodeGlobalDir + "opencode.json", comments},
+		{"comments and trailing commas", openCodeGlobalDir + "opencode.json", both},
+		{"jsonc spelling", openCodeGlobalDir + "opencode.jsonc", both},
+		{"project-level, discovered source", "/Users/testuser/proj/opencode.jsonc", both},
+	}
+
+	det := &MCPDetector{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A project-level config arrives labelled discovered_mcp, so the
+			// JSONC handling cannot key off the source name.
+			source := "opencode"
+			if strings.Contains(tc.path, "/proj/") {
+				source = "discovered_mcp"
+			}
+			filtered, ok := det.filterMCPContent(source, tc.path, []byte(tc.input))
+			if !ok {
+				t.Fatalf("expected filtering to succeed for %s", tc.path)
+			}
+			if got := string(filtered); got != wantEmitted {
+				t.Errorf("emitted content mismatch\n got: %s\nwant: %s", got, wantEmitted)
+			}
+		})
+	}
+}
+
+// TestFilterMCPContent_OpenCode_FailsClosed: a config with no mcp key, and one
+// that is not JSON at all, both emit nothing rather than falling back to raw
+// content. The location is still reported (I8) — that is DetectEnterprise's
+// job, asserted here through the full detector.
+func TestFilterMCPContent_OpenCode_FailsClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"no mcp key", `{"theme":"dark","apiKey":"sk-secret-12345"}`},
+		{"malformed json", `{"mcp": {"widgets": {"command": ["npx"` + "\n"},
+		{"unterminated block comment", `{/* "mcp": {} }`},
+		{"not an object", `["mcp"]`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			det := &MCPDetector{}
+			filtered, ok := det.filterMCPContent("opencode", openCodeGlobalDir+"opencode.json", []byte(tc.content))
+			if ok {
+				t.Errorf("expected filtering to fail, got ok with %q", filtered)
+			}
+			if filtered != nil {
+				t.Errorf("expected nil content on failure, got %q", filtered)
+			}
+
+			// I8: the location is still reported, with empty content.
+			mock := executor.NewMock()
+			mock.SetFile(openCodeGlobalDir+"opencode.json", []byte(tc.content))
+			results := NewMCPDetector(mock).DetectEnterprise(context.Background(), nil)
+			if len(results) != 1 {
+				t.Fatalf("expected the location to still be reported, got %d configs", len(results))
+			}
+			if results[0].ConfigContentBase64 != "" {
+				t.Errorf("expected empty content, got %q", results[0].ConfigContentBase64)
+			}
+			if results[0].ConfigSource != "opencode" || results[0].Vendor != "OpenCode" {
+				t.Errorf("expected opencode/OpenCode, got %s/%s", results[0].ConfigSource, results[0].Vendor)
+			}
+		})
+	}
+}
+
+// TestFilterMCPContent_ScalarMCPKeyDoesNotEvictSiblings: "mcp" is an ordinary
+// enough word to appear as a scalar flag in a config whose real servers live
+// under mcpServers. Reading the key is new, so without a guard it would emit
+// "mcp":null for those files, the backend would reject the whole document, and
+// the valid mcpServers beside it would be lost — a regression reaching every
+// walked .mcp.json, not just OpenCode's own files.
+func TestFilterMCPContent_ScalarMCPKeyDoesNotEvictSiblings(t *testing.T) {
+	const siblings = `{"mcpServers":{"fs":{"command":"npx","args":["-y","s"]}},"mcp":%s}`
+	const wantSiblings = `{"mcpServers":{"fs":{"args":["-y","s"],"command":"npx"}}}`
+
+	for _, mcpValue := range []string{`true`, `"enabled"`, `["a"]`, `42`} {
+		t.Run("keeps siblings when mcp is "+mcpValue, func(t *testing.T) {
+			det := &MCPDetector{}
+			content := fmt.Sprintf(siblings, mcpValue)
+			filtered, ok := det.filterMCPContent("discovered_mcp", "/Users/testuser/proj/.mcp.json", []byte(content))
+			if !ok {
+				t.Fatalf("expected the valid mcpServers to still be emitted, got ok=false")
+			}
+			if string(filtered) != wantSiblings {
+				t.Errorf("emitted %s, want %s", filtered, wantSiblings)
+			}
+			if strings.Contains(string(filtered), `"mcp"`) {
+				t.Errorf("unusable mcp key must be dropped, not emitted empty: %s", filtered)
+			}
+		})
+
+		t.Run("fails closed when only mcp is "+mcpValue, func(t *testing.T) {
+			det := &MCPDetector{}
+			content := fmt.Sprintf(`{"mcp":%s}`, mcpValue)
+			filtered, ok := det.filterMCPContent("opencode", openCodeGlobalDir+"opencode.json", []byte(content))
+			if ok || filtered != nil {
+				t.Errorf("expected no content, got ok=%v %q", ok, filtered)
+			}
+		})
+	}
+
+	// An explicit null is the one non-map that json.Unmarshal accepts into a map
+	// type, so it decodes to an empty server set rather than a filter failure and
+	// is emitted as an empty object. That is not the eviction bug — an empty
+	// object parses backend-side and drops nothing — and it is exactly what a
+	// null under any of the other three keys already does, so the guard leaves
+	// the existing convention alone rather than making "mcp" the odd one out.
+	t.Run("null decodes to an empty set, like every other key", func(t *testing.T) {
+		// Asserted byte-exact, not just "mcpServers survived": the point of this
+		// subtest is that the empty object IS emitted. A looser check would keep
+		// passing if "mcp" started being dropped here too, silently turning the
+		// documented convention into the opposite behaviour.
+		const wantNull = `{"mcp":{},"mcpServers":{"fs":{"args":["-y","s"],"command":"npx"}}}`
+
+		det := &MCPDetector{}
+		filtered, ok := det.filterMCPContent("discovered_mcp", "/Users/testuser/proj/.mcp.json", fmt.Appendf(nil, siblings, `null`))
+		if !ok {
+			t.Fatalf("expected content, got ok=false")
+		}
+		if string(filtered) != wantNull {
+			t.Errorf("emitted %s, want %s", filtered, wantNull)
+		}
+
+		// Same shape under mcpServers, proving this is the pre-existing
+		// convention and not something the mcp branch introduced.
+		legacy, ok := det.filterMCPContent("cursor", "/Users/testuser/.cursor/mcp.json", []byte(`{"mcpServers":null}`))
+		if !ok || string(legacy) != `{"mcpServers":{}}` {
+			t.Errorf("mcpServers null convention changed: ok=%v %s", ok, legacy)
+		}
+	})
+
+	// Control: a well-formed mcp map is still emitted, so the guard rejects only
+	// what it cannot filter.
+	det := &MCPDetector{}
+	filtered, ok := det.filterMCPContent("opencode", openCodeGlobalDir+"opencode.json", []byte(openCodeGoldenConfig))
+	if !ok || string(filtered) != openCodeGoldenEmitted {
+		t.Errorf("valid mcp map regressed: ok=%v %s", ok, filtered)
+	}
+}
+
+// TestMCPDetector_OpenCode_ResolvesUnderResolvedHome: OpenCode uses the same
+// ~/.config/opencode layout on every platform, so both paths are expanded
+// against the home the detector was given — never against the process
+// environment, which on Windows belongs to the service account.
+func TestMCPDetector_OpenCode_ResolvesUnderResolvedHome(t *testing.T) {
+	cases := []struct {
+		goos string
+		home string
+	}{
+		{"windows", `C:\Users\testuser`},
+		{"linux", "/home/dev"},
+		{"darwin", "/Users/testuser"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			mock := executor.NewMock()
+			mock.SetGOOS(tc.goos)
+			mock.SetHomeDir(tc.home)
+			// A roaming profile belonging to somebody else entirely: no
+			// OpenCode path may be resolved through it.
+			mock.SetEnv("APPDATA", `C:\Users\svc-account\AppData\Roaming`)
+
+			for _, spelling := range []string{"opencode.json", "opencode.jsonc"} {
+				path := filepath.Join(tc.home, ".config", "opencode", spelling)
+				mock.SetFile(path, []byte(openCodeGoldenConfig))
+			}
+
+			results := NewMCPDetector(mock).Detect(context.Background(), "testuser", nil, false)
+
+			if len(results) != 2 {
+				t.Fatalf("expected 2 configs, got %d: %+v", len(results), results)
+			}
+			for _, r := range results {
+				if !strings.HasPrefix(r.ConfigPath, tc.home) {
+					t.Errorf("path %q is not under the resolved home %q", r.ConfigPath, tc.home)
+				}
+				if strings.Contains(r.ConfigPath, "svc-account") {
+					t.Errorf("path %q was resolved through the process environment", r.ConfigPath)
+				}
+				if r.ConfigSource != "opencode" || r.Vendor != "OpenCode" {
+					t.Errorf("expected opencode/OpenCode, got %s/%s", r.ConfigSource, r.Vendor)
+				}
+			}
+		})
+	}
+}
+
+// TestFilterMCPContent_NonOpenCodeUnchanged: adding OpenCode must not move any
+// other source onto a different code path. Zed still goes through
+// stripJSONCComments, the plain-JSON sources still go straight to the parser,
+// and a non-JSON config still emits nothing.
+func TestFilterMCPContent_NonOpenCodeUnchanged(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		path    string
+		content string
+		wantOK  bool
+		want    string
+	}{
+		{
+			"cursor", "cursor", "/Users/testuser/.cursor/mcp.json",
+			`{"mcpServers":{"notion":{"url":"https://mcp.notion.com/mcp","headers":{"k":"v"}}}}`,
+			true, `{"mcpServers":{"notion":{"url":"https://mcp.notion.com/mcp"}}}`,
+		},
+		{
+			"claude_desktop", "claude_desktop", "/Users/testuser/Library/Application Support/Claude/claude_desktop_config.json",
+			`{"mcpServers":{"fs":{"command":"npx","args":["-y","server"],"env":{"K":"V"}}}}`,
+			true, `{"mcpServers":{"fs":{"args":["-y","server"],"command":"npx"}}}`,
+		},
+		{
+			"zed keeps the comment stripper", "zed", "/Users/testuser/.config/zed/settings.json",
+			"{\n  // servers\n  \"context_servers\":{\"fs\":{\"command\":\"npx\"}}\n}",
+			true, `{"context_servers":{"fs":{"command":"npx"}}}`,
+		},
+		{
+			"vscode", "vscode", "/Users/testuser/.vscode/mcp.json",
+			`{"servers":{"fs":{"command":"npx","env":{"K":"V"}}}}`,
+			true, `{"servers":{"fs":{"command":"npx"}}}`,
+		},
+		{
+			"codex toml still emits nothing", "codex", "/Users/testuser/.codex/config.toml",
+			"[mcp_servers.fs]\ncommand = \"npx\"\n",
+			false, "",
+		},
+	}
+
+	det := &MCPDetector{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filtered, ok := det.filterMCPContent(tc.source, tc.path, []byte(tc.content))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (content %q)", ok, tc.wantOK, filtered)
+			}
+			if got := string(filtered); tc.wantOK && got != tc.want {
+				t.Errorf("emitted content mismatch\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMCPConfigDefinitions_OpenCodeIsPlatformAgnostic: the two OpenCode
+// definitions leave the Windows and Linux fields empty on purpose, so every
+// consumer that walks mcpConfigDefinitions — including the known-user-config
+// resolver the credential inventory reads — expands them against the home it
+// was given rather than a per-platform override.
+func TestMCPConfigDefinitions_OpenCodeIsPlatformAgnostic(t *testing.T) {
+	found := make(map[string]bool)
+	for _, spec := range mcpConfigDefinitions {
+		if spec.SourceName != "opencode" {
+			continue
+		}
+		found[spec.ConfigPath] = true
+		if spec.Vendor != "OpenCode" {
+			t.Errorf("%s: vendor = %q, want OpenCode", spec.ConfigPath, spec.Vendor)
+		}
+		if spec.WinConfigPath != "" || spec.LinuxConfigPath != "" {
+			t.Errorf("%s: expected empty per-platform overrides, got win=%q linux=%q",
+				spec.ConfigPath, spec.WinConfigPath, spec.LinuxConfigPath)
+		}
+	}
+	for _, want := range []string{
+		"~/.config/opencode/opencode.json",
+		"~/.config/opencode/opencode.jsonc",
+	} {
+		if !found[want] {
+			t.Errorf("mcpConfigDefinitions is missing %s", want)
+		}
 	}
 }


### PR DESCRIPTION
## What

OpenCode servers were invisible to the MCP inventory. Three things about its config kept it out of every existing path:

- servers live under a top-level **`mcp`** key, not `mcpServers`;
- the config is accepted under **two basenames**, `opencode.json` and `opencode.jsonc`;
- OpenCode's own documented examples carry **comments *and* trailing commas**.

This reads all of it.

| | |
|---|---|
| Global config | `~/.config/opencode/opencode.{json,jsonc}` — known exact paths, same layout on every platform |
| Project config | found by the existing bounded walk, via two new recognized basenames |
| Vendor label | basename match, ordered *ahead* of the substring cases |
| Wire key | `mcp` preserved as-is — this pipeline filters fields, it never rewrites another vendor's schema |

Both global paths resolve against the home the detector was given, never the process environment, which on Windows belongs to the service account. Both spellings route through `hujson.Standardize`, which handles the trailing commas the comment stripper alone does not.

## Secrets

Unchanged and deny-by-default. The allowlist is still `command` / `args` / `serverUrl` / `url`, so OpenCode's `environment` and `headers` blocks are never collected, and a parse failure still emits empty content rather than raw bytes. Byte-exact filter tests and forbidden-key assertions cover both.

## The one behavioural guard worth reviewing

`internal/detector/mcp.go` — a value under `mcp` that is not a map of servers is **skipped**, not emitted empty:

```go
if servers, ok := raw["mcp"]; ok {
    if filtered := filterServerFields(servers); filtered != nil {
        result["mcp"] = filtered
        found = true
    }
}
```

Without it, `{"mcpServers":{...},"mcp":true}` emits `{"mcp":null,"mcpServers":{...}}`, the backend rejects the whole document (`mcp is not an object`), and the *valid* `mcpServers` beside it is dropped. `mcp` is an ordinary enough word to show up as a scalar flag, so that regression would reach every walked `.mcp.json`, not just OpenCode's files.

Scoped deliberately:
- **`"mcp": null` is left emitting `{"mcp":{}}`.** `null` is the one non-map `json.Unmarshal` accepts into a map type, so it decodes to an empty set, not a filter failure. An empty object parses backend-side and evicts nothing, and it is exactly what `{"mcpServers":null}` has always done — tightening only `mcp` would make it the odd key out. Pinned byte-exact in both directions.
- `mcpServers` / `context_servers` / `servers` are untouched. Same latent shape, but pre-existing and not introduced here.

## Tests

- Scalar `mcp` values (`true`, `"enabled"`, `["a"]`, `42`): siblings survive, and a *lone* scalar fails closed with no content.
- Vendor-label ordering pinned by `cursor-tools/`, `claude-tools/` and `.vscode/` rows — each would be claimed by a later substring case if the basename case did not come first.
- Negative rows: `.mcp.json` inside an *opencode checkout* stays `Discovered`, as does `opencode.json.bak`.
- Home resolution asserted on all three GOOS.

Mutation-checked rather than assumed: reverting the nil guard reproduces the exact bad wire shape, moving the basename case last flips all three ordering rows, and weakening the guard to `len(filtered) > 0` flips the null assertion.

## Docs

`README.md`, `SCAN_COVERAGE.md` (global + project rows) and `docs/mcp-audit.md`, which now names OpenCode's `environment` alongside `env` as stripped. The MCP table's first column widened 16 → 18 to fit `OpenCode (project)`; the 11 sibling rows are whitespace-only.

Not fixed here: `docs/mcp-audit.md:75` still claims non-JSON configs are included as-is, which is false today and predates this change. Separate fix.

## Not stacked on #186

#186 (credential inventory) also touches OpenCode config parsing. This branch is independently based on `main` and shares no files with it, so either can merge first. Once both land, the literal `DetectKnownUserConfigs` assertion belongs in a follow-up.

## Verification

`gofmt` clean · `go vet` 0 · `go test ./... -race -count=1` → **42 packages ok, 0 failures, 0 data races** · `golangci-lint run ./...` → **0 issues** · `make smoke` → **44/44** · `CGO_ENABLED=0` builds green for `linux/amd64`, `darwin/arm64`, `windows/amd64`.

No version or changelog bump — that is the release cut's job.

End-to-end coverage is in a companion integration-test PR, held until this ships in a release.
