### PR TITLE
feat(detector): find Copilot CLI installs that never land on PATH

### DIFF
--- a/SCAN_COVERAGE.md
+++ b/SCAN_COVERAGE.md
@@ -42,7 +42,7 @@ Detection is cross-platform — binaries are located via `$PATH` lookup and home
 | Codex                 | OpenAI    | `codex`                     | `~/.codex`                      |
 | Gemini CLI            | Google    | `gemini`                    | `~/.gemini`                     |
 | Amazon Q / Kiro CLI   | Amazon    | `kiro-cli`, `kiro`, `q`     | `~/.q`, `~/.kiro`, `~/.aws/q`  |
-| GitHub Copilot CLI    | Microsoft | `copilot`, `gh-copilot`     | `~/.config/github-copilot`      |
+| GitHub Copilot CLI    | Microsoft | `copilot`, `gh-copilot`†    | `~/.config/github-copilot`, `~/.copilot` |
 | Microsoft AI Shell    | Microsoft | `aish`, `ai`                | `~/.aish`                       |
 | Aider                 | OpenSource| `aider`                     | `~/.aider`                      |
 | OpenCode              | OpenSource| `opencode`                  | `~/.config/opencode`            |
@@ -50,6 +50,8 @@ Detection is cross-platform — binaries are located via `$PATH` lookup and home
 | Pi                    | Earendil  | `pi`                        | `~/.pi/agent`                   |
 | Factory Droid         | Factory   | `droid`                     | `~/.factory`                    |
 | Amp                   | Sourcegraph| `amp`                      | `~/.config/amp`                 |
+
+† `gh copilot` launches this same `@github/copilot` CLI, downloading it into gh's own data directory when it isn't already on `$PATH` — so that install never lands on `$PATH`. After the two binary names miss, Copilot is also looked for at `~/.local/share/gh/copilot/copilot`, `~/.local/bin/copilot`, `~/AppData/Local/GitHub CLI/copilot/copilot`, `~/AppData/Local/Microsoft/WinGet/Links/copilot.exe`, `~/AppData/Roaming/npm/copilot.cmd`, and the `gh-copilot` extension directory under both `~/.local/share/gh/extensions` and `~/AppData/Local/GitHub CLI/extensions`. A non-default `$XDG_DATA_HOME` is not followed, and WinGet's hashed `Packages\GitHub.Copilot_<hash>\` payload directory is not globbed — only its `Links` shim.
 
 Pi, Factory Droid and Amp share their binary names with unrelated popular tools, so a `$PATH` hit alone does not report them — each is confirmed from an on-disk artifact (a package manifest, an installer anchor directory, a Homebrew cask root, a winget or pacman package entry), and is searched for in the common global-install prefixes as well as on `$PATH`. Pi and Amp are never executed because macOS Gatekeeper prompts on their binaries; their versions come from disk or are reported as `unknown`.
 

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -107,10 +107,23 @@ var cliToolDefinitions = []cliToolSpec{
 		},
 	},
 	{
-		Name:       "github-copilot-cli",
-		Vendor:     "Microsoft",
-		Binaries:   []string{"copilot", "gh-copilot"},
-		ConfigDirs: []string{"~/.config/github-copilot"},
+		Name:   "github-copilot-cli",
+		Vendor: "Microsoft",
+		// `gh copilot` launches this same CLI, downloading it into gh's own data
+		// directory when it isn't on PATH, so that install never lands on PATH.
+		// Bare names stay first, so PATH hits keep resolving from the npm
+		// manifest without exec'ing anything.
+		Binaries: []string{
+			"copilot", "gh-copilot",
+			"~/.local/share/gh/copilot/copilot",
+			"~/AppData/Local/GitHub CLI/copilot/copilot",
+			"~/.local/bin/copilot",
+			"~/AppData/Local/Microsoft/WinGet/Links/copilot.exe",
+			"~/AppData/Roaming/npm/copilot.cmd",
+			"~/.local/share/gh/extensions/gh-copilot/gh-copilot",
+			"~/AppData/Local/GitHub CLI/extensions/gh-copilot/gh-copilot",
+		},
+		ConfigDirs: []string{"~/.config/github-copilot", "~/.copilot"},
 		// Reject the VS Code Copilot Chat extension's shim, which lives on PATH
 		// even when the real CLI isn't installed and replies to `--version` with
 		// "GitHub Copilot CLI is not installed. Would you like to install it? (Y/n)".

--- a/internal/detector/aicli_agents_test.go
+++ b/internal/detector/aicli_agents_test.go
@@ -915,6 +915,25 @@ func TestAICLIAgents_NoRegression(t *testing.T) {
 				version: "1.2.3", configRel: "~/.config/github-copilot",
 			}},
 		},
+		{
+			// Nothing on PATH: the only way to this row is the gh data-directory
+			// anchor, and with no manifest beside it both probes must be execs.
+			name: "(c) the Copilot CLI gh downloads for itself is found off PATH",
+			setup: func(m *executor.Mock, home string) {
+				bin := expandTilde("~/.local/share/gh/copilot/copilot", home)
+				addBinary(m, bin, 40<<20)
+				m.SetCommand("GitHub Copilot CLI 2077.1.1\n", "", 0, bin, "--version")
+			},
+			allowExec: true,
+			want: []aicliWant{{
+				tool: "github-copilot-cli", binary: "/home/u/.local/share/gh/copilot/copilot",
+				version: "2077.1.1",
+			}},
+			wantExecs: []aicliExecCall{
+				{name: "/home/u/.local/share/gh/copilot/copilot", args: []string{"--version"}},
+				{name: "/home/u/.local/share/gh/copilot/copilot", args: []string{"--version"}},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

`gh copilot` launches the same `@github/copilot` CLI, downloading it into gh's own data directory when it isn't already on `$PATH`. That install never lands on `$PATH`, so a bare-name lookup can't see it — users who let gh install Copilot for them read as having no Copilot CLI at all.

Adds that directory for both platform spellings, plus five more home-relative anchors:

| Anchor | Channel |
|--------|---------|
| `~/.local/share/gh/copilot/copilot` | `gh copilot` download (macOS, Linux) |
| `~/AppData/Local/GitHub CLI/copilot/copilot` | `gh copilot` download (Windows) |
| `~/.local/bin/copilot` | install script run as a non-root user |
| `~/AppData/Local/Microsoft/WinGet/Links/copilot.exe` | WinGet `GitHub.Copilot` shim |
| `~/AppData/Roaming/npm/copilot.cmd` | npm global shim |
| `~/.local/share/gh/extensions/gh-copilot/gh-copilot` | `gh-copilot` extension |
| `~/AppData/Local/GitHub CLI/extensions/gh-copilot/gh-copilot` | `gh-copilot` extension |

The two Windows shims are the ones a machine-context scan misses, because those directories are on the *user's* `PATH`. On Windows each anchor is also tried with `.exe`, which is existing `findBinary` behaviour.

Two ordering details:

- **Bare names stay first**, so machines that already resolve `copilot` through `$PATH` keep taking that branch — identity from the npm manifest, nothing executed. The anchors are only reached after `LookPath` misses, so no existing detection changes.
- **`~/.copilot` is appended** to the config dirs, not prepended. `findConfigDir` returns the first directory that exists, so appending can only turn an empty answer into a real one.

Two limits are documented in `SCAN_COVERAGE.md` rather than worked around: a non-default `$XDG_DATA_HOME` is not followed (the scan runs as a root daemon and doesn't have the user's value), and WinGet's hashed `Packages\GitHub.Copilot_<hash>\` payload directory needs globbing that binary-name resolution doesn't do — only its `Links` shim is covered.

## Type of change

- [ ] Bug fix
- [x] Enhancement
- [x] Documentation

## Testing

- [x] Tested on macOS (version: 26.5.2)
- [x] Binary runs without errors: `./stepsecurity-dev-machine-guard --verbose`
- [x] JSON output is valid: `./stepsecurity-dev-machine-guard --json | python3 -m json.tool`
- [x] No secrets or credentials included
- [x] Lint passes: `make lint` (0 issues)
- [x] Tests pass: `make test`

One case added to `TestAICLIAgents_NoRegression`, covering the new channel with nothing on `$PATH`: no manifest beside the binary, so both probes have to be execs. Removing the anchor from the spec fails it as `github-copilot-cli: not detected`.

End-to-end on the real thing, [integration-test run 31791817876](https://github.com/step-security/integration-test/actions/runs/31791817876) (step-security/integration-test#1138), where the macOS lane plants the measured layout and the agent finds it off `$PATH`:

```
✅  copilot gh-anchor fixture -> PLANTED @ /Users/runner/.local/share/gh/copilot/copilot
[scanning] exec fallback: running .../gh/copilot/copilot --version (copilot identity check)
[scanning] exec fallback: running .../gh/copilot/copilot --version (no metadata version source)
[scanning]   Found: github-copilot-cli (Microsoft) v2077.1.79. at /Users/runner/.local/share/gh/copilot/copilot
```

That run was built from `776a4d7`, this branch before the comments were trimmed; `internal/detector/aicli.go` is byte-identical to the current head once comment lines are stripped, so it covers this code. The Linux lane reached the same result at scan level (`Found: github-copilot-cli (Microsoft) v2077.1.79. at /home/runner/.local/share/gh/copilot/copilot`) but its suite hit the 20-minute `go test` timeout on unrelated failures — same signature as run 31636606284 on a branch predating this work. The Windows lane's single failure is the pre-existing `grunt-cli(yarn)` global.

Also cross-built `CGO_ENABLED=0` for darwin, linux and windows. A local scan on a machine with no Copilot CLI installed reports the same 6 AI rows as before, none of them Copilot — the anchors add no spurious detections.

## Related Issues

<!-- none -->
