### PR TITLE
feat(devicepolicy): add Go package configuration policy

### DIFF
--- a/cmd/stepsecurity-dev-machine-guard/main.go
+++ b/cmd/stepsecurity-dev-machine-guard/main.go
@@ -834,7 +834,7 @@ func runIDEExtensionEnforce(exec executor.Executor, log *progress.Logger) {
 	}
 }
 
-// runPackageConfigEnforce runs npm and PyPI independently after resolving their
+// runPackageConfigEnforce runs npm, PyPI, and Go independently after resolving their
 // shared enterprise and device identity once. Failures never crash main.
 func runPackageConfigEnforce(exec executor.Executor, log *progress.Logger) {
 	cfg, ok := ingest.Snapshot()
@@ -881,6 +881,15 @@ func runPackageConfigLanes(exec executor.Executor, log *progress.Logger, fetcher
 		log.Warn("%v", wrapped)
 		aiagentscli.AppendError("devicepolicy", "enforce_failed", wrapped.Error(), "")
 	}
+
+	goCtx, goCancel := context.WithTimeout(context.Background(), devicePolicyEnforceTimeout)
+	goErr := runGoPackageConfigLane(goCtx, exec, log, fetcher, reporter, customerID, serial, platform)
+	goCancel()
+	if goErr != nil {
+		wrapped := fmt.Errorf("go package-config enforce: %w", goErr)
+		log.Warn("%v", wrapped)
+		aiagentscli.AppendError("devicepolicy", "enforce_failed", wrapped.Error(), "")
+	}
 }
 
 func runNPMPackageConfigLane(ctx context.Context, exec executor.Executor, log *progress.Logger, fetcher devicepolicy.Fetcher, reporter devicepolicy.Reporter, customerID, serial, platform string) error {
@@ -920,6 +929,19 @@ func runNPMPackageConfigLane(ctx context.Context, exec executor.Executor, log *p
 
 func runPyPIPackageConfigLane(ctx context.Context, exec executor.Executor, log *progress.Logger, fetcher devicepolicy.Fetcher, reporter devicepolicy.Reporter, customerID, serial, platform string) error {
 	coordinator := &devicepolicy.PyPICoordinator{
+		Fetcher:    fetcher,
+		Reporter:   reporter,
+		Exec:       exec,
+		CustomerID: customerID,
+		DeviceID:   serial,
+		Platform:   platform,
+		Logf:       func(format string, args ...any) { log.Debug(format, args...) },
+	}
+	return coordinator.Reconcile(ctx)
+}
+
+func runGoPackageConfigLane(ctx context.Context, exec executor.Executor, log *progress.Logger, fetcher devicepolicy.Fetcher, reporter devicepolicy.Reporter, customerID, serial, platform string) error {
+	coordinator := &devicepolicy.GoCoordinator{
 		Fetcher:    fetcher,
 		Reporter:   reporter,
 		Exec:       exec,

--- a/cmd/stepsecurity-dev-machine-guard/main_devicepolicy_test.go
+++ b/cmd/stepsecurity-dev-machine-guard/main_devicepolicy_test.go
@@ -126,8 +126,9 @@ func TestPackageConfigLanes_FailureDoesNotSuppressSibling(t *testing.T) {
 		name       string
 		failTarget string
 	}{
-		{"npm failure still runs PyPI", devicepolicy.TargetNPM},
-		{"PyPI failure keeps npm success", devicepolicy.TargetPyPI},
+		{"npm failure still runs siblings", devicepolicy.TargetNPM},
+		{"PyPI failure still runs siblings", devicepolicy.TargetPyPI},
+		{"Go failure keeps earlier lanes", devicepolicy.TargetGo},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -137,7 +138,7 @@ func TestPackageConfigLanes_FailureDoesNotSuppressSibling(t *testing.T) {
 
 			runPackageConfigLanes(mock, progress.NewNoop(), fetcher, packageConfigReporter{}, "customer", "serial", "linux")
 
-			if got, want := strings.Join(fetcher.calls, ","), devicepolicy.TargetNPM+","+devicepolicy.TargetPyPI; got != want {
+			if got, want := strings.Join(fetcher.calls, ","), devicepolicy.TargetNPM+","+devicepolicy.TargetPyPI+","+devicepolicy.TargetGo; got != want {
 				t.Errorf("lane calls = %q, want %q", got, want)
 			}
 		})
@@ -153,16 +154,20 @@ func TestPackageConfigLanes_UseSeparateTimeoutContexts(t *testing.T) {
 
 	npmCtx := fetcher.contexts[devicepolicy.TargetNPM]
 	pypiCtx := fetcher.contexts[devicepolicy.TargetPyPI]
-	if npmCtx == nil || pypiCtx == nil {
-		t.Fatalf("lane contexts = %#v, want both", fetcher.contexts)
+	goCtx := fetcher.contexts[devicepolicy.TargetGo]
+	if npmCtx == nil || pypiCtx == nil || goCtx == nil {
+		t.Fatalf("lane contexts = %#v, want all three", fetcher.contexts)
 	}
-	if npmCtx == pypiCtx {
-		t.Error("npm and PyPI shared one context")
+	if npmCtx == pypiCtx || npmCtx == goCtx || pypiCtx == goCtx {
+		t.Error("package-config lanes shared a context")
 	}
 	if _, ok := npmCtx.Deadline(); !ok {
 		t.Error("npm context has no deadline")
 	}
 	if _, ok := pypiCtx.Deadline(); !ok {
 		t.Error("PyPI context has no deadline")
+	}
+	if _, ok := goCtx.Deadline(); !ok {
+		t.Error("Go context has no deadline")
 	}
 }

--- a/internal/detector/configaudit/pipconfig.go
+++ b/internal/detector/configaudit/pipconfig.go
@@ -315,6 +315,12 @@ func pipAllowedUserPaths(exec executor.Executor, home string) []string {
 	return out
 }
 
+// TrustedPipUserPaths returns the static home-confined pip user paths without
+// locating or executing a package manager.
+func TrustedPipUserPaths(exec executor.Executor, home string) []string {
+	return pipAllowedUserPaths(exec, home)
+}
+
 type pipUserConfigPath struct {
 	path  string
 	layer string

--- a/internal/devicepolicy/go_coordinator.go
+++ b/internal/devicepolicy/go_coordinator.go
@@ -1,0 +1,690 @@
+package devicepolicy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/step-security/dev-machine-guard/internal/detector/configaudit"
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/model"
+	"github.com/step-security/dev-machine-guard/internal/secureuserfile"
+)
+
+const (
+	goCredentialOwnershipKey = "credential"
+	goEnvOwnershipKey        = "go-env"
+)
+
+// GoCoordinator fetches one Go policy and coordinates its shared credential
+// and default Go environment file.
+type GoCoordinator struct {
+	Fetcher    Fetcher
+	Reporter   Reporter
+	Exec       executor.Executor
+	CustomerID string
+	DeviceID   string
+	Platform   string
+	Logf       func(format string, args ...any)
+
+	buildComponents func(executor.Executor, GoPolicy) (*goComponents, error)
+	writeState      func(category, target string, state AppliedTargetState) error
+	clearState      func(category, target string) error
+}
+
+type goComponents struct {
+	credential           *goComponent
+	env                  *goComponent
+	hasPyPISibling       func() (bool, error)
+	hasManagedCredential func() (bool, error)
+	close                func() error
+}
+
+type goComponent struct {
+	name                string
+	ownershipTarget     string
+	ownershipKey        string
+	ownershipStateValue string
+	writer              Writer
+	initErr             error
+	expected            string
+	converged           func(string) (bool, error)
+	staticConverged     func(string) (bool, error)
+	restoreSnapshot     func() error
+	hasMDMMarker        func() (bool, error)
+	mdmOwned            func() (bool, error)
+	completeState       func(AppliedTargetState, bool, *AppliedTargetState) error
+	prepareWrite        func(AppliedTargetState, bool) error
+	prepareClear        func(AppliedTargetState, bool) error
+	preflight           func() error
+	observe             func() (goComponentObservation, error)
+}
+
+type goComponentObservation struct {
+	auth string
+	env  *GoEnvObservation
+}
+
+type goComponentResult struct {
+	name            string
+	state           string
+	err             error
+	observation     goComponentObservation
+	observationErr  error
+	staticConverged bool
+}
+
+type goFixedFetcher struct{ policy EffectivePolicy }
+
+func (f goFixedFetcher) Fetch(_ context.Context, _, _, category, target string) (EffectivePolicy, error) {
+	if category != CategoryPackageConfig || target != TargetGo {
+		return EffectivePolicy{}, errors.New("devicepolicy: fixed Go fetch identity mismatch")
+	}
+	return f.policy, nil
+}
+
+// Reconcile runs one fetch-once package_config/go cycle.
+func (c *GoCoordinator) Reconcile(ctx context.Context) error {
+	if c.Fetcher == nil {
+		return errors.New("devicepolicy: nil Go fetcher")
+	}
+	effective, err := c.Fetcher.Fetch(ctx, c.CustomerID, c.DeviceID, CategoryPackageConfig, TargetGo)
+	if err != nil {
+		return fmt.Errorf("devicepolicy: fetch Go policy: %w", err)
+	}
+	if !effective.present() {
+		c.logf("devicepolicy: run-config carried no package_config/go policy; leaving state untouched")
+		return nil
+	}
+	if effective.Clear {
+		host, hostErr := c.clearRegistryHost()
+		if host == "" {
+			host = "invalid.invalid"
+		}
+		return c.clear(ctx, effective, clearGoPolicy(host), hostErr)
+	}
+	policy, err := ParseGoPolicy(effective.Policy, c.DeviceID)
+	if err != nil {
+		return errors.Join(err, c.report(ctx, StatePolicyNotApplied, "", effective.Hash, canonicalEnforcement(effective.Enforcement), nil))
+	}
+	components, err := c.components(policy)
+	if err != nil {
+		state := StateWriteFailed
+		if errors.Is(err, ErrNoTargetUser) || errors.Is(err, secureuserfile.ErrNoTargetUser) {
+			state = StatePolicyNotApplied
+		}
+		return errors.Join(err, c.report(ctx, state, "", effective.Hash, canonicalEnforcement(effective.Enforcement), nil))
+	}
+	if components.close != nil {
+		defer func() { _ = components.close() }()
+	}
+	effective.Enforcement = canonicalEnforcement(effective.Enforcement)
+	if effective.Enforcement == enforcementMDM {
+		return c.reconcileMDM(ctx, effective, policy, components)
+	}
+	return c.reconcileDMG(ctx, effective, policy, components)
+}
+
+func (c *GoCoordinator) clear(ctx context.Context, effective EffectivePolicy, policy GoPolicy, credentialInitErr error) error {
+	components, err := c.components(policy)
+	if err != nil {
+		return fmt.Errorf("devicepolicy: Go clear requires an enforceable target user: %w", err)
+	}
+	if components.close != nil {
+		defer func() { _ = components.close() }()
+	}
+	if credentialInitErr != nil {
+		components.credential.initErr = errors.Join(components.credential.initErr, credentialInitErr)
+	}
+	effective.Enforcement = enforcementDMG
+	envResult := c.runClear(ctx, effective, components.env)
+	if envResult.err != nil {
+		return envResult.err
+	}
+	sibling, err := components.hasPyPISibling()
+	if err != nil {
+		return fmt.Errorf("devicepolicy: inspect PyPI sibling marker: %w", err)
+	}
+	if sibling {
+		if err := c.clearOwnershipState(CategoryPackageConfig, GoCredentialOwnershipTarget); err != nil {
+			return fmt.Errorf("devicepolicy: release shared Go credential ownership: %w", err)
+		}
+		return nil
+	}
+	if credentialInitErr != nil && components.hasManagedCredential != nil {
+		managed, err := components.hasManagedCredential()
+		if err != nil {
+			return fmt.Errorf("devicepolicy: inspect shared credential marker: %w", err)
+		}
+		if !managed {
+			return c.clearOwnershipState(CategoryPackageConfig, GoCredentialOwnershipTarget)
+		}
+	}
+	return c.runClear(ctx, effective, components.credential).err
+}
+
+func (c *GoCoordinator) reconcileMDM(ctx context.Context, effective EffectivePolicy, policy GoPolicy, components *goComponents) error {
+	results := []goComponentResult{c.observeMDM(components.credential), c.observeMDM(components.env)}
+	observed, observedErr := buildGoObserved(policy, results)
+	state := StateMDMManaged
+	for _, result := range results {
+		if result.err != nil || result.observationErr != nil {
+			state = StateVerificationFailed
+			break
+		}
+		if result.state != StateMDMManaged {
+			state = StatePolicyNotApplied
+		}
+	}
+	if observedErr != nil {
+		state = StateVerificationFailed
+	}
+	return errors.Join(goComponentErrors(results), observedErr, c.report(ctx, state, "", effective.Hash, enforcementMDM, observed))
+}
+
+func (c *GoCoordinator) observeMDM(component *goComponent) goComponentResult {
+	result := c.observeOnly(component)
+	if result.observationErr != nil || component == nil || component.mdmOwned == nil {
+		result.state = StateVerificationFailed
+		return result
+	}
+	owned, err := component.mdmOwned()
+	if err != nil {
+		result.state, result.err = StateVerificationFailed, err
+	} else if owned && goObservationState(result.observation, nil) == StateCompliant {
+		result.state = StateMDMManaged
+	} else {
+		result.state = StatePolicyNotApplied
+	}
+	return result
+}
+
+func (c *GoCoordinator) reconcileDMG(ctx context.Context, effective EffectivePolicy, policy GoPolicy, components *goComponents) error {
+	managed := false
+	var markerErrs []error
+	for _, component := range []*goComponent{components.credential, components.env} {
+		if component == nil || component.initErr != nil {
+			if component != nil && component.initErr != nil {
+				markerErrs = append(markerErrs, component.initErr)
+			}
+			continue
+		}
+		present, err := component.hasMDMMarker()
+		if err != nil {
+			markerErrs = append(markerErrs, fmt.Errorf("devicepolicy: inspect %s MDM marker: %w", component.name, err))
+			continue
+		}
+		managed = managed || present
+	}
+	if managed {
+		results := []goComponentResult{c.observeMDM(components.credential), c.observeMDM(components.env)}
+		observed, observedErr := buildGoObserved(policy, results)
+		state := StateMDMManaged
+		if len(markerErrs) != 0 || observedErr != nil || goComponentErrors(results) != nil {
+			state = StateVerificationFailed
+		} else {
+			for _, result := range results {
+				if result.state != StateMDMManaged {
+					state = StatePolicyNotApplied
+					break
+				}
+			}
+		}
+		return errors.Join(errors.Join(markerErrs...), goComponentErrors(results), observedErr, c.report(ctx, state, "", effective.Hash, enforcementDMG, observed))
+	}
+	if len(markerErrs) != 0 {
+		return errors.Join(errors.Join(markerErrs...), c.report(ctx, StateVerificationFailed, "", effective.Hash, enforcementDMG, nil))
+	}
+	for _, component := range []*goComponent{components.credential, components.env} {
+		if component.initErr != nil {
+			return errors.Join(component.initErr, c.report(ctx, StateVerificationFailed, "", effective.Hash, enforcementDMG, nil))
+		}
+		if component.preflight != nil {
+			if err := component.preflight(); err != nil {
+				return errors.Join(err, c.report(ctx, StateVerificationFailed, "", effective.Hash, enforcementDMG, nil))
+			}
+		}
+	}
+
+	previous, hadPrevious := ReadAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget)
+	credentialConverged, convergeErr := components.credential.converged(components.credential.expected)
+	if convergeErr != nil {
+		return errors.Join(convergeErr, c.report(ctx, StateVerificationFailed, "", effective.Hash, enforcementDMG, nil))
+	}
+	credentialResult := c.runComponent(ctx, effective, components.credential)
+	results := []goComponentResult{credentialResult}
+	if !goComponentSucceeded(credentialResult.state) {
+		envResult := c.observeOnly(components.env)
+		envResult.state = StatePolicyNotApplied
+		results = append(results, envResult)
+		return c.finishDMG(ctx, effective, policy, results)
+	}
+
+	envResult := c.runComponent(ctx, effective, components.env)
+	results = append(results, envResult)
+	credentialChanged := !credentialConverged && goComponentSucceeded(credentialResult.state)
+	if credentialChanged && !envResult.staticConverged {
+		rollbackErr := components.credential.restoreSnapshot()
+		rollbackState := StateWriteFailed
+		if rollbackErr != nil {
+			rollbackState = StateVerificationFailed
+		} else if hadPrevious {
+			rollbackErr = c.writeOwnershipState(CategoryPackageConfig, GoCredentialOwnershipTarget, previous)
+		} else {
+			rollbackErr = c.clearOwnershipState(CategoryPackageConfig, GoCredentialOwnershipTarget)
+		}
+		if rollbackErr != nil && rollbackState != StateVerificationFailed {
+			rollbackState = StateWriteFailed
+		}
+		results = append(results, goComponentResult{name: "credential_rollback", state: rollbackState, err: rollbackErr})
+		refreshed := c.observeOnly(components.credential)
+		results[0].observation, results[0].observationErr = refreshed.observation, refreshed.observationErr
+	}
+	return c.finishDMG(ctx, effective, policy, results)
+}
+
+func (c *GoCoordinator) finishDMG(ctx context.Context, effective EffectivePolicy, policy GoPolicy, results []goComponentResult) error {
+	observed, observedErr := buildGoObserved(policy, results)
+	state := aggregateGoState(results)
+	if observedErr != nil {
+		state = StateVerificationFailed
+	}
+	appliedHash := ""
+	if state == StateCompliant || state == StateDriftDetected {
+		appliedHash = effective.Hash
+	}
+	return errors.Join(goComponentErrors(results), observedErr, c.report(ctx, state, appliedHash, effective.Hash, enforcementDMG, observed))
+}
+
+func (c *GoCoordinator) runComponent(ctx context.Context, effective EffectivePolicy, component *goComponent) goComponentResult {
+	if component == nil {
+		err := errors.New("devicepolicy: nil Go component")
+		return goComponentResult{state: StateVerificationFailed, err: err, observationErr: err}
+	}
+	result := goComponentResult{name: component.name}
+	if component.initErr != nil {
+		result.state, result.err, result.observationErr = StateVerificationFailed, component.initErr, component.initErr
+		return result
+	}
+	collector := &collectingReporter{}
+	result.err = c.childReconciler(effective, component, collector).Reconcile(ctx)
+	if len(collector.reports) == 1 {
+		result.state = collector.reports[0].State
+	} else {
+		result.state = StateVerificationFailed
+		result.err = errors.Join(result.err, fmt.Errorf("devicepolicy: %s child produced %d reports", component.name, len(collector.reports)))
+	}
+	result.observation, result.observationErr = component.observe()
+	result.state = aggregateGoState([]goComponentResult{{state: result.state}, {state: goObservationState(result.observation, result.observationErr)}})
+	if component.staticConverged != nil {
+		var staticErr error
+		result.staticConverged, staticErr = component.staticConverged(component.expected)
+		result.observationErr = errors.Join(result.observationErr, staticErr)
+		if staticErr != nil {
+			result.state = StateVerificationFailed
+		}
+	}
+	return result
+}
+
+func (c *GoCoordinator) runClear(ctx context.Context, effective EffectivePolicy, component *goComponent) goComponentResult {
+	if component == nil || component.initErr != nil {
+		err := errors.New("devicepolicy: unusable Go component")
+		if component != nil {
+			err = errors.Join(err, component.initErr)
+		}
+		return goComponentResult{state: StateWriteFailed, err: err}
+	}
+	result := goComponentResult{name: component.name, state: StateCompliant}
+	result.err = c.childReconciler(effective, component, &collectingReporter{}).Reconcile(ctx)
+	if result.err != nil {
+		result.state = classifyWriteError(result.err)
+	}
+	return result
+}
+
+func (c *GoCoordinator) observeOnly(component *goComponent) goComponentResult {
+	if component == nil || component.initErr != nil || component.observe == nil {
+		err := errors.New("devicepolicy: Go component cannot be observed")
+		if component != nil {
+			err = errors.Join(err, component.initErr)
+		}
+		return goComponentResult{state: StateVerificationFailed, err: err, observationErr: err}
+	}
+	observation, err := component.observe()
+	return goComponentResult{name: component.name, state: goObservationState(observation, err), observation: observation, observationErr: err}
+}
+
+func (c *GoCoordinator) childReconciler(effective EffectivePolicy, component *goComponent, reporter Reporter) *Reconciler {
+	return &Reconciler{
+		Fetcher:             goFixedFetcher{policy: effective},
+		Reporter:            reporter,
+		Writer:              component.writer,
+		WriterInitErr:       component.initErr,
+		CustomerID:          c.CustomerID,
+		DeviceID:            c.DeviceID,
+		Platform:            c.Platform,
+		Category:            CategoryPackageConfig,
+		Target:              TargetGo,
+		OwnershipTarget:     component.ownershipTarget,
+		OwnershipStateValue: component.ownershipStateValue,
+		OwnershipKey:        component.ownershipKey,
+		OwnsByMarker:        true,
+		Converged:           component.converged,
+		FullStateDrift:      true,
+		RestoreSnapshot:     component.restoreSnapshot,
+		CompleteState:       component.completeState,
+		PrepareWrite:        component.prepareWrite,
+		PrepareClear:        component.prepareClear,
+		ProbeExpected:       func(string) (bool, string) { return false, "" },
+		ProbeContent:        func(string) (bool, map[string]json.RawMessage, error) { return true, nil, nil },
+		Render:              func(json.RawMessage) (string, error) { return component.expected, nil },
+		Logf:                c.Logf,
+		writeState:          c.writeOwnershipState,
+		clearState:          c.clearOwnershipState,
+		probeState:          ProbeAppliedStateWritable,
+	}
+}
+
+func (c *GoCoordinator) components(policy GoPolicy) (*goComponents, error) {
+	if c.buildComponents != nil {
+		return c.buildComponents(c.Exec, policy)
+	}
+	if c.Exec == nil {
+		return nil, errors.New("devicepolicy: nil Go executor")
+	}
+	return buildGoComponents(c.Exec, policy)
+}
+
+func buildGoComponents(exec executor.Executor, policy GoPolicy) (*goComponents, error) {
+	home, err := secureuserfile.OpenUserHome(exec)
+	if err != nil {
+		return nil, err
+	}
+	components := &goComponents{close: home.Close}
+	components.hasManagedCredential = func() (bool, error) { return hasManagedNetrcMarker(home) }
+	credentialExpected := renderNetrcEntry(policy.RegistryHost(), policy.DeviceToken())
+	credential, credentialErr := newNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
+	components.credential = &goComponent{
+		name: "credential", ownershipTarget: GoCredentialOwnershipTarget, ownershipKey: goCredentialOwnershipKey,
+		ownershipStateValue: GoCredentialOwnershipValue, writer: credential, initErr: credentialErr, expected: credentialExpected,
+	}
+	credentialLocation := ""
+	if credential != nil {
+		credentialLocation = credential.Location()
+		components.credential.preflight = credential.ValidateEffectivePath
+		components.credential.converged = credential.Converged
+		components.credential.restoreSnapshot = credential.RestoreSnapshot
+		components.credential.hasMDMMarker = credential.HasMDMMarker
+		components.credential.mdmOwned = func() (bool, error) {
+			owned, err := credential.MDMOwned()
+			if err != nil || !owned {
+				return owned, err
+			}
+			secure, err := credential.file.MetadataSecure(secureuserfile.FileMode)
+			if err != nil {
+				return false, err
+			}
+			if !secure {
+				return false, fmt.Errorf("netrc: insecure MDM metadata: %w", ErrTargetUnusable)
+			}
+			return true, nil
+		}
+		components.credential.completeState = func(_ AppliedTargetState, _ bool, state *AppliedTargetState) error {
+			state.RegistryHost = policy.RegistryHost()
+			return nil
+		}
+		components.credential.observe = func() (goComponentObservation, error) {
+			status, err := credential.Observation(credentialExpected)
+			return goComponentObservation{auth: status}, err
+		}
+	}
+
+	envExpected, envRenderErr := renderGoEnvSettings(policy)
+	envWriter, envErr := NewGoEnvWriter(exec, home, policy)
+	components.env = &goComponent{
+		name: "go-env", ownershipTarget: GoEnvOwnershipTarget, ownershipKey: goEnvOwnershipKey,
+		ownershipStateValue: GoEnvOwnershipValue, writer: envWriter, initErr: errors.Join(envRenderErr, envErr), expected: envExpected,
+	}
+	if envWriter != nil {
+		components.env.preflight = envWriter.ValidateTarget
+		components.env.converged = envWriter.Converged
+		components.env.staticConverged = envWriter.StaticConverged
+		components.env.restoreSnapshot = envWriter.RestoreSnapshot
+		components.env.hasMDMMarker = envWriter.HasMDMMarker
+		components.env.mdmOwned = envWriter.MDMOwned
+		components.env.completeState = envWriter.CompleteState
+		components.env.prepareWrite = envWriter.PrepareWrite
+		components.env.prepareClear = envWriter.PrepareClear
+		components.env.observe = func() (goComponentObservation, error) {
+			observation, err := envWriter.Observation(envExpected, credentialLocation)
+			return goComponentObservation{env: &observation}, err
+		}
+	}
+	components.hasPyPISibling = func() (bool, error) { return hasPyPIDMGMarker(exec, home) }
+	return components, nil
+}
+
+func hasPyPIDMGMarker(exec executor.Executor, home *secureuserfile.Home) (bool, error) {
+	userExec := executor.NewUserAwareExecutor(exec, home.Username())
+	if err := executor.UserEnvironmentError(userExec); err != nil {
+		return false, fmt.Errorf("devicepolicy: inspect target-user environment: %w", err)
+	}
+	for _, path := range configaudit.TrustedPipUserPaths(userExec, home.Path()) {
+		file, err := secureHomeFile(home, path, pipBackupPrefix)
+		if err != nil {
+			return false, err
+		}
+		present, err := file.ParentPresent()
+		if err != nil || !present {
+			if err != nil {
+				return false, err
+			}
+			continue
+		}
+		data, existed, _, err := file.Read()
+		if err != nil {
+			return false, err
+		}
+		if existed {
+			markers, err := scanPipMarkers(data)
+			if err != nil {
+				return false, err
+			}
+			if markers.dmg != nil {
+				return true, nil
+			}
+		}
+	}
+	uvPath, err := uvUserConfigPath(userExec, home.Path())
+	if err != nil {
+		return false, err
+	}
+	uvFile, err := secureHomeFile(home, uvPath, uvBackupPrefix)
+	if err != nil {
+		return false, err
+	}
+	present, err := uvFile.ParentPresent()
+	if err != nil || !present {
+		return false, err
+	}
+	data, existed, _, err := uvFile.Read()
+	if err != nil || !existed {
+		return false, err
+	}
+	markers, err := scanUVMarkers(data)
+	return markers.complete(), err
+}
+
+func secureHomeFile(home *secureuserfile.Home, path, backupPrefix string) (*secureuserfile.File, error) {
+	relative, err := filepath.Rel(home.Path(), filepath.Clean(path))
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return nil, fmt.Errorf("devicepolicy: sibling path is outside resolved home: %w", ErrTargetUnusable)
+	}
+	return home.Open(relative, backupPrefix, secureuserfile.MaxBytes)
+}
+
+func hasGoDMGMarker(exec executor.Executor, home *secureuserfile.Home) (bool, error) {
+	userExec := executor.NewUserAwareExecutor(exec, home.Username())
+	path, err := goUserEnvPath(userExec, home.Path())
+	if err != nil {
+		return false, err
+	}
+	if err := executor.UserEnvironmentError(userExec); err != nil && userExec.GOOS() != model.PlatformDarwin {
+		return false, fmt.Errorf("devicepolicy: inspect target-user environment: %w", err)
+	}
+	file, err := secureHomeFile(home, path, goEnvBackupPrefix)
+	if err != nil {
+		return false, err
+	}
+	present, err := file.ParentPresent()
+	if err != nil || !present {
+		return false, err
+	}
+	data, existed, _, err := file.Read()
+	if err != nil || !existed {
+		return false, err
+	}
+	analysis, err := scanGoEnv(data)
+	return analysis.owner == "dmg", err
+}
+
+func clearGoPolicy(host string) GoPolicy {
+	policy := GoPolicy{Ecosystem: "go", RegistryURL: "https://" + host + "/go", deviceID: "clear"}
+	policy.Auth.Scheme = goAuthScheme
+	policy.Auth.APIKey = "clear"
+	return policy
+}
+
+func (c *GoCoordinator) clearRegistryHost() (string, error) {
+	if state, ok := ReadAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget); ok && isValidHost(state.RegistryHost) {
+		return state.RegistryHost, nil
+	}
+	if c.Exec == nil {
+		return "", errors.New("devicepolicy: nil Go executor")
+	}
+	home, err := secureuserfile.OpenUserHome(c.Exec)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = home.Close() }()
+	return discoverDMGNetrcHost(home)
+}
+
+func goObservationState(observation goComponentObservation, err error) string {
+	if err != nil {
+		return StateVerificationFailed
+	}
+	if observation.auth != "" {
+		switch observation.auth {
+		case authTokenMatch:
+			return StateCompliant
+		case authTokenUnreadable:
+			return StateVerificationFailed
+		default:
+			return StatePolicyNotApplied
+		}
+	}
+	if observation.env == nil {
+		return StateVerificationFailed
+	}
+	if observation.env.ConfigStatus == "unreadable" {
+		return StateVerificationFailed
+	}
+	if observation.env.ConfigStatus != "match" || observation.env.EffectiveStatus != "match" || observation.env.OverrideSource != "none" {
+		return StatePolicyNotApplied
+	}
+	return StateCompliant
+}
+
+func aggregateGoState(results []goComponentResult) string {
+	precedence := map[string]int{StateCompliant: 0, StateDriftDetected: 1, StatePolicyNotApplied: 2, StateWriteFailed: 3, StateVerificationFailed: 4}
+	state, rank := StateCompliant, 0
+	for _, result := range results {
+		candidate, ok := precedence[result.state]
+		if !ok {
+			return StateVerificationFailed
+		}
+		if candidate > rank {
+			state, rank = result.state, candidate
+		}
+	}
+	return state
+}
+
+func goComponentSucceeded(state string) bool {
+	return state == StateCompliant || state == StateDriftDetected
+}
+
+func goComponentErrors(results []goComponentResult) error {
+	var errs []error
+	for _, result := range results {
+		errs = append(errs, result.err, result.observationErr)
+	}
+	return errors.Join(errs...)
+}
+
+func buildGoObserved(policy GoPolicy, results []goComponentResult) (json.RawMessage, error) {
+	observed := GoObserved{
+		Ecosystem:       "go",
+		RegistryURL:     "",
+		AuthTokenStatus: authTokenUnreadable,
+		ConfigStatus:    "unreadable",
+		EffectiveStatus: "unknown",
+		OverrideSource:  "unknown",
+	}
+	for _, result := range results {
+		if result.observation.auth != "" {
+			observed.AuthTokenStatus = result.observation.auth
+		}
+		if result.observation.env != nil {
+			observed.RegistryURL = safeObservedRegistryURL(result.observation.env.RegistryURL)
+			observed.ConfigStatus = result.observation.env.ConfigStatus
+			observed.EffectiveStatus = result.observation.env.EffectiveStatus
+			observed.OverrideSource = result.observation.env.OverrideSource
+		}
+	}
+	if observed.RegistryURL == "" && observed.ConfigStatus == "match" {
+		observed.RegistryURL = policy.RegistryURL
+	}
+	return json.Marshal(observed)
+}
+
+func (c *GoCoordinator) writeOwnershipState(category, target string, state AppliedTargetState) error {
+	if c.writeState != nil {
+		return c.writeState(category, target, state)
+	}
+	return WriteAppliedState(category, target, state)
+}
+
+func (c *GoCoordinator) clearOwnershipState(category, target string) error {
+	if c.clearState != nil {
+		return c.clearState(category, target)
+	}
+	return ClearAppliedState(category, target)
+}
+
+func (c *GoCoordinator) report(ctx context.Context, state, appliedHash, evaluatedHash, enforcement string, observed json.RawMessage) error {
+	report := ComplianceReport{
+		Category: CategoryPackageConfig, Target: TargetGo, State: state, AppliedHash: appliedHash,
+		EvaluatedHash: evaluatedHash, AgentVersion: AgentVersion(), Platform: c.Platform,
+		Observed: observed, EvaluatedEnforcement: enforcement,
+	}
+	c.logf("devicepolicy: reporting aggregate state=%s category=%s target=%s", state, CategoryPackageConfig, TargetGo)
+	if c.Reporter == nil {
+		return nil
+	}
+	if err := c.Reporter.Report(ctx, c.CustomerID, c.DeviceID, report); err != nil {
+		return fmt.Errorf("devicepolicy: report Go state %s: %w", state, err)
+	}
+	return nil
+}
+
+func (c *GoCoordinator) logf(format string, args ...any) {
+	if c.Logf != nil {
+		c.Logf(format, args...)
+	}
+}

--- a/internal/devicepolicy/go_coordinator.go
+++ b/internal/devicepolicy/go_coordinator.go
@@ -194,7 +194,7 @@ func (c *GoCoordinator) observeMDM(component *goComponent) goComponentResult {
 	owned, err := component.mdmOwned()
 	if err != nil {
 		result.state, result.err = StateVerificationFailed, err
-	} else if owned && goObservationState(result.observation, nil) == StateCompliant {
+	} else if owned {
 		result.state = StateMDMManaged
 	} else {
 		result.state = StatePolicyNotApplied

--- a/internal/devicepolicy/go_coordinator.go
+++ b/internal/devicepolicy/go_coordinator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -541,6 +542,9 @@ func hasGoDMGMarker(exec executor.Executor, home *secureuserfile.Home) (bool, er
 	}
 	if err := executor.UserEnvironmentError(userExec); err != nil && userExec.GOOS() != model.PlatformDarwin {
 		return false, fmt.Errorf("devicepolicy: inspect target-user environment: %w", err)
+	}
+	if _, err := userExec.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return false, nil
 	}
 	file, err := secureHomeFile(home, path, goEnvBackupPrefix)
 	if err != nil {

--- a/internal/devicepolicy/go_coordinator.go
+++ b/internal/devicepolicy/go_coordinator.go
@@ -407,7 +407,7 @@ func buildGoComponents(exec executor.Executor, policy GoPolicy) (*goComponents, 
 	components := &goComponents{close: home.Close}
 	components.hasManagedCredential = func() (bool, error) { return hasManagedNetrcMarker(home) }
 	credentialExpected := renderNetrcEntry(policy.RegistryHost(), policy.DeviceToken())
-	credential, credentialErr := newNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
+	credential, credentialErr := newGoNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
 	components.credential = &goComponent{
 		name: "credential", ownershipTarget: GoCredentialOwnershipTarget, ownershipKey: goCredentialOwnershipKey,
 		ownershipStateValue: GoCredentialOwnershipValue, writer: credential, initErr: credentialErr, expected: credentialExpected,

--- a/internal/devicepolicy/go_coordinator.go
+++ b/internal/devicepolicy/go_coordinator.go
@@ -464,7 +464,13 @@ func buildGoComponents(exec executor.Executor, policy GoPolicy) (*goComponents, 
 			return goComponentObservation{env: &observation}, err
 		}
 	}
-	components.hasPyPISibling = func() (bool, error) { return hasPyPIDMGMarker(exec, home) }
+	components.hasPyPISibling = func() (bool, error) {
+		sibling, err := hasPyPIDMGMarker(exec, home)
+		if err != nil || !sibling {
+			return sibling, err
+		}
+		return hasSingleManagedNetrc(home)
+	}
 	return components, nil
 }
 

--- a/internal/devicepolicy/go_coordinator_test.go
+++ b/internal/devicepolicy/go_coordinator_test.go
@@ -484,7 +484,7 @@ func TestGoAndPyPIShareOneNetrcBlockAcrossOrdersAndRotation(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			goWriter, err := newNetrcWriter(home, goPolicy.RegistryHost(), goPolicy.DeviceToken())
+			goWriter, err := newGoNetrcWriter(home, goPolicy.RegistryHost(), goPolicy.DeviceToken())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -509,7 +509,7 @@ func TestGoAndPyPIShareOneNetrcBlockAcrossOrdersAndRotation(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			rotated, err := newNetrcWriter(home, rotatedGo.RegistryHost(), rotatedGo.DeviceToken())
+			rotated, err := newGoNetrcWriter(home, rotatedGo.RegistryHost(), rotatedGo.DeviceToken())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/devicepolicy/go_coordinator_test.go
+++ b/internal/devicepolicy/go_coordinator_test.go
@@ -539,6 +539,8 @@ func TestGoAndPyPISharedCredentialFinalClearAcrossRemovalOrders(t *testing.T) {
 				t.Fatal(err)
 			}
 			homeDir := t.TempDir()
+			current.HomeDir = homeDir
+			normalizeSecureTestUser(t, current)
 			initialNetrc := []byte("machine registry.stepsecurity.io login original password original\nmachine other.example login user password pass\n")
 			if err := os.WriteFile(filepath.Join(homeDir, ".netrc"), initialNetrc, 0o600); err != nil {
 				t.Fatal(err)
@@ -547,7 +549,7 @@ func TestGoAndPyPISharedCredentialFinalClearAcrossRemovalOrders(t *testing.T) {
 			mock.SetGOOS("linux")
 			mock.SetUsername(current.Username)
 			mock.SetHomeDir(homeDir)
-			exec := &coordinatorUserExecutor{Mock: mock, user: &user.User{Username: current.Username, Uid: current.Uid, Gid: current.Gid, HomeDir: homeDir}}
+			exec := &coordinatorUserExecutor{Mock: mock, user: current}
 			pypiFetcher := &coordinatorFetcher{policy: coordinatorPolicy(`["pip"]`, "sha256:P", enforcementDMG)}
 			goFetcher := &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:G", enforcementDMG)}
 			pypi := &PyPICoordinator{Fetcher: pypiFetcher, Reporter: &coordinatorReporter{}, Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux"}
@@ -623,11 +625,13 @@ func TestGoCoordinatorFinalClearIgnoresMalformedPipWithoutMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 	homeDir := t.TempDir()
+	current.HomeDir = homeDir
+	normalizeSecureTestUser(t, current)
 	mock := executor.NewMock()
 	mock.SetGOOS("linux")
 	mock.SetUsername(current.Username)
 	mock.SetHomeDir(homeDir)
-	exec := &coordinatorUserExecutor{Mock: mock, user: &user.User{Username: current.Username, Uid: current.Uid, Gid: current.Gid, HomeDir: homeDir}}
+	exec := &coordinatorUserExecutor{Mock: mock, user: current}
 	getter := &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:G", enforcementDMG)}
 	coordinator := &GoCoordinator{Fetcher: getter, Reporter: &coordinatorReporter{}, Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux"}
 	if err := coordinator.Reconcile(context.Background()); err != nil {

--- a/internal/devicepolicy/go_coordinator_test.go
+++ b/internal/devicepolicy/go_coordinator_test.go
@@ -287,6 +287,37 @@ func TestGoCoordinator_MDMVerificationIsWriteFree(t *testing.T) {
 	}
 }
 
+func TestGoCoordinator_MDMReportsManagedWithGOPROXYDrift(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	fixture.credential.value = renderNetrcEntry("registry.stepsecurity.io", "tenant-secret::dev:DEVICE-123")
+	fixture.credential.present, fixture.credential.static, fixture.credential.mdm = true, true, true
+	fixture.env.value = "GOPROXY=https://other.example/go"
+	fixture.env.present, fixture.env.static, fixture.env.mdm = true, true, true
+	coordinator, _, reporter := newTestGoCoordinator(t, goCoordinatorPolicy("sha256:H", enforcementMDM), fixture)
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var observed GoObserved
+	if len(reporter.reports) != 1 {
+		t.Fatalf("reports = %d, want 1", len(reporter.reports))
+	}
+	if err := json.Unmarshal(reporter.reports[0].Observed, &observed); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(fixture.events), 0; got != want {
+		t.Fatalf("events = %d, want %d", got, want)
+	}
+	if got, want := reporter.reports[0].State, StateMDMManaged; got != want {
+		t.Fatalf("state = %q, want %q", got, want)
+	}
+	if got, want := reporter.reports[0].AppliedHash, ""; got != want {
+		t.Fatalf("applied hash = %q, want %q", got, want)
+	}
+	if got, want := observed.ConfigStatus, "mismatch"; got != want {
+		t.Fatalf("config status = %q, want %q", got, want)
+	}
+}
+
 func TestGoCoordinator_DMGYieldsToCompleteMDMOwnership(t *testing.T) {
 	fixture := newGoCoordinatorFixture()
 	fixture.credential.value = renderNetrcEntry("registry.stepsecurity.io", "tenant-secret::dev:DEVICE-123")
@@ -299,6 +330,37 @@ func TestGoCoordinator_DMGYieldsToCompleteMDMOwnership(t *testing.T) {
 	}
 	if len(fixture.events) != 0 || len(reporter.reports) != 1 || reporter.reports[0].State != StateMDMManaged || reporter.reports[0].EvaluatedEnforcement != enforcementDMG {
 		t.Fatalf("events=%v reports=%+v", fixture.events, reporter.reports)
+	}
+}
+
+func TestGoCoordinator_DMGYieldsToMDMWithCredentialDrift(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	fixture.credential.value = renderNetrcEntry("registry.stepsecurity.io", "different-token")
+	fixture.credential.present, fixture.credential.static, fixture.credential.mdm = true, true, true
+	fixture.env.value = goEnvExpected
+	fixture.env.present, fixture.env.static, fixture.env.mdm = true, true, true
+	coordinator, _, reporter := newTestGoCoordinator(t, goCoordinatorPolicy("sha256:H", enforcementDMG), fixture)
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var observed GoObserved
+	if len(reporter.reports) != 1 {
+		t.Fatalf("reports = %d, want 1", len(reporter.reports))
+	}
+	if err := json.Unmarshal(reporter.reports[0].Observed, &observed); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(fixture.events), 0; got != want {
+		t.Fatalf("events = %d, want %d", got, want)
+	}
+	if got, want := reporter.reports[0].State, StateMDMManaged; got != want {
+		t.Fatalf("state = %q, want %q", got, want)
+	}
+	if got, want := reporter.reports[0].AppliedHash, ""; got != want {
+		t.Fatalf("applied hash = %q, want %q", got, want)
+	}
+	if got, want := observed.AuthTokenStatus, authTokenMismatch; got != want {
+		t.Fatalf("auth token status = %q, want %q", got, want)
 	}
 }
 

--- a/internal/devicepolicy/go_coordinator_test.go
+++ b/internal/devicepolicy/go_coordinator_test.go
@@ -1,0 +1,659 @@
+package devicepolicy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+)
+
+type goCoordinatorFetcher struct {
+	policy EffectivePolicy
+	calls  int
+}
+
+func (f *goCoordinatorFetcher) Fetch(_ context.Context, _, _, category, target string) (EffectivePolicy, error) {
+	f.calls++
+	if category != CategoryPackageConfig || target != TargetGo {
+		return EffectivePolicy{}, errors.New("wrong Go policy identity")
+	}
+	return f.policy, nil
+}
+
+type goCoordinatorFixture struct {
+	events      []string
+	credential  *coordinatorWriter
+	env         *coordinatorWriter
+	pypiSibling bool
+}
+
+func newGoCoordinatorFixture() *goCoordinatorFixture {
+	f := &goCoordinatorFixture{}
+	f.credential = &coordinatorWriter{name: "credential", events: &f.events}
+	f.env = &coordinatorWriter{name: "go-env", events: &f.events}
+	return f
+}
+
+func (f *goCoordinatorFixture) components(policy GoPolicy) *goComponents {
+	credentialExpected := renderNetrcEntry(policy.RegistryHost(), policy.DeviceToken())
+	credential := &goComponent{
+		name: "credential", ownershipTarget: GoCredentialOwnershipTarget, ownershipKey: goCredentialOwnershipKey,
+		ownershipStateValue: GoCredentialOwnershipValue, writer: f.credential, expected: credentialExpected,
+		converged: f.credential.converged, restoreSnapshot: f.credential.restore,
+		hasMDMMarker: func() (bool, error) { return f.credential.mdm, nil },
+		mdmOwned:     func() (bool, error) { return f.credential.mdm && !f.credential.mdmUnowned, nil },
+		observe: func() (goComponentObservation, error) {
+			if f.credential.observeErr != nil {
+				return goComponentObservation{}, f.credential.observeErr
+			}
+			status := authTokenAbsent
+			if f.credential.present {
+				status = authTokenMismatch
+			}
+			if f.credential.static && f.credential.value == credentialExpected {
+				status = authTokenMatch
+			}
+			return goComponentObservation{auth: status}, nil
+		},
+	}
+	credential.completeState = func(_ AppliedTargetState, _ bool, state *AppliedTargetState) error {
+		state.RegistryHost = policy.RegistryHost()
+		return nil
+	}
+	envExpected := "GOPROXY=" + policy.RegistryURL
+	env := &goComponent{
+		name: "go-env", ownershipTarget: GoEnvOwnershipTarget, ownershipKey: goEnvOwnershipKey,
+		ownershipStateValue: GoEnvOwnershipValue, writer: f.env, expected: envExpected,
+		converged: f.env.converged, staticConverged: f.env.staticConverged, restoreSnapshot: f.env.restore,
+		hasMDMMarker: func() (bool, error) { return f.env.mdm, nil },
+		mdmOwned:     func() (bool, error) { return f.env.mdm && !f.env.mdmUnowned, nil },
+		observe: func() (goComponentObservation, error) {
+			if f.env.observeErr != nil {
+				return goComponentObservation{}, f.env.observeErr
+			}
+			status := "absent"
+			if f.env.present {
+				status = "mismatch"
+			}
+			if f.env.static && f.env.value == envExpected {
+				status = "match"
+			}
+			effective, source := "mismatch", "none"
+			if status == "match" {
+				effective = "match"
+			}
+			if f.env.override != "" {
+				effective, source = "mismatch", f.env.override
+			}
+			return goComponentObservation{env: &GoEnvObservation{RegistryURL: policy.RegistryURL, ConfigStatus: status, EffectiveStatus: effective, OverrideSource: source}}, nil
+		},
+	}
+	return &goComponents{
+		credential:           credential,
+		env:                  env,
+		hasPyPISibling:       func() (bool, error) { return f.pypiSibling, nil },
+		hasManagedCredential: func() (bool, error) { return f.credential.present, nil },
+	}
+}
+
+func goCoordinatorPolicy(hash, enforcement string) EffectivePolicy {
+	return EffectivePolicy{
+		Category: CategoryPackageConfig, Target: TargetGo, Hash: hash, Enforcement: enforcement,
+		Policy: json.RawMessage(`{"ecosystem":"go","registry_url":"https://registry.stepsecurity.io/go","auth":{"scheme":"stepsecurity_device_token","api_key":"tenant-secret"}}`),
+	}
+}
+
+func newTestGoCoordinator(t *testing.T, policy EffectivePolicy, fixture *goCoordinatorFixture) (*GoCoordinator, *goCoordinatorFetcher, *coordinatorReporter) {
+	t.Helper()
+	withTempCache(t)
+	fetcher := &goCoordinatorFetcher{policy: policy}
+	reporter := &coordinatorReporter{}
+	coordinator := &GoCoordinator{
+		Fetcher: fetcher, Reporter: reporter, Exec: executor.NewMock(), CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux",
+		buildComponents: func(_ executor.Executor, parsed GoPolicy) (*goComponents, error) {
+			return fixture.components(parsed), nil
+		},
+	}
+	if policy.Clear {
+		if err := WriteAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget, AppliedTargetState{RegistryHost: "registry.stepsecurity.io"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return coordinator, fetcher, reporter
+}
+
+func TestGoCoordinator_FetchesOnceAndMissingPolicyIsNoOp(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	coordinator, fetcher, reporter := newTestGoCoordinator(t, EffectivePolicy{}, fixture)
+	coordinator.buildComponents = func(executor.Executor, GoPolicy) (*goComponents, error) {
+		t.Fatal("components constructed for absent policy")
+		return nil, nil
+	}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if fetcher.calls != 1 || len(reporter.reports) != 0 || len(fixture.events) != 0 {
+		t.Fatalf("fetches=%d reports=%d events=%v", fetcher.calls, len(reporter.reports), fixture.events)
+	}
+}
+
+func TestGoCoordinator_ComponentOrderingAndRollback(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*goCoordinatorFixture)
+		wantEvents string
+		wantState  string
+		wantErr    bool
+	}{
+		{"credential then env", nil, "credential:write,go-env:write", StateCompliant, false},
+		{"credential failure skips env", func(f *goCoordinatorFixture) { f.credential.writeErr = errors.New("credential failed") }, "credential:write", StateWriteFailed, true},
+		{"env failure rolls back changed credential", func(f *goCoordinatorFixture) { f.env.writeErr = errors.New("env failed") }, "credential:write,go-env:write,credential:restore", StateWriteFailed, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newGoCoordinatorFixture()
+			if tc.configure != nil {
+				tc.configure(fixture)
+			}
+			coordinator, fetcher, reporter := newTestGoCoordinator(t, goCoordinatorPolicy("sha256:H", enforcementDMG), fixture)
+			err := coordinator.Reconcile(context.Background())
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Reconcile error = %v", err)
+			}
+			if got := strings.Join(fixture.events, ","); got != tc.wantEvents {
+				t.Fatalf("events = %q, want %q", got, tc.wantEvents)
+			}
+			if fetcher.calls != 1 || len(reporter.reports) != 1 || reporter.reports[0].State != tc.wantState || reporter.reports[0].Target != TargetGo {
+				t.Fatalf("fetches=%d reports=%+v", fetcher.calls, reporter.reports)
+			}
+			if tc.wantState == StateCompliant && reporter.reports[0].AppliedHash != "sha256:H" {
+				t.Fatalf("applied hash = %q", reporter.reports[0].AppliedHash)
+			}
+		})
+	}
+}
+
+func TestGoCoordinator_PreflightsBothComponentsBeforeCredentialMutation(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	coordinator, _, reporter := newTestGoCoordinator(t, goCoordinatorPolicy("sha256:H", enforcementDMG), fixture)
+	coordinator.buildComponents = func(_ executor.Executor, policy GoPolicy) (*goComponents, error) {
+		components := fixture.components(policy)
+		components.env.preflight = func() error { return errors.New("unsafe Go env path") }
+		return components, nil
+	}
+	if err := coordinator.Reconcile(context.Background()); err == nil {
+		t.Fatal("Reconcile error = nil")
+	}
+	if len(fixture.events) != 0 || len(reporter.reports) != 1 || reporter.reports[0].State != StateVerificationFailed {
+		t.Fatalf("events=%v reports=%+v", fixture.events, reporter.reports)
+	}
+}
+
+func TestGoCoordinator_OverrideIsPolicyNotAppliedWithoutAppliedHash(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	fixture.credential.value, fixture.credential.present, fixture.credential.static = "machine", true, true
+	fixture.env.override = "environment"
+	coordinator, _, reporter := newTestGoCoordinator(t, goCoordinatorPolicy("sha256:H", enforcementDMG), fixture)
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if report := reporter.reports[0]; report.State != StatePolicyNotApplied || report.AppliedHash != "" {
+		t.Fatalf("report = %+v", report)
+	}
+}
+
+func TestGoCoordinator_ClearRetainsSharedCredentialForPyPISibling(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	fixture.credential.present, fixture.env.present = true, true
+	fixture.pypiSibling = true
+	clear := EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+	coordinator, _, reporter := newTestGoCoordinator(t, clear, fixture)
+	if err := ClearAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget); err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(fixture.events, ","); got != "go-env:clear" {
+		t.Fatalf("events = %q", got)
+	}
+	if !fixture.credential.present || len(reporter.reports) != 0 {
+		t.Fatalf("credential retained=%v reports=%v", fixture.credential.present, reporter.reports)
+	}
+}
+
+func TestGoCoordinator_StatelessAndRepeatedClearAreNoOps(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	clear := EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+	coordinator, fetcher, reporter := newTestGoCoordinator(t, clear, fixture)
+	if err := ClearAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := coordinator.Reconcile(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if fetcher.calls != 2 || len(reporter.reports) != 0 || len(fixture.events) != 2 {
+		t.Fatalf("fetches=%d reports=%d events=%v", fetcher.calls, len(reporter.reports), fixture.events)
+	}
+	for _, event := range fixture.events {
+		if event != "go-env:clear" {
+			t.Fatalf("unexpected clear event %q", event)
+		}
+	}
+}
+
+func TestGoCoordinator_ClearFailureRetainsCredentialAndRetries(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	fixture.credential.present, fixture.env.present = true, true
+	fixture.env.clearErr = errors.New("forced env clear failure")
+	clear := EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+	coordinator, _, _ := newTestGoCoordinator(t, clear, fixture)
+	if err := coordinator.Reconcile(context.Background()); err == nil {
+		t.Fatal("first clear error = nil")
+	}
+	if !fixture.credential.present {
+		t.Fatal("credential was cleared after config clear failed")
+	}
+	fixture.env.clearErr = nil
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.credential.present || fixture.env.present {
+		t.Fatalf("retry left credential=%v env=%v", fixture.credential.present, fixture.env.present)
+	}
+}
+
+func TestGoCoordinator_MDMVerificationIsWriteFree(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	fixture.credential.value = renderNetrcEntry("registry.stepsecurity.io", "tenant-secret::dev:DEVICE-123")
+	fixture.credential.present, fixture.credential.static, fixture.credential.mdm = true, true, true
+	fixture.env.value = goEnvExpected
+	fixture.env.present, fixture.env.static, fixture.env.mdm = true, true, true
+	coordinator, _, reporter := newTestGoCoordinator(t, goCoordinatorPolicy("sha256:H", enforcementMDM), fixture)
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.events) != 0 || len(reporter.reports) != 1 || reporter.reports[0].State != StateMDMManaged || reporter.reports[0].AppliedHash != "" {
+		t.Fatalf("events=%v reports=%+v", fixture.events, reporter.reports)
+	}
+}
+
+func TestGoCoordinator_DMGYieldsToCompleteMDMOwnership(t *testing.T) {
+	fixture := newGoCoordinatorFixture()
+	fixture.credential.value = renderNetrcEntry("registry.stepsecurity.io", "tenant-secret::dev:DEVICE-123")
+	fixture.credential.present, fixture.credential.static, fixture.credential.mdm = true, true, true
+	fixture.env.value = goEnvExpected
+	fixture.env.present, fixture.env.static, fixture.env.mdm = true, true, true
+	coordinator, _, reporter := newTestGoCoordinator(t, goCoordinatorPolicy("sha256:H", enforcementDMG), fixture)
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(fixture.events) != 0 || len(reporter.reports) != 1 || reporter.reports[0].State != StateMDMManaged || reporter.reports[0].EvaluatedEnforcement != enforcementDMG {
+		t.Fatalf("events=%v reports=%+v", fixture.events, reporter.reports)
+	}
+}
+
+func TestGoCoordinator_RealLifecycleIsIdempotentAndSecretFree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("filesystem lifecycle")
+	}
+	withTempCache(t)
+	current, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	homeDir := t.TempDir()
+	mock := executor.NewMock()
+	mock.SetGOOS("linux")
+	mock.SetUsername(current.Username)
+	mock.SetHomeDir(homeDir)
+	exec := &coordinatorUserExecutor{Mock: mock, user: &user.User{Username: current.Username, Uid: current.Uid, Gid: current.Gid, HomeDir: homeDir}}
+	fetcher := &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:H", enforcementDMG)}
+	reporter := &coordinatorReporter{}
+	coordinator := &GoCoordinator{Fetcher: fetcher, Reporter: reporter, Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux"}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var observed map[string]any
+	if err := json.Unmarshal(reporter.reports[0].Observed, &observed); err != nil {
+		t.Fatal(err)
+	}
+	if len(observed) != 6 || observed["ecosystem"] != "go" || observed["registry_url"] != "https://registry.stepsecurity.io/go" ||
+		observed["auth_token_status"] != "match" || observed["config_status"] != "match" ||
+		observed["effective_status"] != "match" || observed["override_source"] != "none" {
+		t.Fatalf("observed = %#v", observed)
+	}
+	envPath := filepath.Join(homeDir, ".config", "go", "env")
+	netrcPath := filepath.Join(homeDir, ".netrc")
+	before, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("idempotent cycle changed mtime: %v -> %v", before.ModTime(), after.ModTime())
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("idempotent cycle replaced the Go env file")
+	}
+	state, err := os.ReadFile(CachePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	reports, _ := json.Marshal(reporter.reports)
+	for _, forbidden := range [][]byte{[]byte("tenant-secret"), []byte("::dev:")} {
+		if bytes.Contains(state, forbidden) || bytes.Contains(reports, forbidden) {
+			t.Fatalf("state/report leaked %q", forbidden)
+		}
+	}
+	for _, internalTarget := range [][]byte{[]byte(GoCredentialOwnershipTarget), []byte(GoEnvOwnershipTarget)} {
+		if bytes.Contains(reports, internalTarget) {
+			t.Fatalf("report leaked internal target %q", internalTarget)
+		}
+	}
+	fetcher.policy = EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{envPath, netrcPath} {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("clear retained %s: %v", path, err)
+		}
+	}
+	if err := filepath.WalkDir(homeDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := entry.Name()
+		if strings.Contains(name, ".dmg-") || strings.Contains(name, ".install") || strings.Contains(name, ".restore") {
+			t.Fatalf("temporary residue remains at %s", path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(reporter.reports) != 2 {
+		t.Fatalf("clear emitted a report: %d reports", len(reporter.reports))
+	}
+}
+
+func TestPyPICoordinator_ClearRetainsCredentialForGoSibling(t *testing.T) {
+	fixture := newCoordinatorFixture()
+	fixture.credential.present, fixture.pip.present, fixture.uv.present = true, true, true
+	clear := EffectivePolicy{Category: CategoryPackageConfig, Target: TargetPyPI, Clear: true}
+	coordinator, _, _ := newTestCoordinator(t, clear, fixture)
+	coordinator.buildComponents = func(_ context.Context, _ executor.Executor, policy PyPIPolicy) (*pypiComponents, error) {
+		components := fixture.components(policy)
+		components.hasGoSibling = func() (bool, error) { return true, nil }
+		return components, nil
+	}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(fixture.events, ","); got != "pip:clear,uv:clear" {
+		t.Fatalf("events = %q", got)
+	}
+	if !fixture.credential.present {
+		t.Fatal("PyPI clear removed credential still used by Go")
+	}
+}
+
+func TestGoCoordinator_StateFailureRestoresBothFiles(t *testing.T) {
+	withTempCache(t)
+	current, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	homeDir := t.TempDir()
+	envPath := filepath.Join(homeDir, ".config", "go", "env")
+	netrcPath := filepath.Join(homeDir, ".netrc")
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	initialEnv := []byte("GOPRIVATE=corp.example/*\nGOPROXY=https://proxy.golang.org\n")
+	initialNetrc := []byte("machine other.example login user password pass\n")
+	if err := os.WriteFile(envPath, initialEnv, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(netrcPath, initialNetrc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mock := executor.NewMock()
+	mock.SetGOOS("linux")
+	mock.SetUsername(current.Username)
+	exec := &coordinatorUserExecutor{Mock: mock, user: &user.User{Username: current.Username, Uid: current.Uid, Gid: current.Gid, HomeDir: homeDir}}
+	reporter := &coordinatorReporter{}
+	coordinator := &GoCoordinator{
+		Fetcher: &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:H", enforcementDMG)}, Reporter: reporter,
+		Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux",
+		writeState: func(category, target string, state AppliedTargetState) error {
+			if target == GoEnvOwnershipTarget {
+				return errors.New("forced Go env state failure")
+			}
+			return WriteAppliedState(category, target, state)
+		},
+	}
+	if err := coordinator.Reconcile(context.Background()); err == nil {
+		t.Fatal("Reconcile error = nil")
+	}
+	for path, want := range map[string][]byte{envPath: initialEnv, netrcPath: initialNetrc} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s = %q, want %q", path, got, want)
+		}
+	}
+	for _, target := range []string{GoCredentialOwnershipTarget, GoEnvOwnershipTarget} {
+		if _, ok := ReadAppliedState(CategoryPackageConfig, target); ok {
+			t.Fatalf("rollback retained %s state", target)
+		}
+	}
+	if len(reporter.reports) != 1 || reporter.reports[0].AppliedHash != "" {
+		t.Fatalf("reports = %+v", reporter.reports)
+	}
+}
+
+func TestGoAndPyPIShareOneNetrcBlockAcrossOrdersAndRotation(t *testing.T) {
+	for _, order := range []string{"pypi-first", "go-first"} {
+		t.Run(order, func(t *testing.T) {
+			homeDir := t.TempDir()
+			home := newSecureTestHome(t, homeDir)
+			pypi := netrcTestPolicy(t)
+			goPolicy, err := ParseGoPolicy(json.RawMessage(`{"ecosystem":"go","registry_url":"https://registry.stepsecurity.io/go","auth":{"scheme":"stepsecurity_device_token","api_key":"step_acme-1_uuid"}}`), "DEVICE-123")
+			if err != nil {
+				t.Fatal(err)
+			}
+			pypiWriter, err := NewNetrcWriter(home, pypi)
+			if err != nil {
+				t.Fatal(err)
+			}
+			goWriter, err := newNetrcWriter(home, goPolicy.RegistryHost(), goPolicy.DeviceToken())
+			if err != nil {
+				t.Fatal(err)
+			}
+			writers := []*NetrcWriter{pypiWriter, goWriter}
+			if order == "go-first" {
+				writers[0], writers[1] = writers[1], writers[0]
+			}
+			for _, writer := range writers {
+				if _, err := writer.Write(writer.expected); err != nil {
+					t.Fatal(err)
+				}
+			}
+			content, err := os.ReadFile(writers[0].Location())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Count(content, []byte(dmgNetrcBegin)) != 1 || bytes.Count(content, []byte("machine registry.stepsecurity.io")) != 1 {
+				t.Fatalf("shared credential duplicated:\n%s", content)
+			}
+
+			rotatedGo, err := ParseGoPolicy(json.RawMessage(`{"ecosystem":"go","registry_url":"https://registry.stepsecurity.io/go","auth":{"scheme":"stepsecurity_device_token","api_key":"rotated_key"}}`), "DEVICE-123")
+			if err != nil {
+				t.Fatal(err)
+			}
+			rotated, err := newNetrcWriter(home, rotatedGo.RegistryHost(), rotatedGo.DeviceToken())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := rotated.Write(rotated.expected); err != nil {
+				t.Fatal(err)
+			}
+			content, err = os.ReadFile(rotated.Location())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Count(content, []byte(dmgNetrcBegin)) != 1 || bytes.Count(content, []byte("machine registry.stepsecurity.io")) != 1 || bytes.Contains(content, []byte(pypi.DeviceToken())) {
+				t.Fatalf("rotation did not converge one shared block:\n%s", content)
+			}
+		})
+	}
+}
+
+func TestGoAndPyPISharedCredentialFinalClearAcrossRemovalOrders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("filesystem lifecycle")
+	}
+	for _, first := range []string{"go", "pypi"} {
+		t.Run(first+"-first", func(t *testing.T) {
+			withTempCache(t)
+			current, err := user.Current()
+			if err != nil {
+				t.Fatal(err)
+			}
+			homeDir := t.TempDir()
+			initialNetrc := []byte("machine registry.stepsecurity.io login original password original\nmachine other.example login user password pass\n")
+			if err := os.WriteFile(filepath.Join(homeDir, ".netrc"), initialNetrc, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			mock := executor.NewMock()
+			mock.SetGOOS("linux")
+			mock.SetUsername(current.Username)
+			mock.SetHomeDir(homeDir)
+			exec := &coordinatorUserExecutor{Mock: mock, user: &user.User{Username: current.Username, Uid: current.Uid, Gid: current.Gid, HomeDir: homeDir}}
+			pypiFetcher := &coordinatorFetcher{policy: coordinatorPolicy(`["pip"]`, "sha256:P", enforcementDMG)}
+			goFetcher := &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:G", enforcementDMG)}
+			pypi := &PyPICoordinator{Fetcher: pypiFetcher, Reporter: &coordinatorReporter{}, Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux"}
+			goCoordinator := &GoCoordinator{Fetcher: goFetcher, Reporter: &coordinatorReporter{}, Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux"}
+
+			if err := pypi.Reconcile(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if err := goCoordinator.Reconcile(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			managed, err := os.ReadFile(filepath.Join(homeDir, ".netrc"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Count(managed, []byte(dmgNetrcBegin)) != 1 {
+				t.Fatalf("shared credential blocks = %d, want 1", bytes.Count(managed, []byte(dmgNetrcBegin)))
+			}
+
+			pypiFetcher.policy = EffectivePolicy{Category: CategoryPackageConfig, Target: TargetPyPI, Clear: true}
+			goFetcher.policy = EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+			clearedTarget, retainedTarget := GoCredentialOwnershipTarget, PyPICredentialOwnershipTarget
+			if first == "go" {
+				if err := goCoordinator.Reconcile(context.Background()); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				clearedTarget, retainedTarget = PyPICredentialOwnershipTarget, GoCredentialOwnershipTarget
+				if err := pypi.Reconcile(context.Background()); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(homeDir, ".netrc")); err != nil {
+				t.Fatalf("%s-first clear removed shared credential: %v", first, err)
+			}
+			if _, ok := ReadAppliedState(CategoryPackageConfig, clearedTarget); ok {
+				t.Fatalf("first clear retained %s state", clearedTarget)
+			}
+			if _, ok := ReadAppliedState(CategoryPackageConfig, retainedTarget); !ok {
+				t.Fatalf("first clear removed %s state", retainedTarget)
+			}
+			if first == "go" {
+				if err := pypi.Reconcile(context.Background()); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := goCoordinator.Reconcile(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			restored, err := os.ReadFile(filepath.Join(homeDir, ".netrc"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(restored, initialNetrc) {
+				t.Fatalf("final clear restored %q, want %q", restored, initialNetrc)
+			}
+			for _, target := range []string{GoCredentialOwnershipTarget, PyPICredentialOwnershipTarget} {
+				if _, ok := ReadAppliedState(CategoryPackageConfig, target); ok {
+					t.Fatalf("final clear retained %s state", target)
+				}
+			}
+		})
+	}
+}
+
+func TestGoCoordinatorFinalClearIgnoresMalformedPipWithoutMarker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("filesystem lifecycle")
+	}
+	withTempCache(t)
+	current, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	homeDir := t.TempDir()
+	mock := executor.NewMock()
+	mock.SetGOOS("linux")
+	mock.SetUsername(current.Username)
+	mock.SetHomeDir(homeDir)
+	exec := &coordinatorUserExecutor{Mock: mock, user: &user.User{Username: current.Username, Uid: current.Uid, Gid: current.Gid, HomeDir: homeDir}}
+	getter := &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:G", enforcementDMG)}
+	coordinator := &GoCoordinator{Fetcher: getter, Reporter: &coordinatorReporter{}, Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: "linux"}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(homeDir, ".config", "pip", "pip.conf")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("[malformed\nindex-url = https://other.example/simple\n")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	getter.policy = EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, ".netrc")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("final clear retained credential: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("final clear changed unrelated pip content: %q", got)
+	}
+}

--- a/internal/devicepolicy/go_env_writer.go
+++ b/internal/devicepolicy/go_env_writer.go
@@ -520,6 +520,8 @@ func rewriteGoEnv(current []byte, expected string, created bool) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
+	newline := analysis.newline
+	hadFinal := bytes.HasSuffix(current, []byte(newline))
 	if analysis.owner == "mdm" {
 		return nil, fmt.Errorf("go env: MDM marker present: %w", ErrTargetUnusable)
 	}
@@ -531,7 +533,6 @@ func rewriteGoEnv(current []byte, expected string, created bool) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-	newline := goEnvNewline(base)
 	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
 	for i, line := range lines {
 		if strings.HasPrefix(line, "GOPROXY=") {
@@ -545,7 +546,6 @@ func rewriteGoEnv(current []byte, expected string, created bool) ([]byte, error)
 	}
 	managed = append(managed, expected, goEnvEnd)
 	block := strings.Join(managed, newline)
-	hadFinal := strings.HasSuffix(text, newline)
 	if baseText != "" {
 		baseText += newline
 	}

--- a/internal/devicepolicy/go_env_writer.go
+++ b/internal/devicepolicy/go_env_writer.go
@@ -1,0 +1,592 @@
+package devicepolicy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/model"
+	"github.com/step-security/dev-machine-guard/internal/secureuserfile"
+)
+
+const (
+	dmgGoEnvBegin          = "# BEGIN StepSecurity Go Secure Registry GOPROXY -- managed by dmg"
+	mdmGoEnvBegin          = "# BEGIN StepSecurity Go Secure Registry GOPROXY -- managed by mdm"
+	goEnvEnd               = "# END StepSecurity Go Secure Registry GOPROXY"
+	dmgGoEnvDisabledPrefix = "# [stepsecurity-go-env-dmg] "
+	mdmGoEnvDisabledPrefix = "# [stepsecurity-go-env-mdm] "
+	dmgGoEnvCreatedFile    = "# [stepsecurity-go-env-dmg] created=true"
+	mdmGoEnvCreatedFile    = "# [stepsecurity-go-env-mdm] created=true"
+	goEnvBackupPrefix      = ".dmg-go-env-"
+)
+
+// GoEnvObservation is the secret-free static and effective Go proxy state.
+type GoEnvObservation struct {
+	RegistryURL     string
+	ConfigStatus    string
+	EffectiveStatus string
+	OverrideSource  string
+}
+
+// GoEnvWriter manages only GOPROXY in the resolved user's default Go env file.
+type GoEnvWriter struct {
+	exec        executor.Executor
+	home        *secureuserfile.Home
+	file        *secureuserfile.File
+	expected    string
+	registryURL string
+}
+
+func NewGoEnvWriter(exec executor.Executor, home *secureuserfile.Home, policy GoPolicy) (*GoEnvWriter, error) {
+	if exec == nil {
+		return nil, errors.New("go env: nil executor")
+	}
+	if home == nil {
+		return nil, errors.New("go env: nil secure user home")
+	}
+	expected, err := renderGoEnvSettings(policy)
+	if err != nil {
+		return nil, err
+	}
+	userExec := executor.NewUserAwareExecutor(exec, home.Username())
+	path, err := goUserEnvPath(userExec, home.Path())
+	if err != nil {
+		return nil, err
+	}
+	if err := executor.UserEnvironmentError(userExec); err != nil && userExec.GOOS() != model.PlatformDarwin {
+		return nil, fmt.Errorf("go env: resolving user environment: %w", err)
+	}
+	relative, err := filepath.Rel(home.Path(), path)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return nil, fmt.Errorf("go env: user path is outside resolved home: %w", ErrTargetUnusable)
+	}
+	file, err := home.Open(relative, goEnvBackupPrefix, secureuserfile.MaxBytes)
+	if err != nil {
+		return nil, err
+	}
+	return &GoEnvWriter{exec: userExec, home: home, file: file, expected: expected, registryURL: policy.RegistryURL}, nil
+}
+
+func renderGoEnvSettings(policy GoPolicy) (string, error) {
+	u, err := parsePyPIRegistryURL(policy.RegistryURL)
+	if policy.Ecosystem != "go" || policy.Auth.Scheme != goAuthScheme || err != nil || u.EscapedPath() != "/go" ||
+		policy.Auth.APIKey == "" || len(policy.Auth.APIKey) > npmrcMaxKeyBytes || policy.deviceID == "" ||
+		len(policy.deviceID) > npmrcMaxSerialBytes || strings.Contains(policy.Auth.APIKey, "::") ||
+		!isNPMSafe(policy.Auth.APIKey) || !isNPMSafe(policy.deviceID) || !isValidHost(policy.RegistryHost()) ||
+		strings.ContainsAny(policy.RegistryURL, ",|") {
+		return "", errors.New("go env: policy cannot render safe user settings")
+	}
+	return "GOPROXY=" + policy.RegistryURL, nil
+}
+
+func goUserEnvPath(exec executor.Executor, home string) (string, error) {
+	var root string
+	switch exec.GOOS() {
+	case model.PlatformDarwin:
+		root = filepath.Join(home, "Library", "Application Support")
+	case model.PlatformWindows:
+		root = strings.TrimSpace(exec.Getenv("APPDATA"))
+		if root == "" {
+			root = filepath.Join(home, "AppData", "Roaming")
+		}
+	case model.PlatformLinux:
+		root = strings.TrimSpace(exec.Getenv("XDG_CONFIG_HOME"))
+		if root == "" {
+			root = filepath.Join(home, ".config")
+		}
+	default:
+		return "", fmt.Errorf("go env: unsupported platform %q: %w", exec.GOOS(), ErrTargetUnusable)
+	}
+	root = filepath.Clean(root)
+	if !filepath.IsAbs(root) {
+		return "", fmt.Errorf("go env: configuration root must be absolute: %w", ErrTargetUnusable)
+	}
+	relative, err := filepath.Rel(filepath.Clean(home), root)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", fmt.Errorf("go env: configuration root is outside resolved home: %w", ErrTargetUnusable)
+	}
+	return filepath.Join(root, "go", "env"), nil
+}
+
+func (w *GoEnvWriter) Location() string { return w.file.Location() }
+
+func (w *GoEnvWriter) validateExpected(expected string) error {
+	if w == nil || w.file == nil || expected == "" || expected != w.expected {
+		return errors.New("go env: expected setting does not match the validated policy")
+	}
+	return nil
+}
+
+func (w *GoEnvWriter) readCurrent() ([]byte, bool, os.FileMode, error) {
+	present, err := w.file.ParentPresent()
+	if err != nil || !present {
+		return nil, false, 0, err
+	}
+	return w.file.Read()
+}
+
+func (w *GoEnvWriter) Read() (string, bool, error) {
+	ok, err := w.StaticConverged(w.expected)
+	if err != nil || !ok {
+		return "", false, err
+	}
+	return w.expected, true, nil
+}
+
+func (w *GoEnvWriter) Write(expected string) (string, error) {
+	if err := w.validateExpected(expected); err != nil {
+		return "", err
+	}
+	if err := w.home.EnsureParent(w.file.RelativePath()); err != nil {
+		return "", err
+	}
+	current, existed, _, err := w.file.Read()
+	if err != nil {
+		return "", err
+	}
+	markers, err := scanGoEnv(current)
+	if err != nil {
+		return "", err
+	}
+	if markers.owner == "mdm" {
+		return "", fmt.Errorf("go env: MDM marker present: %w", ErrTargetUnusable)
+	}
+	created := !existed
+	if markers.owner == "dmg" {
+		created = markers.created
+	}
+	updated, err := rewriteGoEnv(current, expected, created)
+	if err != nil {
+		return "", err
+	}
+	if err := w.file.Commit(updated, secureuserfile.FileMode); err != nil {
+		return "", err
+	}
+	ok, err := w.StaticConverged(expected)
+	if err != nil {
+		return "", errors.Join(err, w.file.RestoreSnapshot())
+	}
+	if !ok {
+		return "", errors.Join(errors.New("go env: committed setting did not verify"), w.file.RestoreSnapshot())
+	}
+	return expected, nil
+}
+
+func (w *GoEnvWriter) Clear() (bool, error) {
+	current, existed, _, err := w.readCurrent()
+	if err != nil {
+		return false, err
+	}
+	if !existed {
+		present, err := w.file.ParentPresent()
+		if err != nil || !present {
+			return false, err
+		}
+		return false, w.file.PurgeBackups()
+	}
+	markers, err := scanGoEnv(current)
+	if err != nil {
+		return false, err
+	}
+	updated, changed, err := clearGoEnv(current)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, w.file.PurgeBackups()
+	}
+	if markers.created && len(bytes.TrimSpace(stripUTF8BOM(updated))) == 0 {
+		err = w.file.Remove()
+	} else {
+		err = w.file.Commit(updated, secureuserfile.FileMode)
+	}
+	if err != nil {
+		return false, err
+	}
+	if err := w.file.PurgeBackups(); err != nil {
+		return false, errors.Join(err, w.file.RestoreSnapshot())
+	}
+	return true, nil
+}
+
+func (w *GoEnvWriter) Converged(expected string) (bool, error) {
+	return w.StaticConverged(expected)
+}
+
+func (w *GoEnvWriter) StaticConverged(expected string) (bool, error) {
+	if err := w.validateExpected(expected); err != nil {
+		return false, err
+	}
+	data, existed, _, err := w.readCurrent()
+	if err != nil || !existed {
+		return false, err
+	}
+	analysis, err := scanGoEnv(data)
+	if err != nil {
+		return false, err
+	}
+	if analysis.owner != "dmg" || analysis.managedValue != expected || analysis.activeOutside {
+		return false, nil
+	}
+	return w.file.MetadataSecure(secureuserfile.FileMode)
+}
+
+func (w *GoEnvWriter) RestoreSnapshot() error { return w.file.RestoreSnapshot() }
+
+func (w *GoEnvWriter) ValidateTarget() error {
+	data, existed, _, err := w.readCurrent()
+	if err != nil || !existed {
+		return err
+	}
+	_, err = scanGoEnv(data)
+	return err
+}
+
+func (w *GoEnvWriter) HasDMGMarker() (bool, error) { return w.hasMarker("dmg") }
+func (w *GoEnvWriter) HasMDMMarker() (bool, error) { return w.hasMarker("mdm") }
+
+func (w *GoEnvWriter) MDMOwned() (bool, error) {
+	owned, err := w.HasMDMMarker()
+	if err != nil || !owned {
+		return owned, err
+	}
+	secure, err := w.file.MetadataSecure(secureuserfile.FileMode)
+	if err != nil {
+		return false, err
+	}
+	if !secure {
+		return false, fmt.Errorf("go env: insecure MDM metadata: %w", ErrTargetUnusable)
+	}
+	return true, nil
+}
+
+func (w *GoEnvWriter) hasMarker(owner string) (bool, error) {
+	data, existed, _, err := w.readCurrent()
+	if err != nil || !existed {
+		return false, err
+	}
+	analysis, err := scanGoEnv(data)
+	return analysis.owner == owner, err
+}
+
+func (w *GoEnvWriter) CompleteState(previous AppliedTargetState, hadPrevious bool, current *AppliedTargetState) error {
+	resolved, err := w.file.ResolvedPath()
+	if err != nil {
+		return err
+	}
+	if hadPrevious && previous.ResolvedPath != "" && previous.ResolvedPath != resolved {
+		return fmt.Errorf("go env: resolved ownership target changed from %q to %q: %w", previous.ResolvedPath, resolved, ErrTargetUnusable)
+	}
+	current.ResolvedPath = resolved
+	return nil
+}
+
+func (w *GoEnvWriter) PrepareClear(previous AppliedTargetState, hadPrevious bool) error {
+	if !hadPrevious || emptyOwnershipState(previous) {
+		return w.ValidateTarget()
+	}
+	if previous.ResolvedPath == "" {
+		managed, err := w.HasDMGMarker()
+		if err != nil {
+			return err
+		}
+		if !managed {
+			return fmt.Errorf("go env: legacy ownership target cannot be verified: %w", ErrTargetUnusable)
+		}
+		return nil
+	}
+	return w.file.RequireResolvedPath(previous.ResolvedPath)
+}
+
+func (w *GoEnvWriter) PrepareWrite(previous AppliedTargetState, hadPrevious bool) error {
+	return w.PrepareClear(previous, hadPrevious)
+}
+
+func (w *GoEnvWriter) Observation(expected, credentialLocation string) (GoEnvObservation, error) {
+	observation := GoEnvObservation{EffectiveStatus: "unknown", OverrideSource: "unknown"}
+	data, existed, _, err := w.readCurrent()
+	if err != nil {
+		observation.ConfigStatus = "unreadable"
+		return observation, err
+	}
+	if !existed {
+		observation.ConfigStatus = "absent"
+	} else {
+		analysis, scanErr := scanGoEnv(data)
+		if scanErr != nil {
+			observation.ConfigStatus = "unreadable"
+			return observation, scanErr
+		}
+		secure, metadataErr := w.file.MetadataSecure(secureuserfile.FileMode)
+		if metadataErr != nil {
+			observation.ConfigStatus = "unreadable"
+			return observation, metadataErr
+		}
+		conflicting := analysis.activeOutside
+		if analysis.owner == "mdm" {
+			conflicting = analysis.activeAfter
+		}
+		if secure && (analysis.owner == "dmg" || analysis.owner == "mdm") && analysis.managedValue == expected && !conflicting {
+			observation.ConfigStatus = "match"
+			observation.RegistryURL = w.registryURL
+		} else {
+			observation.ConfigStatus = "mismatch"
+			observation.RegistryURL = analysis.observedRegistryURL()
+		}
+	}
+	if err := executor.UserEnvironmentError(w.exec); err != nil {
+		return observation, err
+	}
+	classes := make([]string, 0, 4)
+	effective := ""
+	if visible := strings.TrimSpace(w.exec.Getenv("GOPROXY")); visible != "" {
+		classes = append(classes, "environment")
+		if visible == w.registryURL {
+			effective = "match"
+		} else {
+			effective = "mismatch"
+		}
+	}
+	if goenv := strings.TrimSpace(w.exec.Getenv("GOENV")); goenv != "" && !sameManagedPath(goenv, w.Location(), w.exec.GOOS()) {
+		classes = append(classes, "goenv")
+		effective = "mismatch"
+	}
+	if netrc := strings.TrimSpace(w.exec.Getenv("NETRC")); netrc != "" && !sameManagedPath(netrc, credentialLocation, w.exec.GOOS()) {
+		classes = append(classes, "netrc")
+		effective = "mismatch"
+	}
+	if goauth := strings.TrimSpace(w.exec.Getenv("GOAUTH")); goauth != "" && goauth != "netrc" {
+		classes = append(classes, "goauth")
+		if effective != "mismatch" {
+			effective = "unknown"
+		}
+	}
+	if len(classes) == 0 {
+		observation.OverrideSource = "none"
+		switch observation.ConfigStatus {
+		case "match":
+			observation.EffectiveStatus = "match"
+		case "absent", "mismatch":
+			observation.EffectiveStatus = "mismatch"
+		default:
+			observation.EffectiveStatus = "unknown"
+		}
+	} else {
+		observation.OverrideSource = classes[0]
+		if len(classes) > 1 {
+			observation.OverrideSource = "multiple"
+		}
+		observation.EffectiveStatus = effective
+	}
+	return observation, nil
+}
+
+func sameManagedPath(raw, managed, goos string) bool {
+	if raw == "off" || managed == "" {
+		return false
+	}
+	if !filepath.IsAbs(raw) {
+		return false
+	}
+	raw, managed = filepath.Clean(raw), filepath.Clean(managed)
+	return raw == managed || goos == model.PlatformWindows && strings.EqualFold(raw, managed)
+}
+
+type goEnvAnalysis struct {
+	owner         string
+	created       bool
+	begin         int
+	end           int
+	managedValue  string
+	activeOutside bool
+	activeAfter   bool
+	lastActiveURL string
+	newline       string
+	bom           bool
+}
+
+func scanGoEnv(data []byte) (goEnvAnalysis, error) {
+	analysis := goEnvAnalysis{begin: -1, end: -1}
+	text, err := validatedGoEnvText(data)
+	if err != nil {
+		return analysis, err
+	}
+	analysis.bom = bytes.HasPrefix(data, []byte{0xef, 0xbb, 0xbf})
+	analysis.newline = goEnvNewline(data)
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	inside := false
+	managedValues := 0
+	reservedOwners := map[string]bool{}
+	for i, line := range lines {
+		switch line {
+		case dmgGoEnvBegin, mdmGoEnvBegin:
+			owner := "dmg"
+			if line == mdmGoEnvBegin {
+				owner = "mdm"
+			}
+			if inside || analysis.owner != "" {
+				return analysis, fmt.Errorf("go env: nested or duplicated managed marker: %w", ErrTargetUnusable)
+			}
+			analysis.owner, analysis.begin, inside = owner, i, true
+			continue
+		case goEnvEnd:
+			if !inside {
+				return analysis, fmt.Errorf("go env: reversed managed marker: %w", ErrTargetUnusable)
+			}
+			analysis.end, inside = i, false
+			continue
+		case dmgGoEnvCreatedFile, mdmGoEnvCreatedFile:
+			owner := "dmg"
+			if line == mdmGoEnvCreatedFile {
+				owner = "mdm"
+			}
+			if !inside || analysis.owner != owner || analysis.created {
+				return analysis, fmt.Errorf("go env: misplaced or duplicated file marker: %w", ErrTargetUnusable)
+			}
+			analysis.created = true
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, dmgGoEnvDisabledPrefix):
+			if !strings.HasPrefix(strings.TrimPrefix(line, dmgGoEnvDisabledPrefix), "GOPROXY=") {
+				return analysis, fmt.Errorf("go env: invalid DMG disabled setting: %w", ErrTargetUnusable)
+			}
+			reservedOwners["dmg"] = true
+		case strings.HasPrefix(line, mdmGoEnvDisabledPrefix):
+			if !strings.HasPrefix(strings.TrimPrefix(line, mdmGoEnvDisabledPrefix), "GOPROXY=") {
+				return analysis, fmt.Errorf("go env: invalid MDM disabled setting: %w", ErrTargetUnusable)
+			}
+			reservedOwners["mdm"] = true
+		}
+		if strings.HasPrefix(line, "GOPROXY=") {
+			if inside {
+				managedValues++
+				analysis.managedValue = line
+			} else {
+				analysis.activeOutside = true
+				analysis.activeAfter = analysis.activeAfter || analysis.end >= 0
+				analysis.lastActiveURL = strings.TrimPrefix(line, "GOPROXY=")
+			}
+		} else if inside && line != "" {
+			return analysis, fmt.Errorf("go env: unexpected managed-block content: %w", ErrTargetUnusable)
+		}
+	}
+	if inside || analysis.owner != "" && analysis.end < 0 {
+		return analysis, fmt.Errorf("go env: incomplete managed markers: %w", ErrTargetUnusable)
+	}
+	if analysis.owner != "" && managedValues != 1 {
+		return analysis, fmt.Errorf("go env: managed block must contain one GOPROXY setting: %w", ErrTargetUnusable)
+	}
+	for owner := range reservedOwners {
+		if analysis.owner != owner {
+			return analysis, fmt.Errorf("go env: orphaned or mixed disabled prefix: %w", ErrTargetUnusable)
+		}
+	}
+	return analysis, nil
+}
+
+func (a goEnvAnalysis) observedRegistryURL() string {
+	if safe := safeObservedRegistryURL(a.lastActiveURL); safe != "" {
+		return safe
+	}
+	return safeObservedRegistryURL(strings.TrimPrefix(a.managedValue, "GOPROXY="))
+}
+
+func validatedGoEnvText(data []byte) (string, error) {
+	if !utf8.Valid(data) || bytes.IndexByte(data, 0) >= 0 || hasLoneCR(string(data)) {
+		return "", fmt.Errorf("go env: invalid text encoding: %w", ErrTargetUnusable)
+	}
+	text := string(stripUTF8BOM(data))
+	if strings.Contains(text, "\r\n") && strings.Contains(strings.ReplaceAll(text, "\r\n", ""), "\n") {
+		return "", fmt.Errorf("go env: mixed line endings: %w", ErrTargetUnusable)
+	}
+	return text, nil
+}
+
+func goEnvNewline(data []byte) string {
+	if bytes.Contains(data, []byte("\r\n")) {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+func rewriteGoEnv(current []byte, expected string, created bool) ([]byte, error) {
+	analysis, err := scanGoEnv(current)
+	if err != nil {
+		return nil, err
+	}
+	if analysis.owner == "mdm" {
+		return nil, fmt.Errorf("go env: MDM marker present: %w", ErrTargetUnusable)
+	}
+	base, _, err := clearGoEnv(current)
+	if err != nil {
+		return nil, err
+	}
+	text, err := validatedGoEnvText(base)
+	if err != nil {
+		return nil, err
+	}
+	newline := goEnvNewline(base)
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "GOPROXY=") {
+			lines[i] = dmgGoEnvDisabledPrefix + line
+		}
+	}
+	baseText := strings.Join(lines, newline)
+	managed := []string{dmgGoEnvBegin}
+	if created {
+		managed = append(managed, dmgGoEnvCreatedFile)
+	}
+	managed = append(managed, expected, goEnvEnd)
+	block := strings.Join(managed, newline)
+	hadFinal := strings.HasSuffix(text, newline)
+	if baseText != "" {
+		baseText += newline
+	}
+	result := baseText + block
+	if created || hadFinal {
+		result += newline
+	}
+	if analysis.bom || bytes.HasPrefix(base, []byte{0xef, 0xbb, 0xbf}) {
+		result = string([]byte{0xef, 0xbb, 0xbf}) + result
+	}
+	return []byte(result), nil
+}
+
+func clearGoEnv(data []byte) ([]byte, bool, error) {
+	analysis, err := scanGoEnv(data)
+	if err != nil {
+		return nil, false, err
+	}
+	if analysis.owner != "dmg" {
+		return data, false, nil
+	}
+	text, err := validatedGoEnvText(data)
+	if err != nil {
+		return nil, false, err
+	}
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	out := append([]string(nil), lines[:analysis.begin]...)
+	if len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	out = append(out, lines[analysis.end+1:]...)
+	for i, line := range out {
+		if strings.HasPrefix(line, dmgGoEnvDisabledPrefix) {
+			out[i] = strings.TrimPrefix(line, dmgGoEnvDisabledPrefix)
+		}
+	}
+	result := strings.Join(out, analysis.newline)
+	if analysis.bom {
+		result = string([]byte{0xef, 0xbb, 0xbf}) + result
+	}
+	return []byte(result), true, nil
+}
+
+var _ Writer = (*GoEnvWriter)(nil)

--- a/internal/devicepolicy/go_env_writer.go
+++ b/internal/devicepolicy/go_env_writer.go
@@ -23,6 +23,7 @@ const (
 	dmgGoEnvCreatedFile    = "# [stepsecurity-go-env-dmg] created=true"
 	mdmGoEnvCreatedFile    = "# [stepsecurity-go-env-mdm] created=true"
 	dmgGoEnvRestoreCRLF    = "# [stepsecurity-go-env-dmg] newline=crlf"
+	mdmGoEnvRestoreCRLF    = "# [stepsecurity-go-env-mdm] restore-crlf=true"
 	goEnvBackupPrefix      = ".dmg-go-env-"
 )
 
@@ -454,8 +455,12 @@ func scanGoEnv(data []byte) (goEnvAnalysis, error) {
 			}
 			analysis.created = true
 			continue
-		case dmgGoEnvRestoreCRLF:
-			if !inside || analysis.owner != "dmg" || analysis.restoreCRLF {
+		case dmgGoEnvRestoreCRLF, mdmGoEnvRestoreCRLF:
+			owner := "dmg"
+			if line == mdmGoEnvRestoreCRLF {
+				owner = "mdm"
+			}
+			if !inside || analysis.owner != owner || analysis.restoreCRLF {
 				return analysis, fmt.Errorf("go env: misplaced or duplicated newline marker: %w", ErrTargetUnusable)
 			}
 			analysis.restoreCRLF = true

--- a/internal/devicepolicy/go_env_writer.go
+++ b/internal/devicepolicy/go_env_writer.go
@@ -22,7 +22,7 @@ const (
 	mdmGoEnvDisabledPrefix = "# [stepsecurity-go-env-mdm] "
 	dmgGoEnvCreatedFile    = "# [stepsecurity-go-env-dmg] created=true"
 	mdmGoEnvCreatedFile    = "# [stepsecurity-go-env-mdm] created=true"
-	dmgGoEnvRestoreCRLF    = "# [stepsecurity-go-env-dmg] newline=crlf"
+	dmgGoEnvRestoreCRLF    = "# [stepsecurity-go-env-dmg] restore-crlf=true"
 	mdmGoEnvRestoreCRLF    = "# [stepsecurity-go-env-mdm] restore-crlf=true"
 	goEnvBackupPrefix      = ".dmg-go-env-"
 )

--- a/internal/devicepolicy/go_env_writer.go
+++ b/internal/devicepolicy/go_env_writer.go
@@ -22,6 +22,7 @@ const (
 	mdmGoEnvDisabledPrefix = "# [stepsecurity-go-env-mdm] "
 	dmgGoEnvCreatedFile    = "# [stepsecurity-go-env-dmg] created=true"
 	mdmGoEnvCreatedFile    = "# [stepsecurity-go-env-mdm] created=true"
+	dmgGoEnvRestoreCRLF    = "# [stepsecurity-go-env-dmg] newline=crlf"
 	goEnvBackupPrefix      = ".dmg-go-env-"
 )
 
@@ -160,7 +161,7 @@ func (w *GoEnvWriter) Write(expected string) (string, error) {
 	if markers.owner == "dmg" {
 		created = markers.created
 	}
-	updated, err := rewriteGoEnv(current, expected, created)
+	updated, err := rewriteGoEnv(current, expected, created, w.exec.GOOS() == model.PlatformWindows)
 	if err != nil {
 		return "", err
 	}
@@ -230,7 +231,8 @@ func (w *GoEnvWriter) StaticConverged(expected string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if analysis.owner != "dmg" || analysis.managedValue != expected || analysis.activeOutside {
+	if analysis.owner != "dmg" || analysis.managedValue != expected || analysis.activeOutside ||
+		w.exec.GOOS() == model.PlatformWindows && analysis.newline != "\n" {
 		return false, nil
 	}
 	return w.file.MetadataSecure(secureuserfile.FileMode)
@@ -331,7 +333,8 @@ func (w *GoEnvWriter) Observation(expected, credentialLocation string) (GoEnvObs
 		if analysis.owner == "mdm" {
 			conflicting = analysis.activeAfter
 		}
-		if secure && (analysis.owner == "dmg" || analysis.owner == "mdm") && analysis.managedValue == expected && !conflicting {
+		if secure && (analysis.owner == "dmg" || analysis.owner == "mdm") && analysis.managedValue == expected && !conflicting &&
+			(w.exec.GOOS() != model.PlatformWindows || analysis.newline == "\n") {
 			observation.ConfigStatus = "match"
 			observation.RegistryURL = w.registryURL
 		} else {
@@ -407,6 +410,7 @@ type goEnvAnalysis struct {
 	activeAfter   bool
 	lastActiveURL string
 	newline       string
+	restoreCRLF   bool
 	bom           bool
 }
 
@@ -449,6 +453,12 @@ func scanGoEnv(data []byte) (goEnvAnalysis, error) {
 				return analysis, fmt.Errorf("go env: misplaced or duplicated file marker: %w", ErrTargetUnusable)
 			}
 			analysis.created = true
+			continue
+		case dmgGoEnvRestoreCRLF:
+			if !inside || analysis.owner != "dmg" || analysis.restoreCRLF {
+				return analysis, fmt.Errorf("go env: misplaced or duplicated newline marker: %w", ErrTargetUnusable)
+			}
+			analysis.restoreCRLF = true
 			continue
 		}
 		switch {
@@ -515,13 +525,17 @@ func goEnvNewline(data []byte) string {
 	return "\n"
 }
 
-func rewriteGoEnv(current []byte, expected string, created bool) ([]byte, error) {
+func rewriteGoEnv(current []byte, expected string, created, normalizeCRLF bool) ([]byte, error) {
 	analysis, err := scanGoEnv(current)
 	if err != nil {
 		return nil, err
 	}
 	newline := analysis.newline
 	hadFinal := bytes.HasSuffix(current, []byte(newline))
+	restoreCRLF := analysis.restoreCRLF || normalizeCRLF && newline == "\r\n"
+	if normalizeCRLF {
+		newline = "\n"
+	}
 	if analysis.owner == "mdm" {
 		return nil, fmt.Errorf("go env: MDM marker present: %w", ErrTargetUnusable)
 	}
@@ -543,6 +557,9 @@ func rewriteGoEnv(current []byte, expected string, created bool) ([]byte, error)
 	managed := []string{dmgGoEnvBegin}
 	if created {
 		managed = append(managed, dmgGoEnvCreatedFile)
+	}
+	if restoreCRLF {
+		managed = append(managed, dmgGoEnvRestoreCRLF)
 	}
 	managed = append(managed, expected, goEnvEnd)
 	block := strings.Join(managed, newline)
@@ -582,7 +599,11 @@ func clearGoEnv(data []byte) ([]byte, bool, error) {
 			out[i] = strings.TrimPrefix(line, dmgGoEnvDisabledPrefix)
 		}
 	}
-	result := strings.Join(out, analysis.newline)
+	newline := analysis.newline
+	if analysis.restoreCRLF {
+		newline = "\r\n"
+	}
+	result := strings.Join(out, newline)
 	if analysis.bom {
 		result = string([]byte{0xef, 0xbb, 0xbf}) + result
 	}

--- a/internal/devicepolicy/go_env_writer_test.go
+++ b/internal/devicepolicy/go_env_writer_test.go
@@ -1,0 +1,582 @@
+package devicepolicy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/model"
+	"github.com/step-security/dev-machine-guard/internal/secureuserfile"
+)
+
+const goEnvExpected = "GOPROXY=https://registry.stepsecurity.io/go"
+
+func goTestPolicy(t *testing.T) GoPolicy {
+	t.Helper()
+	policy, err := ParseGoPolicy(json.RawMessage(validGoPolicyJSON()), "device-1")
+	if err != nil {
+		t.Fatalf("ParseGoPolicy: %v", err)
+	}
+	return policy
+}
+
+func newGoEnvTestWriter(t *testing.T, initial []byte) (*GoEnvWriter, *executor.Mock, string) {
+	t.Helper()
+	homeDir := t.TempDir()
+	path := filepath.Join(homeDir, ".config", "go", "env")
+	if initial != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, initial, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	home := newSecureTestHomeAs(t, homeDir, "")
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformLinux)
+	mock.SetUsername("")
+	mock.SetHomeDir(homeDir)
+	w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatalf("NewGoEnvWriter: %v", err)
+	}
+	w.exec = mock
+	return w, mock, path
+}
+
+func TestGoEnvWriter_TransformsAndExactlyRestores(t *testing.T) {
+	private := "GOPRIVATE=corp.example/*\nGONOPROXY=corp.example/*\nGONOSUMDB=corp.example/*\nGOSUMDB=sum.golang.org"
+	cases := map[string][]byte{
+		"empty existing": {},
+		"LF final":       []byte("# keep\nGOPROXY=https://proxy.golang.org,direct\n" + private + "\n"),
+		"LF no final":    []byte("# keep\nGOPROXY=https://proxy.golang.org\nGOPROXY=direct\n" + private),
+		"CRLF":           []byte(strings.ReplaceAll("# keep\nGOPROXY=https://proxy.golang.org\n"+private+"\n", "\n", "\r\n")),
+		"BOM":            append([]byte{0xef, 0xbb, 0xbf}, []byte("# keep\n"+private+"\n")...),
+	}
+	for name, initial := range cases {
+		t.Run(name, func(t *testing.T) {
+			w, _, path := newGoEnvTestWriter(t, initial)
+			if got, err := w.Write(goEnvExpected); err != nil || got != goEnvExpected {
+				t.Fatalf("Write = %q, %v", got, err)
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Count(content, []byte(dmgGoEnvBegin)) != 1 || bytes.Count(content, []byte(goEnvExpected)) != 1 {
+				t.Fatalf("managed block is not canonical:\n%s", content)
+			}
+			for _, line := range []string{"GOPRIVATE=", "GONOPROXY=", "GONOSUMDB=", "GOSUMDB="} {
+				if bytes.Count(content, []byte(line)) != bytes.Count(initial, []byte(line)) {
+					t.Fatalf("%s changed:\n%s", line, content)
+				}
+			}
+			if ok, err := w.Converged(goEnvExpected); err != nil || !ok {
+				t.Fatalf("Converged = %v, %v", ok, err)
+			}
+			changed, err := w.Clear()
+			if err != nil || !changed {
+				t.Fatalf("Clear = %v, %v", changed, err)
+			}
+			restored, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(restored, initial) {
+				t.Fatalf("restored %q, want %q", restored, initial)
+			}
+			if changed, err := w.Clear(); err != nil || changed {
+				t.Fatalf("second Clear = %v, %v", changed, err)
+			}
+		})
+	}
+}
+
+func TestGoEnvWriter_CreatedFileIsRemovedOnClear(t *testing.T) {
+	w, _, path := newGoEnvTestWriter(t, nil)
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := w.Clear(); err != nil || !changed {
+		t.Fatalf("Clear = %v, %v", changed, err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("created file remains: %v", err)
+	}
+}
+
+func TestGoEnvWriter_CleanHomePlatformPaths(t *testing.T) {
+	for _, goos := range []string{model.PlatformLinux, model.PlatformDarwin, model.PlatformWindows} {
+		t.Run(goos, func(t *testing.T) {
+			homeDir := t.TempDir()
+			home := newSecureTestHomeAs(t, homeDir, "")
+			mock := executor.NewMock()
+			mock.SetGOOS(goos)
+			if goos == model.PlatformWindows {
+				mock.SetEnv("APPDATA", filepath.Join(homeDir, "AppData", "Roaming"))
+			}
+			w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := w.Write(goEnvExpected); err != nil {
+				t.Fatal(err)
+			}
+			want, err := goUserEnvPath(mock, homeDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if w.Location() != want {
+				t.Fatalf("Location = %q, want %q", w.Location(), want)
+			}
+		})
+	}
+}
+
+type noGoCommandExecutor struct {
+	executor.Executor
+	calls int
+}
+
+func (e *noGoCommandExecutor) Run(context.Context, string, ...string) (string, string, int, error) {
+	e.calls++
+	return "", "", 1, errors.New("unexpected command")
+}
+
+func (e *noGoCommandExecutor) RunWithTimeout(context.Context, time.Duration, string, ...string) (string, string, int, error) {
+	e.calls++
+	return "", "", 1, errors.New("unexpected command")
+}
+
+func (e *noGoCommandExecutor) RunInDir(context.Context, string, time.Duration, string, ...string) (string, string, int, error) {
+	e.calls++
+	return "", "", 1, errors.New("unexpected command")
+}
+
+func (e *noGoCommandExecutor) RunAsUser(context.Context, string, string) (string, error) {
+	e.calls++
+	return "", errors.New("unexpected command")
+}
+
+func (e *noGoCommandExecutor) LookPath(string) (string, error) {
+	e.calls++
+	return "", errors.New("unexpected command")
+}
+
+func TestGoEnvWriter_NeverLocatesOrExecutesGo(t *testing.T) {
+	homeDir := t.TempDir()
+	home := newSecureTestHomeAs(t, homeDir, "")
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformLinux)
+	exec := &noGoCommandExecutor{Executor: mock}
+	w, err := NewGoEnvWriter(exec, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Observation(goEnvExpected, filepath.Join(homeDir, ".netrc")); err != nil {
+		t.Fatal(err)
+	}
+	if exec.calls != 0 {
+		t.Fatalf("Go enforcement made %d external command calls", exec.calls)
+	}
+}
+
+func TestGoEnvWriter_RepairsDriftAndPreservesPrivateSettings(t *testing.T) {
+	initial := []byte("GOPRIVATE=secret.example/*\nGOPROXY=https://proxy.golang.org\n")
+	w, _, path := newGoEnvTestWriter(t, initial)
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString("GOPROXY=https://proxy.golang.org|direct\n")
+	_ = f.Close()
+	if ok, err := w.Converged(goEnvExpected); err != nil || ok {
+		t.Fatalf("Converged after drift = %v, %v", ok, err)
+	}
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	content, _ := os.ReadFile(path)
+	if bytes.Count(content, []byte("GOPRIVATE=secret.example/*")) != 1 || !bytes.Contains(content, []byte(dmgGoEnvDisabledPrefix+"GOPROXY=https://proxy.golang.org|direct")) {
+		t.Fatalf("drift repair changed unrelated data:\n%s", content)
+	}
+}
+
+func TestGoEnvWriter_RejectsAmbiguousInput(t *testing.T) {
+	cases := map[string][]byte{
+		"invalid UTF-8": {0xff},
+		"NUL":           []byte("GOPROXY=x\x00"),
+		"lone CR":       []byte("GOPROXY=x\rnext"),
+		"mixed newline": []byte("one\r\ntwo\n"),
+		"orphan prefix": []byte(dmgGoEnvDisabledPrefix + "GOPROXY=direct\n"),
+		"incomplete":    []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n"),
+		"duplicate":     []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n" + dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd),
+		"mixed owner":   []byte(mdmGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n" + dmgGoEnvDisabledPrefix + "GOPROXY=direct"),
+		"oversized":     bytes.Repeat([]byte("x"), (1<<20)+1),
+	}
+	for name, initial := range cases {
+		t.Run(name, func(t *testing.T) {
+			w, _, path := newGoEnvTestWriter(t, initial)
+			before, _ := os.ReadFile(path)
+			if _, err := w.Write(goEnvExpected); err == nil {
+				t.Fatal("Write() error = nil")
+			}
+			after, _ := os.ReadFile(path)
+			if !bytes.Equal(after, before) {
+				t.Fatal("rejected input was mutated")
+			}
+		})
+	}
+}
+
+func TestGoEnvWriter_RejectsNonGOPROXYDisabledPayloadOnEnforceAndClear(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		prefix string
+		begin  string
+	}{
+		{"DMG", dmgGoEnvDisabledPrefix, dmgGoEnvBegin},
+		{"MDM", mdmGoEnvDisabledPrefix, mdmGoEnvBegin},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			initial := []byte(tc.prefix + "GONOPROXY=corp.example\n" + tc.begin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n")
+			w, _, path := newGoEnvTestWriter(t, initial)
+			if err := w.ValidateTarget(); err == nil {
+				t.Fatal("ValidateTarget() error = nil")
+			}
+			if changed, err := w.Clear(); err == nil || changed {
+				t.Fatalf("Clear = %v, %v, want rejection", changed, err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, initial) {
+				t.Fatal("rejected disabled payload was mutated")
+			}
+		})
+	}
+}
+
+func TestGoEnvWriter_ObservesExactMDMShapeWithoutWriting(t *testing.T) {
+	initial := []byte(strings.Join([]string{
+		"GOPROXY=https://prior.example/go",
+		mdmGoEnvDisabledPrefix + "GOPROXY=https://proxy.golang.org",
+		mdmGoEnvBegin,
+		goEnvExpected,
+		goEnvEnd,
+		"GOPRIVATE=corp.example/*",
+		"",
+	}, "\n"))
+	w, _, path := newGoEnvTestWriter(t, initial)
+	hardenSecureTestFile(t, w.file)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owned, err := w.MDMOwned()
+	if err != nil || !owned {
+		t.Fatalf("MDMOwned = %v, %v", owned, err)
+	}
+	observed, err := w.Observation(goEnvExpected, filepath.Join(w.home.Path(), ".netrc"))
+	if err != nil || observed.ConfigStatus != "match" || observed.EffectiveStatus != "match" || observed.OverrideSource != "none" {
+		t.Fatalf("Observation = %#v, %v", observed, err)
+	}
+	if _, err := w.Write(goEnvExpected); err == nil {
+		t.Fatal("Write() error = nil with MDM ownership")
+	}
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(after, before) {
+		t.Fatal("MDM inspection mutated the file")
+	}
+
+	if err := os.WriteFile(path, append(after, []byte("GOPROXY=https://proxy.golang.org\n")...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hardenSecureTestFile(t, w.file)
+	observed, err = w.Observation(goEnvExpected, filepath.Join(w.home.Path(), ".netrc"))
+	if err != nil || observed.ConfigStatus != "mismatch" {
+		t.Fatalf("active line after MDM block = %#v, %v", observed, err)
+	}
+}
+
+func TestGoUserEnvPath(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator), "users", "alice")
+	cases := []struct {
+		name, goos, xdg, appdata, want string
+		wantErr                        bool
+	}{
+		{"linux default", model.PlatformLinux, "", "", filepath.Join(home, ".config", "go", "env"), false},
+		{"linux XDG", model.PlatformLinux, filepath.Join(home, "xdg"), "", filepath.Join(home, "xdg", "go", "env"), false},
+		{"linux XDG trailing separator", model.PlatformLinux, filepath.Join(home, "xdg") + string(filepath.Separator), "", filepath.Join(home, "xdg", "go", "env"), false},
+		{"darwin", model.PlatformDarwin, "", "", filepath.Join(home, "Library", "Application Support", "go", "env"), false},
+		{"windows AppData", model.PlatformWindows, "", filepath.Join(home, "AppData", "Roaming"), filepath.Join(home, "AppData", "Roaming", "go", "env"), false},
+		{"windows AppData trailing separator", model.PlatformWindows, "", filepath.Join(home, "AppData", "Roaming") + string(filepath.Separator), filepath.Join(home, "AppData", "Roaming", "go", "env"), false},
+		{"external XDG", model.PlatformLinux, filepath.Join(string(filepath.Separator), "tmp", "xdg"), "", "", true},
+		{"normalized AppData", model.PlatformWindows, "", filepath.Join(home, "AppData", "..", "Roaming"), filepath.Join(home, "Roaming", "go", "env"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := executor.NewMock()
+			mock.SetGOOS(tc.goos)
+			mock.SetEnv("XDG_CONFIG_HOME", tc.xdg)
+			mock.SetEnv("APPDATA", tc.appdata)
+			got, err := goUserEnvPath(mock, home)
+			if (err != nil) != tc.wantErr || got != tc.want {
+				t.Fatalf("goUserEnvPath = %q, %v; want %q, err=%v", got, err, tc.want, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestGoEnvObservationOverrides(t *testing.T) {
+	w, mock, _ := newGoEnvTestWriter(t, nil)
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name, goproxy, goenv, netrc, goauth, status, source string
+	}{
+		{"none", "", "", "", "", "match", "none"},
+		{"matching environment", w.registryURL, "", "", "", "match", "environment"},
+		{"mismatching environment", "https://proxy.golang.org", "", "", "", "mismatch", "environment"},
+		{"GOENV off", "", "off", "", "", "mismatch", "goenv"},
+		{"relative GOENV", "", "relative-goenv", "", "", "mismatch", "goenv"},
+		{"managed GOENV", "", w.Location(), "", "", "match", "none"},
+		{"NETRC", "", "", filepath.Join(filepath.Dir(w.home.Path()), "other"), "", "mismatch", "netrc"},
+		{"relative NETRC", "", "", "relative-netrc", "", "mismatch", "netrc"},
+		{"managed NETRC", "", "", filepath.Join(w.home.Path(), ".netrc"), "", "match", "none"},
+		{"GOAUTH netrc", "", "", "", "netrc", "match", "none"},
+		{"GOAUTH off", "", "", "", "off", "unknown", "goauth"},
+		{"multiple", "https://proxy.golang.org", "off", "", "", "mismatch", "multiple"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.SetEnv("GOPROXY", tc.goproxy)
+			mock.SetEnv("GOENV", tc.goenv)
+			mock.SetEnv("NETRC", tc.netrc)
+			mock.SetEnv("GOAUTH", tc.goauth)
+			got, err := w.Observation(goEnvExpected, filepath.Join(w.home.Path(), ".netrc"))
+			if err != nil || got.EffectiveStatus != tc.status || got.OverrideSource != tc.source {
+				t.Fatalf("Observation = %#v, %v", got, err)
+			}
+		})
+	}
+}
+
+type failingGoEnvExecutor struct{ executor.Executor }
+
+func (failingGoEnvExecutor) RunAsUser(context.Context, string, string) (string, error) {
+	return "", errors.New("environment capture failed")
+}
+
+func TestGoEnvObservationCaptureFailureIsUnknown(t *testing.T) {
+	if runtime.GOOS == model.PlatformWindows {
+		t.Skip("Windows environment capture is supplied directly by the executor")
+	}
+	w, _, _ := newGoEnvTestWriter(t, nil)
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	inner := executor.NewMock()
+	inner.SetGOOS(model.PlatformLinux)
+	w.exec = executor.NewUserAwareExecutor(failingGoEnvExecutor{Executor: inner}, "alice")
+	observed, err := w.Observation(goEnvExpected, filepath.Join(w.home.Path(), ".netrc"))
+	if err == nil || observed.EffectiveStatus != "unknown" || observed.OverrideSource != "unknown" {
+		t.Fatalf("Observation = %#v, %v", observed, err)
+	}
+}
+
+func TestSiblingMarkerChecksFailClosedOnUserEnvironmentCaptureFailure(t *testing.T) {
+	if runtime.GOOS == model.PlatformWindows {
+		t.Skip("Windows reads the target-user environment directly")
+	}
+	home := newSecureTestHomeAs(t, t.TempDir(), "alice")
+	inner := executor.NewMock()
+	inner.SetGOOS(model.PlatformLinux)
+	exec := failingGoEnvExecutor{Executor: inner}
+	for name, check := range map[string]func(executor.Executor, *secureuserfile.Home) (bool, error){
+		"PyPI": hasPyPIDMGMarker,
+		"Go":   hasGoDMGMarker,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := check(exec, home); err == nil {
+				t.Fatal("sibling marker check error = nil")
+			}
+		})
+	}
+}
+
+func TestGoSiblingMarkerOnDarwinDoesNotRequireEnvironmentCapture(t *testing.T) {
+	if runtime.GOOS == model.PlatformWindows {
+		t.Skip("Windows environment capture is supplied directly by the executor")
+	}
+	homeDir := t.TempDir()
+	path := filepath.Join(homeDir, "Library", "Application Support", "go", "env")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHomeAs(t, homeDir, "alice")
+	inner := executor.NewMock()
+	inner.SetGOOS(model.PlatformDarwin)
+	managed, err := hasGoDMGMarker(failingGoEnvExecutor{Executor: inner}, home)
+	if err != nil || !managed {
+		t.Fatalf("hasGoDMGMarker = %v, %v", managed, err)
+	}
+}
+
+func TestGoEnvWriter_RecordedSymlinkTargetCannotBeRetargeted(t *testing.T) {
+	homeDir := t.TempDir()
+	dir := filepath.Join(homeDir, ".config", "go")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"a", "b"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(dir, "env")
+	if err := os.Symlink("a", link); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHomeAs(t, homeDir, "")
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformLinux)
+	w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	state := AppliedTargetState{}
+	if err := w.CompleteState(AppliedTargetState{}, false, &state); err != nil {
+		t.Fatal(err)
+	}
+	a, err := os.ReadFile(filepath.Join(dir, "a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b"), a, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("b", link); err != nil {
+		t.Fatal(err)
+	}
+	beforeA, _ := os.ReadFile(filepath.Join(dir, "a"))
+	beforeB, _ := os.ReadFile(filepath.Join(dir, "b"))
+	if err := w.PrepareWrite(state, true); err == nil {
+		t.Fatal("PrepareWrite() error = nil after retarget")
+	}
+	if err := w.PrepareClear(state, true); err == nil {
+		t.Fatal("PrepareClear() error = nil after retarget")
+	}
+	afterA, _ := os.ReadFile(filepath.Join(dir, "a"))
+	afterB, _ := os.ReadFile(filepath.Join(dir, "b"))
+	if !bytes.Equal(afterA, beforeA) || !bytes.Equal(afterB, beforeB) {
+		t.Fatal("retarget rejection mutated a file")
+	}
+}
+
+func TestGoEnvWriter_LegacyPathlessStateRequiresCurrentMarkerProof(t *testing.T) {
+	homeDir := t.TempDir()
+	dir := filepath.Join(homeDir, ".config", "go")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	aPath, bPath := filepath.Join(dir, "a"), filepath.Join(dir, "b")
+	managed := []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n")
+	if err := os.WriteFile(aPath, managed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte("# clean\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "env")
+	if err := os.Symlink("a", link); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHomeAs(t, homeDir, "")
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformLinux)
+	w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := AppliedTargetState{AppliedHash: "sha256:legacy", WrittenSettings: map[string]string{goEnvOwnershipKey: GoEnvOwnershipValue}}
+	if err := w.PrepareClear(legacy, true); err != nil {
+		t.Fatalf("unchanged legacy target rejected: %v", err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("b", link); err != nil {
+		t.Fatal(err)
+	}
+	beforeA, _ := os.ReadFile(aPath)
+	beforeB, _ := os.ReadFile(bPath)
+	if err := w.PrepareClear(legacy, true); err == nil {
+		t.Fatal("PrepareClear() error = nil after legacy retarget")
+	}
+	if err := w.PrepareWrite(legacy, true); err == nil {
+		t.Fatal("PrepareWrite() error = nil after legacy retarget")
+	}
+	afterA, _ := os.ReadFile(aPath)
+	afterB, _ := os.ReadFile(bPath)
+	if !bytes.Equal(afterA, beforeA) || !bytes.Equal(afterB, beforeB) {
+		t.Fatal("legacy retarget rejection mutated files")
+	}
+}
+
+func TestGoEnvWriter_RejectsEscapingSymlink(t *testing.T) {
+	homeDir := t.TempDir()
+	dir := filepath.Join(homeDir, ".config", "go")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	initial := []byte("do not change")
+	if err := os.WriteFile(outside, initial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "env")); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHomeAs(t, homeDir, "")
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformLinux)
+	w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(goEnvExpected); err == nil {
+		t.Fatal("Write() error = nil")
+	}
+	got, _ := os.ReadFile(outside)
+	if !bytes.Equal(got, initial) {
+		t.Fatal("escaping symlink target was mutated")
+	}
+}

--- a/internal/devicepolicy/go_env_writer_test.go
+++ b/internal/devicepolicy/go_env_writer_test.go
@@ -118,7 +118,7 @@ func TestRewriteGoEnv_NormalizesCRLFAndExactlyRestores(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Contains(first, []byte("\r")) || !bytes.Contains(first, []byte(dmgGoEnvRestoreCRLF)) {
+	if bytes.Contains(first, []byte("\r")) || !bytes.Contains(first, []byte("# [stepsecurity-go-env-dmg] restore-crlf=true")) {
 		t.Fatalf("rewriteGoEnv did not normalize CRLF with restoration metadata: %q", first)
 	}
 	second, err := rewriteGoEnv(first, goEnvExpected, false, true)
@@ -255,15 +255,16 @@ func TestGoEnvWriter_RepairsDriftAndPreservesPrivateSettings(t *testing.T) {
 
 func TestGoEnvWriter_RejectsAmbiguousInput(t *testing.T) {
 	cases := map[string][]byte{
-		"invalid UTF-8": {0xff},
-		"NUL":           []byte("GOPROXY=x\x00"),
-		"lone CR":       []byte("GOPROXY=x\rnext"),
-		"mixed newline": []byte("one\r\ntwo\n"),
-		"orphan prefix": []byte(dmgGoEnvDisabledPrefix + "GOPROXY=direct\n"),
-		"incomplete":    []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n"),
-		"duplicate":     []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n" + dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd),
-		"mixed owner":   []byte(mdmGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n" + dmgGoEnvDisabledPrefix + "GOPROXY=direct"),
-		"oversized":     bytes.Repeat([]byte("x"), (1<<20)+1),
+		"invalid UTF-8":   {0xff},
+		"NUL":             []byte("GOPROXY=x\x00"),
+		"lone CR":         []byte("GOPROXY=x\rnext"),
+		"mixed newline":   []byte("one\r\ntwo\n"),
+		"orphan prefix":   []byte(dmgGoEnvDisabledPrefix + "GOPROXY=direct\n"),
+		"incomplete":      []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n"),
+		"duplicate":       []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n" + dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd),
+		"mixed owner":     []byte(mdmGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n" + dmgGoEnvDisabledPrefix + "GOPROXY=direct"),
+		"old CRLF marker": []byte(dmgGoEnvBegin + "\n# [stepsecurity-go-env-dmg] newline=crlf\n" + goEnvExpected + "\n" + goEnvEnd),
+		"oversized":       bytes.Repeat([]byte("x"), (1<<20)+1),
 	}
 	for name, initial := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/devicepolicy/go_env_writer_test.go
+++ b/internal/devicepolicy/go_env_writer_test.go
@@ -103,12 +103,37 @@ func TestGoEnvWriter_TransformsAndExactlyRestores(t *testing.T) {
 
 func TestRewriteGoEnv_PreservesManagedOnlyCRLF(t *testing.T) {
 	initial := []byte(dmgGoEnvBegin + "\r\n" + goEnvExpected + "\r\n" + goEnvEnd + "\r\n")
-	got, err := rewriteGoEnv(initial, goEnvExpected, false)
+	got, err := rewriteGoEnv(initial, goEnvExpected, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(got, initial) {
 		t.Fatalf("rewriteGoEnv = %q, want %q", got, initial)
+	}
+}
+
+func TestRewriteGoEnv_NormalizesCRLFAndExactlyRestores(t *testing.T) {
+	initial := []byte("# keep\r\nGOPROXY=https://proxy.golang.org\r\nGOPRIVATE=corp.example/*\r\n")
+	first, err := rewriteGoEnv(initial, goEnvExpected, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(first, []byte("\r")) || !bytes.Contains(first, []byte(dmgGoEnvRestoreCRLF)) {
+		t.Fatalf("rewriteGoEnv did not normalize CRLF with restoration metadata: %q", first)
+	}
+	second, err := rewriteGoEnv(first, goEnvExpected, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(second, first) {
+		t.Fatalf("repeated rewrite = %q, want %q", second, first)
+	}
+	restored, changed, err := clearGoEnv(first)
+	if err != nil || !changed {
+		t.Fatalf("clearGoEnv = %q, %v, %v", restored, changed, err)
+	}
+	if !bytes.Equal(restored, initial) {
+		t.Fatalf("clearGoEnv = %q, want %q", restored, initial)
 	}
 }
 

--- a/internal/devicepolicy/go_env_writer_test.go
+++ b/internal/devicepolicy/go_env_writer_test.go
@@ -101,6 +101,17 @@ func TestGoEnvWriter_TransformsAndExactlyRestores(t *testing.T) {
 	}
 }
 
+func TestRewriteGoEnvPreservesManagedOnlyCRLF(t *testing.T) {
+	initial := []byte(dmgGoEnvBegin + "\r\n" + goEnvExpected + "\r\n" + goEnvEnd + "\r\n")
+	got, err := rewriteGoEnv(initial, goEnvExpected, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, initial) {
+		t.Fatalf("rewriteGoEnv = %q, want %q", got, initial)
+	}
+}
+
 func TestGoEnvWriter_CreatedFileIsRemovedOnClear(t *testing.T) {
 	w, _, path := newGoEnvTestWriter(t, nil)
 	if _, err := w.Write(goEnvExpected); err != nil {
@@ -316,7 +327,8 @@ func TestGoEnvWriter_ObservesExactMDMShapeWithoutWriting(t *testing.T) {
 }
 
 func TestGoUserEnvPath(t *testing.T) {
-	home := filepath.Join(string(filepath.Separator), "users", "alice")
+	home := t.TempDir()
+	externalRoot := t.TempDir()
 	cases := []struct {
 		name, goos, xdg, appdata, want string
 		wantErr                        bool
@@ -327,7 +339,7 @@ func TestGoUserEnvPath(t *testing.T) {
 		{"darwin", model.PlatformDarwin, "", "", filepath.Join(home, "Library", "Application Support", "go", "env"), false},
 		{"windows AppData", model.PlatformWindows, "", filepath.Join(home, "AppData", "Roaming"), filepath.Join(home, "AppData", "Roaming", "go", "env"), false},
 		{"windows AppData trailing separator", model.PlatformWindows, "", filepath.Join(home, "AppData", "Roaming") + string(filepath.Separator), filepath.Join(home, "AppData", "Roaming", "go", "env"), false},
-		{"external XDG", model.PlatformLinux, filepath.Join(string(filepath.Separator), "tmp", "xdg"), "", "", true},
+		{"external XDG", model.PlatformLinux, externalRoot, "", "", true},
 		{"normalized AppData", model.PlatformWindows, "", filepath.Join(home, "AppData", "..", "Roaming"), filepath.Join(home, "Roaming", "go", "env"), false},
 	}
 	for _, tc := range cases {

--- a/internal/devicepolicy/go_env_writer_test.go
+++ b/internal/devicepolicy/go_env_writer_test.go
@@ -314,6 +314,7 @@ func TestGoEnvWriter_ObservesExactMDMShapeWithoutWriting(t *testing.T) {
 		"GOPROXY=https://prior.example/go",
 		mdmGoEnvDisabledPrefix + "GOPROXY=https://proxy.golang.org",
 		mdmGoEnvBegin,
+		mdmGoEnvRestoreCRLF,
 		goEnvExpected,
 		goEnvEnd,
 		"GOPRIVATE=corp.example/*",
@@ -348,6 +349,31 @@ func TestGoEnvWriter_ObservesExactMDMShapeWithoutWriting(t *testing.T) {
 	observed, err = w.Observation(goEnvExpected, filepath.Join(w.home.Path(), ".netrc"))
 	if err != nil || observed.ConfigStatus != "mismatch" {
 		t.Fatalf("active line after MDM block = %#v, %v", observed, err)
+	}
+}
+
+func TestScanGoEnv_MDMRestoreCRLFMarker(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{"inside MDM block", mdmGoEnvBegin + "\n" + mdmGoEnvRestoreCRLF + "\n" + goEnvExpected + "\n" + goEnvEnd, false},
+		{"outside block", mdmGoEnvRestoreCRLF + "\n" + mdmGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd, true},
+		{"inside DMG block", dmgGoEnvBegin + "\n" + mdmGoEnvRestoreCRLF + "\n" + goEnvExpected + "\n" + goEnvEnd, true},
+		{"duplicated", mdmGoEnvBegin + "\n" + mdmGoEnvRestoreCRLF + "\n" + mdmGoEnvRestoreCRLF + "\n" + goEnvExpected + "\n" + goEnvEnd, true},
+		{"different value", mdmGoEnvBegin + "\n# [stepsecurity-go-env-mdm] restore-crlf=false\n" + goEnvExpected + "\n" + goEnvEnd, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			analysis, err := scanGoEnv([]byte(tc.content))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("scanGoEnv() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && (analysis.owner != "mdm" || !analysis.restoreCRLF) {
+				t.Fatalf("scanGoEnv() = %+v, want MDM CRLF restoration", analysis)
+			}
+		})
 	}
 }
 

--- a/internal/devicepolicy/go_env_writer_test.go
+++ b/internal/devicepolicy/go_env_writer_test.go
@@ -449,6 +449,10 @@ func (failingGoEnvExecutor) RunAsUser(context.Context, string, string) (string, 
 	return "", errors.New("environment capture failed")
 }
 
+type filesystemStatExecutor struct{ executor.Executor }
+
+func (filesystemStatExecutor) Stat(path string) (os.FileInfo, error) { return os.Stat(path) }
+
 func TestGoEnvObservationCaptureFailureIsUnknown(t *testing.T) {
 	if runtime.GOOS == model.PlatformWindows {
 		t.Skip("Windows environment capture is supplied directly by the executor")
@@ -502,9 +506,28 @@ func TestGoSiblingMarkerOnDarwinDoesNotRequireEnvironmentCapture(t *testing.T) {
 	home := newSecureTestHomeAs(t, homeDir, "alice")
 	inner := executor.NewMock()
 	inner.SetGOOS(model.PlatformDarwin)
+	inner.SetFile(path, content)
 	managed, err := hasGoDMGMarker(failingGoEnvExecutor{Executor: inner}, home)
 	if err != nil || !managed {
 		t.Fatalf("hasGoDMGMarker = %v, %v", managed, err)
+	}
+}
+
+func TestGoSiblingMarkerAbsentFileIgnoresUnusableParent(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(homeDir, ".config"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), filepath.Join(homeDir, ".config", "go")); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHomeAs(t, homeDir, "")
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformLinux)
+	mock.SetHomeDir(homeDir)
+	managed, err := hasGoDMGMarker(filesystemStatExecutor{Executor: mock}, home)
+	if err != nil || managed {
+		t.Fatalf("hasGoDMGMarker = %v, %v, want false, nil", managed, err)
 	}
 }
 

--- a/internal/devicepolicy/go_env_writer_test.go
+++ b/internal/devicepolicy/go_env_writer_test.go
@@ -101,7 +101,7 @@ func TestGoEnvWriter_TransformsAndExactlyRestores(t *testing.T) {
 	}
 }
 
-func TestRewriteGoEnvPreservesManagedOnlyCRLF(t *testing.T) {
+func TestRewriteGoEnv_PreservesManagedOnlyCRLF(t *testing.T) {
 	initial := []byte(dmgGoEnvBegin + "\r\n" + goEnvExpected + "\r\n" + goEnvEnd + "\r\n")
 	got, err := rewriteGoEnv(initial, goEnvExpected, false)
 	if err != nil {

--- a/internal/devicepolicy/go_env_writer_windows_test.go
+++ b/internal/devicepolicy/go_env_writer_windows_test.go
@@ -5,10 +5,14 @@ package devicepolicy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
+	osexec "os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
 	"github.com/step-security/dev-machine-guard/internal/model"
@@ -16,7 +20,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestGoEnvWriterWindowsACLCRLFAndRollback(t *testing.T) {
+func TestGoEnvWriter_WindowsNormalizesCRLFAndRollsBack(t *testing.T) {
 	homeDir := t.TempDir()
 	appData := filepath.Join(homeDir, "AppData", "Roaming")
 	path := filepath.Join(appData, "go", "env")
@@ -46,8 +50,8 @@ func TestGoEnvWriterWindowsACLCRLFAndRollback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Contains(bytes.ReplaceAll(content, []byte("\r\n"), nil), []byte("\n")) {
-		t.Fatalf("writer introduced LF into CRLF file: %q", content)
+	if bytes.Contains(content, []byte("\r")) || !bytes.Contains(content, []byte(dmgGoEnvRestoreCRLF)) {
+		t.Fatalf("writer did not normalize CRLF with restoration metadata: %q", content)
 	}
 	secure, err := w.file.MetadataSecure(secureuserfile.FileMode)
 	if err != nil || !secure {
@@ -69,11 +73,11 @@ func TestGoEnvWriterWindowsACLCRLFAndRollback(t *testing.T) {
 	}
 }
 
-func TestGoEnvWriterWindowsRepairsOnlyACLForCompliantContent(t *testing.T) {
+func TestGoEnvWriter_WindowsACLRepairPreservesCompliantBytes(t *testing.T) {
 	homeDir := t.TempDir()
 	appData := filepath.Join(homeDir, "AppData", "Roaming")
 	path := filepath.Join(appData, "go", "env")
-	initial := []byte(dmgGoEnvBegin + "\r\n" + goEnvExpected + "\r\n" + goEnvEnd + "\r\n")
+	initial := []byte(dmgGoEnvBegin + "\n" + goEnvExpected + "\n" + goEnvEnd + "\n")
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +138,116 @@ func weakenGoEnvTestACL(t *testing.T, path string) {
 	}
 }
 
-func TestGoCoordinatorWindowsMDMNilCredentialWriterReportsVerificationFailed(t *testing.T) {
+func TestGoEnvWriter_WindowsGoCommandReadsValuesWithoutCarriageReturns(t *testing.T) {
+	withTempCache(t)
+	homeDir := t.TempDir()
+	appData := filepath.Join(homeDir, "AppData", "Roaming")
+	path := filepath.Join(appData, "go", "env")
+	initial := []byte("# keep\r\n" +
+		"GOPROXY=https://proxy.golang.org,direct\r\n" +
+		"GOPRIVATE=corp.example/*\r\n" +
+		"GONOPROXY=noproxy.example/*\r\n" +
+		"GONOSUMDB=nosum.example/*\r\n" +
+		"GOSUMDB=sum.golang.org\r\n")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, initial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.HomeDir = homeDir
+	normalizeSecureTestUser(t, current)
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformWindows)
+	mock.SetUsername(current.Username)
+	mock.SetHomeDir(homeDir)
+	mock.SetEnv("APPDATA", appData)
+	userExec := &coordinatorUserExecutor{Mock: mock, user: current}
+	fetcher := &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:H", enforcementDMG)}
+	coordinator := &GoCoordinator{
+		Fetcher: fetcher, Reporter: &coordinatorReporter{}, Exec: userExec,
+		CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+	}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(first, []byte("\r")) {
+		t.Fatalf("enforced Go env contains carriage returns: %q", first)
+	}
+	firstInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := osexec.CommandContext(ctx, "go", "env", "-json", "GOPROXY", "GOPRIVATE", "GONOPROXY", "GONOSUMDB", "GOSUMDB")
+	blocked := map[string]bool{
+		"GOENV": true, "GOPROXY": true, "GOPRIVATE": true, "GONOPROXY": true, "GONOSUMDB": true, "GOSUMDB": true,
+	}
+	for _, value := range os.Environ() {
+		key, _, _ := strings.Cut(value, "=")
+		if !blocked[strings.ToUpper(key)] {
+			cmd.Env = append(cmd.Env, value)
+		}
+	}
+	cmd.Env = append(cmd.Env, "GOENV="+path)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go env: %v", err)
+	}
+	var values map[string]string
+	if err := json.Unmarshal(out, &values); err != nil {
+		t.Fatalf("decode go env output: %v", err)
+	}
+	want := map[string]string{
+		"GOPROXY":   goTestPolicy(t).RegistryURL,
+		"GOPRIVATE": "corp.example/*", "GONOPROXY": "noproxy.example/*",
+		"GONOSUMDB": "nosum.example/*", "GOSUMDB": "sum.golang.org",
+	}
+	for key, expected := range want {
+		if values[key] != expected || strings.Contains(values[key], "\r") {
+			t.Errorf("go env %s = %q, want %q without carriage return", key, values[key], expected)
+		}
+	}
+
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(second, first) || !os.SameFile(firstInfo, secondInfo) || !secondInfo.ModTime().Equal(firstInfo.ModTime()) {
+		t.Fatal("repeated enforcement rewrote the converged Go env file")
+	}
+
+	fetcher.policy = EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(restored, initial) {
+		t.Fatalf("clear restored %q, want %q", restored, initial)
+	}
+}
+
+func TestGoCoordinator_WindowsMDMNilCredentialWriterReportsVerificationFailed(t *testing.T) {
 	homeDir := t.TempDir()
 	if err := os.Mkdir(filepath.Join(homeDir, ".netrc"), 0o700); err != nil {
 		t.Fatal(err)

--- a/internal/devicepolicy/go_env_writer_windows_test.go
+++ b/internal/devicepolicy/go_env_writer_windows_test.go
@@ -247,7 +247,7 @@ func TestGoEnvWriter_WindowsGoCommandReadsValuesWithoutCarriageReturns(t *testin
 	}
 }
 
-func TestGoCoordinator_WindowsClearWithoutCredentialStateRetainsSharedCredential(t *testing.T) {
+func TestGoCoordinator_WindowsClearWithoutCredentialStatePreservesPyPICredential(t *testing.T) {
 	withTempCache(t)
 	homeDir := t.TempDir()
 	appData := filepath.Join(homeDir, "AppData", "Roaming")
@@ -289,13 +289,13 @@ func TestGoCoordinator_WindowsClearWithoutCredentialStateRetainsSharedCredential
 	if err := goCoordinator.Reconcile(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	dot, err := os.ReadFile(dotPath)
-	if err != nil || !bytes.Equal(dot, dotInitial) {
-		t.Fatalf(".netrc = %q, %v, want unchanged %q", dot, err, dotInitial)
+	managedDot, err := os.ReadFile(dotPath)
+	if err != nil || !bytes.Contains(managedDot, []byte(dmgNetrcBegin)) {
+		t.Fatalf("managed .netrc = %q, %v", managedDot, err)
 	}
-	managed, err := os.ReadFile(underscorePath)
-	if err != nil || !bytes.Contains(managed, []byte(dmgNetrcBegin)) {
-		t.Fatalf("managed _netrc = %q, %v", managed, err)
+	managedUnderscore, err := os.ReadFile(underscorePath)
+	if err != nil || !bytes.Contains(managedUnderscore, []byte(dmgNetrcBegin)) {
+		t.Fatalf("managed _netrc = %q, %v", managedUnderscore, err)
 	}
 	if err := ClearAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget); err != nil {
 		t.Fatal(err)
@@ -306,12 +306,12 @@ func TestGoCoordinator_WindowsClearWithoutCredentialStateRetainsSharedCredential
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(underscorePath)
-	if err != nil || !bytes.Equal(got, managed) {
-		t.Fatalf("shared _netrc changed: %q, %v", got, err)
+	if err != nil || !bytes.Equal(got, underscoreInitial) {
+		t.Fatalf("_netrc = %q, %v, want restored %q", got, err, underscoreInitial)
 	}
-	dot, err = os.ReadFile(dotPath)
-	if err != nil || !bytes.Equal(dot, dotInitial) {
-		t.Fatalf(".netrc changed: %q, %v", dot, err)
+	dot, err := os.ReadFile(dotPath)
+	if err != nil || !bytes.Equal(dot, managedDot) {
+		t.Fatalf("PyPI .netrc changed: %q, %v", dot, err)
 	}
 	if _, err := os.Stat(filepath.Join(appData, "go", "env")); !os.IsNotExist(err) {
 		t.Fatalf("Go env remains after clear: %v", err)

--- a/internal/devicepolicy/go_env_writer_windows_test.go
+++ b/internal/devicepolicy/go_env_writer_windows_test.go
@@ -247,6 +247,83 @@ func TestGoEnvWriter_WindowsGoCommandReadsValuesWithoutCarriageReturns(t *testin
 	}
 }
 
+func TestGoCoordinator_WindowsClearWithoutCredentialStateRestoresDualFiles(t *testing.T) {
+	withTempCache(t)
+	homeDir := t.TempDir()
+	appData := filepath.Join(homeDir, "AppData", "Roaming")
+	dotPath := filepath.Join(homeDir, ".netrc")
+	underscorePath := filepath.Join(homeDir, "_netrc")
+	dotInitial := []byte("machine dot.example login user password keep\r\n")
+	underscoreInitial := []byte("machine underscore.example login user password keep\r\n")
+	if err := os.WriteFile(dotPath, dotInitial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(underscorePath, underscoreInitial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	current, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.HomeDir = homeDir
+	normalizeSecureTestUser(t, current)
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformWindows)
+	mock.SetUsername(current.Username)
+	mock.SetHomeDir(homeDir)
+	mock.SetEnv("APPDATA", appData)
+	exec := &coordinatorUserExecutor{Mock: mock, user: current}
+	pypi := &PyPICoordinator{
+		Fetcher: &coordinatorFetcher{policy: coordinatorPolicy(`["pip"]`, "sha256:P", enforcementDMG)}, Reporter: &coordinatorReporter{},
+		Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+	}
+	goFetcher := &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:G", enforcementDMG)}
+	goCoordinator := &GoCoordinator{
+		Fetcher: goFetcher, Reporter: &coordinatorReporter{}, Exec: exec,
+		CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+	}
+	if err := pypi.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := goCoordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{dotPath, underscorePath} {
+		data, err := os.ReadFile(path)
+		if err != nil || !bytes.Contains(data, []byte(dmgNetrcBegin)) {
+			t.Fatalf("managed credential %s = %q, %v", path, data, err)
+		}
+	}
+	if err := ClearAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget); err != nil {
+		t.Fatal(err)
+	}
+
+	goFetcher.policy = EffectivePolicy{Category: CategoryPackageConfig, Target: TargetGo, Clear: true}
+	if err := goCoordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(underscorePath)
+	if err != nil || !bytes.Equal(got, underscoreInitial) {
+		t.Fatalf("restored _netrc = %q, %v, want %q", got, err, underscoreInitial)
+	}
+	dot, err := os.ReadFile(dotPath)
+	if err != nil || !bytes.Contains(dot, []byte(dmgNetrcBegin)) {
+		t.Fatalf("PyPI credential changed: %q, %v", dot, err)
+	}
+	if _, err := os.Stat(filepath.Join(appData, "go", "env")); !os.IsNotExist(err) {
+		t.Fatalf("Go env remains after clear: %v", err)
+	}
+	for _, target := range []string{GoCredentialOwnershipTarget, GoEnvOwnershipTarget} {
+		if _, ok := ReadAppliedState(CategoryPackageConfig, target); ok {
+			t.Fatalf("clear retained %s state", target)
+		}
+	}
+	if _, ok := ReadAppliedState(CategoryPackageConfig, PyPICredentialOwnershipTarget); !ok {
+		t.Fatal("clear removed PyPI credential state")
+	}
+}
+
 func TestGoCoordinator_WindowsMDMNilCredentialWriterReportsVerificationFailed(t *testing.T) {
 	homeDir := t.TempDir()
 	if err := os.Mkdir(filepath.Join(homeDir, ".netrc"), 0o700); err != nil {

--- a/internal/devicepolicy/go_env_writer_windows_test.go
+++ b/internal/devicepolicy/go_env_writer_windows_test.go
@@ -1,0 +1,188 @@
+//go:build windows
+
+package devicepolicy
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/model"
+	"github.com/step-security/dev-machine-guard/internal/secureuserfile"
+	"golang.org/x/sys/windows"
+)
+
+func TestGoEnvWriterWindowsACLCRLFAndRollback(t *testing.T) {
+	homeDir := t.TempDir()
+	appData := filepath.Join(homeDir, "AppData", "Roaming")
+	path := filepath.Join(appData, "go", "env")
+	initial := []byte("# keep\r\nGOPROXY=https://proxy.golang.org\r\nGOPRIVATE=corp.example/*\r\n")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, initial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHome(t, homeDir)
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformWindows)
+	mock.SetEnv("APPDATA", appData)
+	w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	weakenGoEnvTestACL(t, path)
+	if secure, err := w.file.MetadataSecure(secureuserfile.FileMode); err != nil || secure {
+		t.Fatalf("fixture metadata = %v, %v, want insecure", secure, err)
+	}
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(bytes.ReplaceAll(content, []byte("\r\n"), nil), []byte("\n")) {
+		t.Fatalf("writer introduced LF into CRLF file: %q", content)
+	}
+	secure, err := w.file.MetadataSecure(secureuserfile.FileMode)
+	if err != nil || !secure {
+		t.Fatalf("secure metadata = %v, %v", secure, err)
+	}
+	if err := w.RestoreSnapshot(); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(restored, initial) {
+		t.Fatalf("rollback restored %q, want %q", restored, initial)
+	}
+	secure, err = w.file.MetadataSecure(secureuserfile.FileMode)
+	if err != nil || !secure {
+		t.Fatalf("rollback metadata = %v, %v", secure, err)
+	}
+}
+
+func TestGoEnvWriterWindowsRepairsOnlyACLForCompliantContent(t *testing.T) {
+	homeDir := t.TempDir()
+	appData := filepath.Join(homeDir, "AppData", "Roaming")
+	path := filepath.Join(appData, "go", "env")
+	initial := []byte(dmgGoEnvBegin + "\r\n" + goEnvExpected + "\r\n" + goEnvEnd + "\r\n")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, initial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHome(t, homeDir)
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformWindows)
+	mock.SetEnv("APPDATA", appData)
+	w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	weakenGoEnvTestACL(t, path)
+	if secure, err := w.file.MetadataSecure(secureuserfile.FileMode); err != nil || secure {
+		t.Fatalf("fixture metadata = %v, %v, want insecure", secure, err)
+	}
+
+	if _, err := w.Write(goEnvExpected); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, initial) {
+		t.Fatalf("ACL repair changed content: %q", content)
+	}
+	if secure, err := w.file.MetadataSecure(secureuserfile.FileMode); err != nil || !secure {
+		t.Fatalf("secure metadata = %v, %v", secure, err)
+	}
+}
+
+func weakenGoEnvTestACL(t *testing.T, path string) {
+	t.Helper()
+	descriptor, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetSID, _, err := descriptor.Owner()
+	if err != nil || targetSID == nil {
+		t.Fatalf("target owner: %v", err)
+	}
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		goEnvTestExplicitAccess(targetSID, windows.GENERIC_READ, windows.TRUSTEE_IS_USER),
+		goEnvTestExplicitAccess(systemSID, windows.GENERIC_READ, windows.TRUSTEE_IS_WELL_KNOWN_GROUP),
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGoCoordinatorWindowsMDMNilCredentialWriterReportsVerificationFailed(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(homeDir, ".netrc"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	appData := filepath.Join(homeDir, "AppData", "Roaming")
+	home := newSecureTestHome(t, homeDir)
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformWindows)
+	mock.SetEnv("APPDATA", appData)
+	w, err := NewGoEnvWriter(mock, home, goTestPolicy(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mdm := []byte(mdmGoEnvBegin + "\r\n" + goEnvExpected + "\r\n" + goEnvEnd + "\r\n")
+	if err := w.file.Commit(mdm, secureuserfile.FileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	current, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.HomeDir = homeDir
+	normalizeSecureTestUser(t, current)
+	mock.SetHomeDir(homeDir)
+	exec := &coordinatorUserExecutor{Mock: mock, user: current}
+	reporter := &coordinatorReporter{}
+	coordinator := &GoCoordinator{
+		Fetcher: &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:H", enforcementMDM)}, Reporter: reporter,
+		Exec: exec, CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+	}
+	if err := coordinator.Reconcile(context.Background()); err == nil {
+		t.Fatal("Reconcile error = nil")
+	}
+	if len(reporter.reports) != 1 || reporter.reports[0].State != StateVerificationFailed {
+		t.Fatalf("reports = %+v", reporter.reports)
+	}
+}
+
+func goEnvTestExplicitAccess(sid *windows.SID, permissions windows.ACCESS_MASK, trusteeType windows.TRUSTEE_TYPE) windows.EXPLICIT_ACCESS {
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: permissions,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  trusteeType,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}

--- a/internal/devicepolicy/go_env_writer_windows_test.go
+++ b/internal/devicepolicy/go_env_writer_windows_test.go
@@ -247,7 +247,7 @@ func TestGoEnvWriter_WindowsGoCommandReadsValuesWithoutCarriageReturns(t *testin
 	}
 }
 
-func TestGoCoordinator_WindowsClearWithoutCredentialStateRestoresDualFiles(t *testing.T) {
+func TestGoCoordinator_WindowsClearWithoutCredentialStateRetainsSharedCredential(t *testing.T) {
 	withTempCache(t)
 	homeDir := t.TempDir()
 	appData := filepath.Join(homeDir, "AppData", "Roaming")
@@ -289,11 +289,13 @@ func TestGoCoordinator_WindowsClearWithoutCredentialStateRestoresDualFiles(t *te
 	if err := goCoordinator.Reconcile(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	for _, path := range []string{dotPath, underscorePath} {
-		data, err := os.ReadFile(path)
-		if err != nil || !bytes.Contains(data, []byte(dmgNetrcBegin)) {
-			t.Fatalf("managed credential %s = %q, %v", path, data, err)
-		}
+	dot, err := os.ReadFile(dotPath)
+	if err != nil || !bytes.Equal(dot, dotInitial) {
+		t.Fatalf(".netrc = %q, %v, want unchanged %q", dot, err, dotInitial)
+	}
+	managed, err := os.ReadFile(underscorePath)
+	if err != nil || !bytes.Contains(managed, []byte(dmgNetrcBegin)) {
+		t.Fatalf("managed _netrc = %q, %v", managed, err)
 	}
 	if err := ClearAppliedState(CategoryPackageConfig, GoCredentialOwnershipTarget); err != nil {
 		t.Fatal(err)
@@ -304,12 +306,12 @@ func TestGoCoordinator_WindowsClearWithoutCredentialStateRestoresDualFiles(t *te
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(underscorePath)
-	if err != nil || !bytes.Equal(got, underscoreInitial) {
-		t.Fatalf("restored _netrc = %q, %v, want %q", got, err, underscoreInitial)
+	if err != nil || !bytes.Equal(got, managed) {
+		t.Fatalf("shared _netrc changed: %q, %v", got, err)
 	}
-	dot, err := os.ReadFile(dotPath)
-	if err != nil || !bytes.Contains(dot, []byte(dmgNetrcBegin)) {
-		t.Fatalf("PyPI credential changed: %q, %v", dot, err)
+	dot, err = os.ReadFile(dotPath)
+	if err != nil || !bytes.Equal(dot, dotInitial) {
+		t.Fatalf(".netrc changed: %q, %v", dot, err)
 	}
 	if _, err := os.Stat(filepath.Join(appData, "go", "env")); !os.IsNotExist(err) {
 		t.Fatalf("Go env remains after clear: %v", err)

--- a/internal/devicepolicy/go_env_writer_windows_test.go
+++ b/internal/devicepolicy/go_env_writer_windows_test.go
@@ -149,6 +149,9 @@ func TestGoCoordinatorWindowsMDMNilCredentialWriterReportsVerificationFailed(t *
 		t.Fatal(err)
 	}
 	mdm := []byte(mdmGoEnvBegin + "\r\n" + goEnvExpected + "\r\n" + goEnvEnd + "\r\n")
+	if err := home.EnsureParent(w.file.RelativePath()); err != nil {
+		t.Fatal(err)
+	}
 	if err := w.file.Commit(mdm, secureuserfile.FileMode); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/devicepolicy/go_policy.go
+++ b/internal/devicepolicy/go_policy.go
@@ -1,0 +1,106 @@
+package devicepolicy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+)
+
+const goAuthScheme = pypiAuthScheme
+
+// GoPolicy is the compiled package_config/go policy delivered to this device.
+type GoPolicy struct {
+	Ecosystem   string `json:"ecosystem"`
+	RegistryURL string `json:"registry_url"`
+	Auth        struct {
+		Scheme string `json:"scheme"`
+		APIKey string `json:"api_key"`
+	} `json:"auth"`
+
+	deviceID string
+}
+
+// GoObserved is the strict, secret-free package_config/go report body.
+type GoObserved struct {
+	Ecosystem       string `json:"ecosystem"`
+	RegistryURL     string `json:"registry_url"`
+	AuthTokenStatus string `json:"auth_token_status"`
+	ConfigStatus    string `json:"config_status"`
+	EffectiveStatus string `json:"effective_status"`
+	OverrideSource  string `json:"override_source"`
+}
+
+// ParseGoPolicy strictly validates one compiled package_config/go policy.
+func ParseGoPolicy(raw json.RawMessage, deviceID string) (GoPolicy, error) {
+	var policy GoPolicy
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&policy); err != nil {
+		return GoPolicy{}, errors.New("go: policy is not a well-formed policy object")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return GoPolicy{}, errors.New("go: policy has trailing data")
+	}
+	if err := rejectDuplicateJSONKeys(raw); err != nil {
+		return GoPolicy{}, errors.New("go: policy contains duplicate JSON keys")
+	}
+	if policy.Ecosystem != "go" {
+		return GoPolicy{}, errors.New("go: policy ecosystem is not go")
+	}
+	if policy.Auth.Scheme != goAuthScheme {
+		return GoPolicy{}, errors.New("go: unsupported auth scheme")
+	}
+	if err := validateGoCredentialPart("api_key", policy.Auth.APIKey, npmrcMaxKeyBytes); err != nil {
+		return GoPolicy{}, err
+	}
+	if strings.Contains(policy.Auth.APIKey, "::") {
+		return GoPolicy{}, errors.New("go: policy api_key already contains a source suffix")
+	}
+	if err := validateGoCredentialPart("device_id", deviceID, npmrcMaxSerialBytes); err != nil {
+		return GoPolicy{}, err
+	}
+	if strings.ContainsAny(policy.RegistryURL, ",|") {
+		return GoPolicy{}, errors.New("go: policy registry_url must not contain fallback delimiters")
+	}
+	u, err := parsePyPIRegistryURL(policy.RegistryURL)
+	if err != nil {
+		return GoPolicy{}, fmt.Errorf("go: policy %w", err)
+	}
+	switch u.EscapedPath() {
+	case "/go":
+	case "/go/":
+		policy.RegistryURL = strings.TrimSuffix(policy.RegistryURL, "/")
+	default:
+		return GoPolicy{}, errors.New("go: policy registry_url path must be /go")
+	}
+	policy.deviceID = deviceID
+	return policy, nil
+}
+
+func validateGoCredentialPart(name, value string, maxBytes int) error {
+	if value == "" || strings.TrimSpace(value) == "" {
+		return fmt.Errorf("go: policy %s is empty", name)
+	}
+	if len(value) > maxBytes {
+		return fmt.Errorf("go: policy %s too long", name)
+	}
+	if !isNPMSafe(value) {
+		return fmt.Errorf("go: policy %s contains unsupported characters", name)
+	}
+	return nil
+}
+
+func (p GoPolicy) RegistryHost() string {
+	u, err := url.Parse(p.RegistryURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+func (p GoPolicy) DeviceToken() string { return p.Auth.APIKey + "::dev:" + p.deviceID }

--- a/internal/devicepolicy/go_policy_test.go
+++ b/internal/devicepolicy/go_policy_test.go
@@ -1,0 +1,70 @@
+package devicepolicy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validGoPolicyJSON() json.RawMessage {
+	return json.RawMessage(`{"ecosystem":"go","registry_url":"https://registry.stepsecurity.io/go","auth":{"scheme":"stepsecurity_device_token","api_key":"tenant-key"}}`)
+}
+
+func TestParseGoPolicy(t *testing.T) {
+	policy, err := ParseGoPolicy(validGoPolicyJSON(), "device-1")
+	if err != nil {
+		t.Fatalf("ParseGoPolicy: %v", err)
+	}
+	if policy.RegistryURL != "https://registry.stepsecurity.io/go" || policy.RegistryHost() != "registry.stepsecurity.io" {
+		t.Fatalf("unexpected registry: %#v", policy)
+	}
+	if got := policy.DeviceToken(); got != "tenant-key::dev:device-1" {
+		t.Fatalf("DeviceToken() = %q", got)
+	}
+
+	withSlash := json.RawMessage(`{"ecosystem":"go","registry_url":"https://registry.stepsecurity.io/go/","auth":{"scheme":"stepsecurity_device_token","api_key":"tenant-key"}}`)
+	policy, err = ParseGoPolicy(withSlash, "device-1")
+	if err != nil || policy.RegistryURL != "https://registry.stepsecurity.io/go" {
+		t.Fatalf("trailing slash normalization: policy=%#v err=%v", policy, err)
+	}
+}
+
+func TestParseGoPolicyRejectsInvalidContract(t *testing.T) {
+	valid := string(validGoPolicyJSON())
+	cases := map[string]string{
+		"wrong ecosystem":        strings.Replace(valid, `"go"`, `"pypi"`, 1),
+		"unknown field":          strings.Replace(valid, `"ecosystem"`, `"extra":true,"ecosystem"`, 1),
+		"duplicate field":        strings.Replace(valid, `"ecosystem":"go"`, `"ecosystem":"go","ecosystem":"go"`, 1),
+		"trailing data":          valid + `{}`,
+		"wrong auth scheme":      strings.Replace(valid, "stepsecurity_device_token", "basic", 1),
+		"empty key":              strings.Replace(valid, "tenant-key", "", 1),
+		"suffixed key":           strings.Replace(valid, "tenant-key", "tenant-key::dev:old", 1),
+		"unsafe key":             strings.Replace(valid, "tenant-key", "tenant key", 1),
+		"wrong path":             strings.Replace(valid, "/go", "/javascript", 1),
+		"double trailing slash":  strings.Replace(valid, "/go", "/go//", 1),
+		"http":                   strings.Replace(valid, "https://", "http://", 1),
+		"uppercase host":         strings.Replace(valid, "registry.stepsecurity.io", "Registry.stepsecurity.io", 1),
+		"port":                   strings.Replace(valid, ".io/go", ".io:443/go", 1),
+		"userinfo":               strings.Replace(valid, "https://", "https://user@", 1),
+		"query":                  strings.Replace(valid, "/go", "/go?q=1", 1),
+		"fragment":               strings.Replace(valid, "/go", "/go#x", 1),
+		"comma fallback":         strings.Replace(valid, "/go", "/go,direct", 1),
+		"pipe fallback":          strings.Replace(valid, "/go", "/go|direct", 1),
+		"wrong registry type":    strings.Replace(valid, `"registry_url":"https://registry.stepsecurity.io/go"`, `"registry_url":7`, 1),
+		"wrong auth object type": strings.Replace(valid, `"auth":{"scheme":"stepsecurity_device_token","api_key":"tenant-key"}`, `"auth":null`, 1),
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseGoPolicy(json.RawMessage(raw), "device-1"); err == nil {
+				t.Fatal("ParseGoPolicy() error = nil")
+			}
+		})
+	}
+	for name, deviceID := range map[string]string{"empty": "", "unsafe": "device id", "oversized": strings.Repeat("x", npmrcMaxSerialBytes+1)} {
+		t.Run("device "+name, func(t *testing.T) {
+			if _, err := ParseGoPolicy(validGoPolicyJSON(), deviceID); err == nil {
+				t.Fatal("ParseGoPolicy() error = nil")
+			}
+		})
+	}
+}

--- a/internal/devicepolicy/netrc_writer.go
+++ b/internal/devicepolicy/netrc_writer.go
@@ -78,15 +78,14 @@ func newNetrcWriter(home *secureuserfile.Home, host, token string) (*NetrcWriter
 	if err != nil {
 		return nil, err
 	}
-	_, primaryExists, _, err := primary.Read()
-	if err != nil {
+	if _, _, _, err := primary.Read(); err != nil {
 		return nil, err
 	}
 	_, alternateExists, _, err := alternate.Read()
 	if err != nil {
 		return nil, err
 	}
-	if !primaryExists && alternateExists {
+	if alternateExists {
 		w.file, w.alternate = alternate, primary
 	} else {
 		w.alternate = alternate

--- a/internal/devicepolicy/netrc_writer.go
+++ b/internal/devicepolicy/netrc_writer.go
@@ -14,15 +14,15 @@ import (
 )
 
 const (
-	dmgNetrcBegin = "#stepsecurity-package-registry-credential-dmg-begin"
-	dmgNetrcEnd   = "#stepsecurity-package-registry-credential-end"
+	dmgNetrcBegin = "#stepsecurity-secure-registry-credential-dmg-begin"
+	dmgNetrcEnd   = "#stepsecurity-secure-registry-credential-end"
 
-	mdmNetrcBegin = "#stepsecurity-package-registry-credential-mdm-begin"
-	mdmNetrcEnd   = "#stepsecurity-package-registry-credential-end"
+	mdmNetrcBegin = "#stepsecurity-secure-registry-credential-mdm-begin"
+	mdmNetrcEnd   = "#stepsecurity-secure-registry-credential-end"
 
-	dmgNetrcDisabledPrefix = "#stepsecurity-package-registry-credential-dmg-disabled:"
-	mdmNetrcDisabledPrefix = "#stepsecurity-package-registry-credential-mdm-disabled:"
-	mdmNetrcCreated        = "#stepsecurity-package-registry-credential-mdm-created"
+	dmgNetrcDisabledPrefix = "#stepsecurity-secure-registry-credential-dmg-disabled:"
+	mdmNetrcDisabledPrefix = "#stepsecurity-secure-registry-credential-mdm-disabled:"
+	mdmNetrcCreated        = "#stepsecurity-secure-registry-credential-mdm-created"
 	netrcBackupPrefix      = ".dmg-"
 )
 

--- a/internal/devicepolicy/netrc_writer.go
+++ b/internal/devicepolicy/netrc_writer.go
@@ -99,7 +99,14 @@ func newGoNetrcWriter(home *secureuserfile.Home, host, token string) (*NetrcWrit
 	if err != nil || home.GOOS() != model.PlatformWindows {
 		return w, err
 	}
-	if filepath.Base(w.file.Location()) != "_netrc" {
+	if filepath.Base(w.file.Location()) == "_netrc" {
+		return w, nil
+	}
+	_, underscoreExists, _, err := w.alternate.Read()
+	if err != nil {
+		return nil, err
+	}
+	if underscoreExists {
 		w.file, w.alternate = w.alternate, w.file
 	}
 	return w, nil
@@ -287,17 +294,18 @@ func discoverDMGNetrcHost(home *secureuserfile.Home) (string, error) {
 		if markers.dmg == nil {
 			continue
 		}
-		if host != "" {
-			return "", fmt.Errorf("netrc: multiple managed credential files: %w", ErrTargetUnusable)
-		}
 		entries, err := parseNetrc([]byte(markers.dmg.body))
 		if err != nil || len(entries) != 1 || entries[0].isDefault || !isValidHost(entries[0].host) {
 			return "", fmt.Errorf("netrc: cannot derive a trusted managed host: %w", ErrTargetUnusable)
 		}
-		host = entries[0].host
-		if _, err := analyzeNetrc(data, host); err != nil {
+		managedHost := entries[0].host
+		if host != "" && (home.GOOS() != model.PlatformWindows || host != managedHost) {
+			return "", fmt.Errorf("netrc: conflicting managed credential files: %w", ErrTargetUnusable)
+		}
+		if _, err := analyzeNetrc(data, managedHost); err != nil {
 			return "", err
 		}
+		host = managedHost
 	}
 	if host == "" {
 		return "", fmt.Errorf("netrc: no trusted managed host: %w", ErrTargetUnusable)

--- a/internal/devicepolicy/netrc_writer.go
+++ b/internal/devicepolicy/netrc_writer.go
@@ -81,15 +81,10 @@ func newNetrcWriter(home *secureuserfile.Home, host, token string) (*NetrcWriter
 	if _, _, _, err := primary.Read(); err != nil {
 		return nil, err
 	}
-	_, alternateExists, _, err := alternate.Read()
-	if err != nil {
+	if _, _, _, err := alternate.Read(); err != nil {
 		return nil, err
 	}
-	if alternateExists {
-		w.file, w.alternate = alternate, primary
-	} else {
-		w.alternate = alternate
-	}
+	w.alternate = alternate
 	return w, nil
 }
 
@@ -97,9 +92,6 @@ func newGoNetrcWriter(home *secureuserfile.Home, host, token string) (*NetrcWrit
 	w, err := newNetrcWriter(home, host, token)
 	if err != nil || home.GOOS() != model.PlatformWindows {
 		return w, err
-	}
-	if filepath.Base(w.file.Location()) == "_netrc" {
-		return w, nil
 	}
 	_, underscoreExists, _, err := w.alternate.Read()
 	if err != nil {
@@ -440,26 +432,11 @@ func (w *NetrcWriter) MDMOwned() (bool, error) {
 }
 
 func (w *NetrcWriter) HasMDMMarker() (bool, error) {
-	for _, file := range []*secureuserfile.File{w.file, w.alternate} {
-		if file == nil {
-			continue
-		}
-		data, existed, _, err := file.Read()
-		if err != nil {
-			return false, err
-		}
-		if !existed {
-			continue
-		}
-		analysis, err := analyzeNetrc(data, w.host)
-		if err != nil {
-			return false, err
-		}
-		if analysis.markers.mdm {
-			return true, nil
-		}
+	analysis, err := w.readSelected()
+	if err != nil || !analysis.existed {
+		return false, err
 	}
-	return false, nil
+	return analysis.markers.mdm, nil
 }
 
 // ValidateEffectivePath fails closed when NETRC redirects credential lookup
@@ -495,8 +472,12 @@ func (w *NetrcWriter) checkAlternateConflict() error {
 		return err
 	}
 	exact := exactHostEntries(analysis.entries, w.host)
-	if analysis.markers.dmg != nil {
-		managed, err := parseNetrc([]byte(analysis.markers.dmg.body))
+	managedBlock := analysis.markers.dmg
+	if managedBlock == nil {
+		managedBlock = analysis.markers.mdmBlock
+	}
+	if managedBlock != nil {
+		managed, err := parseNetrc([]byte(managedBlock.body))
 		if err == nil && len(exactHostEntries(managed, w.host)) == 1 && len(exact) == 1 {
 			return nil
 		}

--- a/internal/devicepolicy/netrc_writer.go
+++ b/internal/devicepolicy/netrc_writer.go
@@ -94,6 +94,17 @@ func newNetrcWriter(home *secureuserfile.Home, host, token string) (*NetrcWriter
 	return w, nil
 }
 
+func newGoNetrcWriter(home *secureuserfile.Home, host, token string) (*NetrcWriter, error) {
+	w, err := newNetrcWriter(home, host, token)
+	if err != nil || home.GOOS() != model.PlatformWindows {
+		return w, err
+	}
+	if filepath.Base(w.file.Location()) != "_netrc" {
+		w.file, w.alternate = w.alternate, w.file
+	}
+	return w, nil
+}
+
 func renderNetrcEntry(host, token string) string {
 	return "machine " + host + "\nlogin step-security\npassword " + token
 }

--- a/internal/devicepolicy/netrc_writer.go
+++ b/internal/devicepolicy/netrc_writer.go
@@ -14,15 +14,15 @@ import (
 )
 
 const (
-	dmgNetrcBegin = "#stepsecurity-pypi-credential-dmg-begin"
-	dmgNetrcEnd   = "#stepsecurity-pypi-credential-end"
+	dmgNetrcBegin = "#stepsecurity-package-registry-credential-dmg-begin"
+	dmgNetrcEnd   = "#stepsecurity-package-registry-credential-end"
 
-	mdmNetrcBegin = "#stepsecurity-pypi-credential-mdm-begin"
-	mdmNetrcEnd   = "#stepsecurity-pypi-credential-end"
+	mdmNetrcBegin = "#stepsecurity-package-registry-credential-mdm-begin"
+	mdmNetrcEnd   = "#stepsecurity-package-registry-credential-end"
 
-	dmgNetrcDisabledPrefix = "#stepsecurity-pypi-credential-dmg-disabled:"
-	mdmNetrcDisabledPrefix = "#stepsecurity-pypi-credential-mdm-disabled:"
-	mdmNetrcCreated        = "#stepsecurity-pypi-credential-mdm-created"
+	dmgNetrcDisabledPrefix = "#stepsecurity-package-registry-credential-dmg-disabled:"
+	mdmNetrcDisabledPrefix = "#stepsecurity-package-registry-credential-mdm-disabled:"
+	mdmNetrcCreated        = "#stepsecurity-package-registry-credential-mdm-created"
 	netrcBackupPrefix      = ".dmg-"
 )
 
@@ -50,6 +50,18 @@ func NewNetrcWriter(home *secureuserfile.Home, policy PyPIPolicy) (*NetrcWriter,
 		strings.Contains(policy.Auth.APIKey, "::") || !isNPMSafe(policy.Auth.APIKey) || !isNPMSafe(policy.deviceID) ||
 		!isValidHost(host) || !isNetrcCredential(token) {
 		return nil, errors.New("netrc: policy cannot render a safe credential entry")
+	}
+	return newNetrcWriter(home, host, token)
+}
+
+// newNetrcWriter builds the shared exact-host credential writer after the
+// ecosystem-specific policy parser has validated and derived its inputs.
+func newNetrcWriter(home *secureuserfile.Home, host, token string) (*NetrcWriter, error) {
+	if home == nil {
+		return nil, errors.New("netrc: nil secure user home")
+	}
+	if !isValidHost(host) || !isNetrcCredential(token) {
+		return nil, errors.New("netrc: cannot render a safe credential entry")
 	}
 	expected := renderNetrcEntry(host, token)
 
@@ -416,11 +428,7 @@ func (w *NetrcWriter) ValidateEffectivePath() error {
 		return nil
 	}
 	if !filepath.IsAbs(override) {
-		absolute, err := filepath.Abs(override)
-		if err != nil {
-			return fmt.Errorf("netrc: resolve NETRC override: %w", ErrTargetUnusable)
-		}
-		override = absolute
+		return fmt.Errorf("netrc: NETRC override must be absolute: %w", ErrTargetUnusable)
 	}
 	override, managed := filepath.Clean(override), filepath.Clean(w.Location())
 	if override != managed && (w.goos != model.PlatformWindows || !strings.EqualFold(override, managed)) {

--- a/internal/devicepolicy/netrc_writer.go
+++ b/internal/devicepolicy/netrc_writer.go
@@ -215,17 +215,16 @@ func (w *NetrcWriter) Clear() (bool, error) {
 			if err != nil || len(exactHostEntries(entries, w.host)) != 1 {
 				return false, fmt.Errorf("netrc: managed credential host conflicts with ownership state: %w", ErrTargetUnusable)
 			}
-			if owned >= 0 {
-				return false, fmt.Errorf("netrc: multiple managed credential files: %w", ErrTargetUnusable)
+			if owned < 0 || file == w.file {
+				owned = len(candidates) - 1
 			}
-			owned = len(candidates) - 1
 		} else if analysis.markers.mdm || len(exactHostEntries(analysis.entries, w.host)) != 0 {
 			conflict = true
 		}
 	}
 	if owned >= 0 {
 		for i, candidate := range candidates {
-			if i != owned && (candidate.analysis.markers.dmg != nil || candidate.analysis.markers.mdm || len(exactHostEntries(candidate.analysis.entries, w.host)) != 0) {
+			if i != owned && (candidate.analysis.markers.mdm || candidate.analysis.markers.dmg == nil && len(exactHostEntries(candidate.analysis.entries, w.host)) != 0) {
 				return false, fmt.Errorf("netrc: alternate credential file conflicts with managed file: %w", ErrTargetUnusable)
 			}
 		}
@@ -324,6 +323,34 @@ func hasManagedNetrcMarker(home *secureuserfile.Home) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func hasSingleManagedNetrc(home *secureuserfile.Home) (bool, error) {
+	if home == nil {
+		return false, errors.New("netrc: nil secure user home")
+	}
+	count := 0
+	for _, name := range []string{".netrc", "_netrc"} {
+		file, err := home.Open(name, netrcBackupPrefix, secureuserfile.MaxBytes)
+		if err != nil {
+			return false, err
+		}
+		data, existed, _, err := file.Read()
+		if err != nil {
+			return false, err
+		}
+		if !existed {
+			continue
+		}
+		markers, err := scanNetrcMarkers(data)
+		if err != nil {
+			return false, err
+		}
+		if markers.dmg != nil {
+			count++
+		}
+	}
+	return count == 1, nil
 }
 
 func (w *NetrcWriter) RestoreSnapshot() error { return w.file.RestoreSnapshot() }
@@ -460,7 +487,14 @@ func (w *NetrcWriter) checkAlternateConflict() error {
 	if err != nil {
 		return err
 	}
-	if analysis.markers.dmg != nil || analysis.markers.mdm || len(exactHostEntries(analysis.entries, w.host)) != 0 {
+	exact := exactHostEntries(analysis.entries, w.host)
+	if analysis.markers.dmg != nil {
+		managed, err := parseNetrc([]byte(analysis.markers.dmg.body))
+		if err == nil && len(exactHostEntries(managed, w.host)) == 1 && len(exact) == 1 {
+			return nil
+		}
+	}
+	if analysis.markers.dmg != nil || analysis.markers.mdm || len(exact) != 0 {
 		return fmt.Errorf("netrc: alternate credential file conflicts with selected file: %w", ErrTargetUnusable)
 	}
 	return nil

--- a/internal/devicepolicy/netrc_writer_test.go
+++ b/internal/devicepolicy/netrc_writer_test.go
@@ -27,13 +27,13 @@ func TestNetrcMarkers_Canonical(t *testing.T) {
 		got  string
 		want string
 	}{
-		{"DMG begin", dmgNetrcBegin, "#stepsecurity-pypi-credential-dmg-begin"},
-		{"DMG end", dmgNetrcEnd, "#stepsecurity-pypi-credential-end"},
-		{"MDM begin", mdmNetrcBegin, "#stepsecurity-pypi-credential-mdm-begin"},
-		{"MDM end", mdmNetrcEnd, "#stepsecurity-pypi-credential-end"},
-		{"DMG disabled prefix", dmgNetrcDisabledPrefix, "#stepsecurity-pypi-credential-dmg-disabled:"},
-		{"MDM disabled prefix", mdmNetrcDisabledPrefix, "#stepsecurity-pypi-credential-mdm-disabled:"},
-		{"MDM created", mdmNetrcCreated, "#stepsecurity-pypi-credential-mdm-created"},
+		{"DMG begin", dmgNetrcBegin, "#stepsecurity-package-registry-credential-dmg-begin"},
+		{"DMG end", dmgNetrcEnd, "#stepsecurity-package-registry-credential-end"},
+		{"MDM begin", mdmNetrcBegin, "#stepsecurity-package-registry-credential-mdm-begin"},
+		{"MDM end", mdmNetrcEnd, "#stepsecurity-package-registry-credential-end"},
+		{"DMG disabled prefix", dmgNetrcDisabledPrefix, "#stepsecurity-package-registry-credential-dmg-disabled:"},
+		{"MDM disabled prefix", mdmNetrcDisabledPrefix, "#stepsecurity-package-registry-credential-mdm-disabled:"},
+		{"MDM created", mdmNetrcCreated, "#stepsecurity-package-registry-credential-mdm-created"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestNetrcWriter_CredentialOwnershipLinesAreSingleTokens(t *testing.T) {
 				t.Fatalf("credential ownership lines = %q, want %d", ownershipLines, tc.wantLines)
 			}
 			for _, line := range ownershipLines {
-				if !strings.HasPrefix(line, "#stepsecurity-pypi-credential") || strings.ContainsAny(line, " \t\r") {
+				if !strings.HasPrefix(line, "#stepsecurity-package-registry-credential") || strings.ContainsAny(line, " \t\r") {
 					t.Errorf("credential ownership line %q is not one whitespace-free token", line)
 				}
 			}
@@ -535,12 +535,12 @@ func TestNetrcWriter_NETRCOverrideRefusesWriteWithoutMutation(t *testing.T) {
 	}
 }
 
-func TestNetrcWriter_NETRCRelativeDefaultPathIsEquivalent(t *testing.T) {
+func TestNetrcWriter_NETRCRelativeOverrideIsUnusable(t *testing.T) {
 	w, _ := newNetrcTestWriter(t, nil)
 	t.Chdir(filepath.Dir(w.Location()))
 	t.Setenv("NETRC", filepath.Base(w.Location()))
-	if err := w.ValidateEffectivePath(); err != nil {
-		t.Fatalf("ValidateEffectivePath: %v", err)
+	if err := w.ValidateEffectivePath(); !errors.Is(err, ErrTargetUnusable) {
+		t.Fatalf("ValidateEffectivePath error = %v, want target unusable", err)
 	}
 }
 

--- a/internal/devicepolicy/netrc_writer_test.go
+++ b/internal/devicepolicy/netrc_writer_test.go
@@ -27,13 +27,13 @@ func TestNetrcMarkers_Canonical(t *testing.T) {
 		got  string
 		want string
 	}{
-		{"DMG begin", dmgNetrcBegin, "#stepsecurity-package-registry-credential-dmg-begin"},
-		{"DMG end", dmgNetrcEnd, "#stepsecurity-package-registry-credential-end"},
-		{"MDM begin", mdmNetrcBegin, "#stepsecurity-package-registry-credential-mdm-begin"},
-		{"MDM end", mdmNetrcEnd, "#stepsecurity-package-registry-credential-end"},
-		{"DMG disabled prefix", dmgNetrcDisabledPrefix, "#stepsecurity-package-registry-credential-dmg-disabled:"},
-		{"MDM disabled prefix", mdmNetrcDisabledPrefix, "#stepsecurity-package-registry-credential-mdm-disabled:"},
-		{"MDM created", mdmNetrcCreated, "#stepsecurity-package-registry-credential-mdm-created"},
+		{"DMG begin", dmgNetrcBegin, "#stepsecurity-secure-registry-credential-dmg-begin"},
+		{"DMG end", dmgNetrcEnd, "#stepsecurity-secure-registry-credential-end"},
+		{"MDM begin", mdmNetrcBegin, "#stepsecurity-secure-registry-credential-mdm-begin"},
+		{"MDM end", mdmNetrcEnd, "#stepsecurity-secure-registry-credential-end"},
+		{"DMG disabled prefix", dmgNetrcDisabledPrefix, "#stepsecurity-secure-registry-credential-dmg-disabled:"},
+		{"MDM disabled prefix", mdmNetrcDisabledPrefix, "#stepsecurity-secure-registry-credential-mdm-disabled:"},
+		{"MDM created", mdmNetrcCreated, "#stepsecurity-secure-registry-credential-mdm-created"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestNetrcWriter_CredentialOwnershipLinesAreSingleTokens(t *testing.T) {
 				t.Fatalf("credential ownership lines = %q, want %d", ownershipLines, tc.wantLines)
 			}
 			for _, line := range ownershipLines {
-				if !strings.HasPrefix(line, "#stepsecurity-package-registry-credential") || strings.ContainsAny(line, " \t\r") {
+				if !strings.HasPrefix(line, "#stepsecurity-secure-registry-credential") || strings.ContainsAny(line, " \t\r") {
 					t.Errorf("credential ownership line %q is not one whitespace-free token", line)
 				}
 			}

--- a/internal/devicepolicy/netrc_writer_test.go
+++ b/internal/devicepolicy/netrc_writer_test.go
@@ -544,10 +544,11 @@ func TestNetrcWriter_NETRCRelativeOverrideIsUnusable(t *testing.T) {
 	}
 }
 
-func TestNetrcWriter_UsesResolvedPlatformForWindowsAlternate(t *testing.T) {
+func TestNetrcWriter_UsesResolvedPlatformForWindowsAlternateValidation(t *testing.T) {
 	homeDir := t.TempDir()
+	dot := filepath.Join(homeDir, ".netrc")
 	underscore := filepath.Join(homeDir, "_netrc")
-	if err := os.WriteFile(underscore, []byte("machine other.example login u password p\n"), 0o600); err != nil {
+	if err := os.WriteFile(underscore, []byte("machine registry.stepsecurity.io login stale password old-secret\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	u, err := user.Current()
@@ -567,8 +568,11 @@ func TestNetrcWriter_UsesResolvedPlatformForWindowsAlternate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if w.Location() != underscore {
-		t.Fatalf("Location = %q, want Windows alternate %q", w.Location(), underscore)
+	if w.Location() != dot {
+		t.Fatalf("Location = %q, want %q", w.Location(), dot)
+	}
+	if _, err := w.Write(netrcExpected); !errors.Is(err, ErrTargetUnusable) {
+		t.Fatalf("Write error = %v, want alternate conflict", err)
 	}
 }
 

--- a/internal/devicepolicy/netrc_writer_windows_test.go
+++ b/internal/devicepolicy/netrc_writer_windows_test.go
@@ -241,26 +241,27 @@ func TestNetrcWriter_WindowsSeparateManagedFilesClearInEitherOrder(t *testing.T)
 }
 
 func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
-	t.Run("managed underscore survives selection change", func(t *testing.T) {
+	t.Run("managed dot file survives Go selection change", func(t *testing.T) {
 		home := t.TempDir()
-		underscore := filepath.Join(home, "_netrc")
+		dot := filepath.Join(home, ".netrc")
 		initial := []byte("machine other.example login u password p\r\n")
-		if err := os.WriteFile(underscore, initial, 0o600); err != nil {
+		if err := os.WriteFile(dot, initial, 0o600); err != nil {
 			t.Fatal(err)
 		}
-		writer, err := NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
+		policy := netrcTestPolicy(t)
+		writer, err := newGoNetrcWriter(newSecureTestHome(t, home), policy.RegistryHost(), policy.DeviceToken())
 		if err != nil {
 			t.Fatal(err)
 		}
 		if _, err := writer.Write(netrcExpected); err != nil {
 			t.Fatal(err)
 		}
-		dot := filepath.Join(home, ".netrc")
-		dotContent := []byte("machine dot.example login u password p\r\n")
-		if err := os.WriteFile(dot, dotContent, 0o600); err != nil {
+		underscore := filepath.Join(home, "_netrc")
+		underscoreContent := []byte("machine underscore.example login u password p\r\n")
+		if err := os.WriteFile(underscore, underscoreContent, 0o600); err != nil {
 			t.Fatal(err)
 		}
-		writer, err = NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
+		writer, err = newGoNetrcWriter(newSecureTestHome(t, home), policy.RegistryHost(), policy.DeviceToken())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -268,16 +269,16 @@ func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
 		if err != nil || !changed {
 			t.Fatalf("Clear = %v, %v, want managed alternate cleared", changed, err)
 		}
-		got, err := os.ReadFile(underscore)
+		got, err := os.ReadFile(dot)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if string(got) != string(initial) {
-			t.Fatalf("underscore = %q, want restored %q", got, initial)
+			t.Fatalf("dot file = %q, want restored %q", got, initial)
 		}
-		got, err = os.ReadFile(dot)
-		if err != nil || string(got) != string(dotContent) {
-			t.Fatalf("dot file changed: %q, %v", got, err)
+		got, err = os.ReadFile(underscore)
+		if err != nil || string(got) != string(underscoreContent) {
+			t.Fatalf("underscore file changed: %q, %v", got, err)
 		}
 	})
 

--- a/internal/devicepolicy/netrc_writer_windows_test.go
+++ b/internal/devicepolicy/netrc_writer_windows_test.go
@@ -3,6 +3,7 @@
 package devicepolicy
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,6 +68,94 @@ func TestNetrcWriter_WindowsPathSelectionAndAlternateConflict(t *testing.T) {
 			t.Fatalf("alternate conflict leaked credential: %v", err)
 		}
 	})
+}
+
+func TestNetrcWriter_WindowsGoAlwaysUsesUnderscoreNetrc(t *testing.T) {
+	tests := []struct {
+		name       string
+		dot        []byte
+		underscore []byte
+	}{
+		{name: "neither file"},
+		{name: "dot file only", dot: []byte("machine dot.example login user password keep\r\n")},
+		{
+			name:       "both files",
+			dot:        []byte("machine dot.example login user password keep\r\n"),
+			underscore: []byte("machine underscore.example login user password keep\r\n"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			dotPath := filepath.Join(homeDir, ".netrc")
+			underscorePath := filepath.Join(homeDir, "_netrc")
+			if tc.dot != nil {
+				if err := os.WriteFile(dotPath, tc.dot, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.underscore != nil {
+				if err := os.WriteFile(underscorePath, tc.underscore, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			policy := goTestPolicy(t)
+			writer, err := newGoNetrcWriter(newSecureTestHome(t, homeDir), policy.RegistryHost(), policy.DeviceToken())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if writer.Location() != underscorePath {
+				t.Fatalf("Location = %q, want %q", writer.Location(), underscorePath)
+			}
+			if _, err := writer.Write(writer.expected); err != nil {
+				t.Fatal(err)
+			}
+			first, err := os.ReadFile(underscorePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := writer.Write(writer.expected); err != nil {
+				t.Fatal(err)
+			}
+			second, err := os.ReadFile(underscorePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(second, first) {
+				t.Fatalf("repeated write changed _netrc: %q, want %q", second, first)
+			}
+			if tc.dot != nil {
+				got, err := os.ReadFile(dotPath)
+				if err != nil || !bytes.Equal(got, tc.dot) {
+					t.Fatalf(".netrc changed: %q, %v", got, err)
+				}
+			} else if _, err := os.Stat(dotPath); !os.IsNotExist(err) {
+				t.Fatalf(".netrc was created: %v", err)
+			}
+
+			changed, err := writer.Clear()
+			if err != nil || !changed {
+				t.Fatalf("Clear = %v, %v, want true", changed, err)
+			}
+			if tc.underscore == nil {
+				if _, err := os.Stat(underscorePath); !os.IsNotExist(err) {
+					t.Fatalf("created _netrc remains: %v", err)
+				}
+			} else {
+				got, err := os.ReadFile(underscorePath)
+				if err != nil || !bytes.Equal(got, tc.underscore) {
+					t.Fatalf("restored _netrc = %q, %v, want %q", got, err, tc.underscore)
+				}
+			}
+			if tc.dot != nil {
+				got, err := os.ReadFile(dotPath)
+				if err != nil || !bytes.Equal(got, tc.dot) {
+					t.Fatalf("clear changed .netrc: %q, %v", got, err)
+				}
+			}
+		})
+	}
 }
 
 func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {

--- a/internal/devicepolicy/netrc_writer_windows_test.go
+++ b/internal/devicepolicy/netrc_writer_windows_test.go
@@ -13,28 +13,34 @@ import (
 )
 
 func TestNetrcWriter_WindowsPathSelectionAndAlternateConflict(t *testing.T) {
-	t.Run("existing underscore file is selected", func(t *testing.T) {
+	t.Run("PyPI uses dot file when only underscore exists", func(t *testing.T) {
 		home := t.TempDir()
+		dot := filepath.Join(home, ".netrc")
 		underscore := filepath.Join(home, "_netrc")
-		if err := os.WriteFile(underscore, []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
+		initial := []byte("machine other.example login u password p\r\n")
+		if err := os.WriteFile(underscore, initial, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		w, err := NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if w.Location() != underscore {
-			t.Fatalf("Location = %q, want existing %q", w.Location(), underscore)
+		if w.Location() != dot {
+			t.Fatalf("Location = %q, want %q", w.Location(), dot)
 		}
 		if _, err := w.Write(netrcExpected); err != nil {
 			t.Fatalf("Write: %v", err)
 		}
-		if _, err := os.Stat(filepath.Join(home, ".netrc")); !os.IsNotExist(err) {
-			t.Fatalf("Write created a second netrc file: %v", err)
+		got, err := os.ReadFile(underscore)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, initial) {
+			t.Fatalf("_netrc = %q, want unchanged %q", got, initial)
 		}
 	})
 
-	t.Run("underscore file wins when both exist", func(t *testing.T) {
+	t.Run("dot file wins when both exist", func(t *testing.T) {
 		home := t.TempDir()
 		for _, name := range []string{".netrc", "_netrc"} {
 			if err := os.WriteFile(filepath.Join(home, name), []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
@@ -45,17 +51,17 @@ func TestNetrcWriter_WindowsPathSelectionAndAlternateConflict(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if filepath.Base(w.Location()) != "_netrc" {
-			t.Fatalf("Location = %q, want preferred _netrc", w.Location())
+		if filepath.Base(w.Location()) != ".netrc" {
+			t.Fatalf("Location = %q, want preferred .netrc", w.Location())
 		}
 	})
 
 	t.Run("unused alternate exact host fails closed", func(t *testing.T) {
 		home := t.TempDir()
-		if err := os.WriteFile(filepath.Join(home, ".netrc"), []byte("machine registry.stepsecurity.io login stale password old-secret\r\n"), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(home, ".netrc"), []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(home, "_netrc"), []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(home, "_netrc"), []byte("machine registry.stepsecurity.io login stale password old-secret\r\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		w, err := NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
@@ -158,58 +164,88 @@ func TestNetrcWriter_WindowsGoUsesCmdGoNetrcPrecedence(t *testing.T) {
 	}
 }
 
-func TestNetrcWriter_WindowsGoAndPyPIShareUnderscoreNetrc(t *testing.T) {
-	homeDir := t.TempDir()
-	dotPath := filepath.Join(homeDir, ".netrc")
-	underscorePath := filepath.Join(homeDir, "_netrc")
-	dotInitial := []byte("machine dot.example login user password keep\r\n")
-	underscoreInitial := []byte("machine underscore.example login user password keep\r\n")
-	if err := os.WriteFile(dotPath, dotInitial, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(underscorePath, underscoreInitial, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	home := newSecureTestHome(t, homeDir)
-	policy := netrcTestPolicy(t)
-	pypi, err := NewNetrcWriter(home, policy)
-	if err != nil {
-		t.Fatal(err)
-	}
-	goWriter, err := newGoNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, writer := range []*NetrcWriter{pypi, goWriter} {
-		if writer.Location() != underscorePath {
-			t.Fatalf("Location = %q, want shared %q", writer.Location(), underscorePath)
-		}
-		if _, err := writer.Write(writer.expected); err != nil {
-			t.Fatal(err)
-		}
-	}
-	got, err := os.ReadFile(dotPath)
-	if err != nil || !bytes.Equal(got, dotInitial) {
-		t.Fatalf(".netrc = %q, %v, want unchanged %q", got, err, dotInitial)
-	}
-	got, err = os.ReadFile(underscorePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Count(got, []byte(dmgNetrcBegin)) != 1 || bytes.Count(got, []byte("machine registry.stepsecurity.io")) != 1 {
-		t.Fatalf("shared credential duplicated:\n%s", got)
-	}
-	if single, err := hasSingleManagedNetrc(home); err != nil || !single {
-		t.Fatalf("hasSingleManagedNetrc = %v, %v, want true", single, err)
+func TestNetrcWriter_WindowsSeparateManagedFilesClearInEitherOrder(t *testing.T) {
+	for _, first := range []string{"go", "pypi"} {
+		t.Run(first+" first", func(t *testing.T) {
+			homeDir := t.TempDir()
+			dotPath := filepath.Join(homeDir, ".netrc")
+			underscorePath := filepath.Join(homeDir, "_netrc")
+			dotInitial := []byte("machine dot.example login user password keep\r\n")
+			underscoreInitial := []byte("machine underscore.example login user password keep\r\n")
+			if err := os.WriteFile(dotPath, dotInitial, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(underscorePath, underscoreInitial, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			home := newSecureTestHome(t, homeDir)
+			pypi, err := NewNetrcWriter(home, netrcTestPolicy(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			policy := goTestPolicy(t)
+			goWriter, err := newGoNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, writer := range []*NetrcWriter{pypi, goWriter} {
+				if _, err := writer.Write(writer.expected); err != nil {
+					t.Fatal(err)
+				}
+			}
+			single, err := hasSingleManagedNetrc(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if single {
+				t.Fatal("hasSingleManagedNetrc = true, want false")
+			}
+
+			writers := map[string]*NetrcWriter{"go": goWriter, "pypi": pypi}
+			changed, err := writers[first].Clear()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !changed {
+				t.Fatal("first Clear = false, want true")
+			}
+			single, err = hasSingleManagedNetrc(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !single {
+				t.Fatal("hasSingleManagedNetrc after first clear = false, want true")
+			}
+			second := "go"
+			if first == second {
+				second = "pypi"
+			}
+			changed, err = writers[second].Clear()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !changed {
+				t.Fatal("second Clear = false, want true")
+			}
+			for path, want := range map[string][]byte{dotPath: dotInitial, underscorePath: underscoreInitial} {
+				got, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatalf("restored %s = %q, want %q", path, got, want)
+				}
+			}
+		})
 	}
 }
 
 func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
-	t.Run("managed dot file survives selection change", func(t *testing.T) {
+	t.Run("managed underscore survives selection change", func(t *testing.T) {
 		home := t.TempDir()
-		dot := filepath.Join(home, ".netrc")
+		underscore := filepath.Join(home, "_netrc")
 		initial := []byte("machine other.example login u password p\r\n")
-		if err := os.WriteFile(dot, initial, 0o600); err != nil {
+		if err := os.WriteFile(underscore, initial, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		writer, err := NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
@@ -219,9 +255,9 @@ func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
 		if _, err := writer.Write(netrcExpected); err != nil {
 			t.Fatal(err)
 		}
-		underscore := filepath.Join(home, "_netrc")
-		underscoreContent := []byte("machine underscore.example login u password p\r\n")
-		if err := os.WriteFile(underscore, underscoreContent, 0o600); err != nil {
+		dot := filepath.Join(home, ".netrc")
+		dotContent := []byte("machine dot.example login u password p\r\n")
+		if err := os.WriteFile(dot, dotContent, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		writer, err = NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
@@ -232,16 +268,16 @@ func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
 		if err != nil || !changed {
 			t.Fatalf("Clear = %v, %v, want managed alternate cleared", changed, err)
 		}
-		got, err := os.ReadFile(dot)
+		got, err := os.ReadFile(underscore)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if string(got) != string(initial) {
-			t.Fatalf("dot file = %q, want restored %q", got, initial)
+			t.Fatalf("underscore = %q, want restored %q", got, initial)
 		}
-		got, err = os.ReadFile(underscore)
-		if err != nil || string(got) != string(underscoreContent) {
-			t.Fatalf("underscore file changed: %q, %v", got, err)
+		got, err = os.ReadFile(dot)
+		if err != nil || string(got) != string(dotContent) {
+			t.Fatalf("dot file changed: %q, %v", got, err)
 		}
 	})
 

--- a/internal/devicepolicy/netrc_writer_windows_test.go
+++ b/internal/devicepolicy/netrc_writer_windows_test.go
@@ -70,18 +70,21 @@ func TestNetrcWriter_WindowsPathSelectionAndAlternateConflict(t *testing.T) {
 	})
 }
 
-func TestNetrcWriter_WindowsGoAlwaysUsesUnderscoreNetrc(t *testing.T) {
+func TestNetrcWriter_WindowsGoUsesCmdGoNetrcPrecedence(t *testing.T) {
 	tests := []struct {
 		name       string
 		dot        []byte
 		underscore []byte
+		selected   string
 	}{
-		{name: "neither file"},
-		{name: "dot file only", dot: []byte("machine dot.example login user password keep\r\n")},
+		{name: "neither file", selected: ".netrc"},
+		{name: "dot file only", dot: []byte("machine dot.example login user password keep\r\n"), selected: ".netrc"},
+		{name: "underscore file only", underscore: []byte("machine underscore.example login user password keep\r\n"), selected: "_netrc"},
 		{
 			name:       "both files",
 			dot:        []byte("machine dot.example login user password keep\r\n"),
 			underscore: []byte("machine underscore.example login user password keep\r\n"),
+			selected:   "_netrc",
 		},
 	}
 	for _, tc := range tests {
@@ -89,6 +92,19 @@ func TestNetrcWriter_WindowsGoAlwaysUsesUnderscoreNetrc(t *testing.T) {
 			homeDir := t.TempDir()
 			dotPath := filepath.Join(homeDir, ".netrc")
 			underscorePath := filepath.Join(homeDir, "_netrc")
+			assertFile := func(path string, want []byte) {
+				t.Helper()
+				got, err := os.ReadFile(path)
+				if want == nil {
+					if !os.IsNotExist(err) {
+						t.Fatalf("%s exists, want absent: %q, %v", path, got, err)
+					}
+					return
+				}
+				if err != nil || !bytes.Equal(got, want) {
+					t.Fatalf("%s = %q, %v, want %q", path, got, err, want)
+				}
+			}
 			if tc.dot != nil {
 				if err := os.WriteFile(dotPath, tc.dot, 0o600); err != nil {
 					t.Fatal(err)
@@ -105,55 +121,39 @@ func TestNetrcWriter_WindowsGoAlwaysUsesUnderscoreNetrc(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if writer.Location() != underscorePath {
-				t.Fatalf("Location = %q, want %q", writer.Location(), underscorePath)
+			selectedPath := filepath.Join(homeDir, tc.selected)
+			if writer.Location() != selectedPath {
+				t.Fatalf("Location = %q, want %q", writer.Location(), selectedPath)
 			}
 			if _, err := writer.Write(writer.expected); err != nil {
 				t.Fatal(err)
 			}
-			first, err := os.ReadFile(underscorePath)
+			first, err := os.ReadFile(selectedPath)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if _, err := writer.Write(writer.expected); err != nil {
 				t.Fatal(err)
 			}
-			second, err := os.ReadFile(underscorePath)
+			second, err := os.ReadFile(selectedPath)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !bytes.Equal(second, first) {
-				t.Fatalf("repeated write changed _netrc: %q, want %q", second, first)
+				t.Fatalf("repeated write changed %s: %q, want %q", tc.selected, second, first)
 			}
-			if tc.dot != nil {
-				got, err := os.ReadFile(dotPath)
-				if err != nil || !bytes.Equal(got, tc.dot) {
-					t.Fatalf(".netrc changed: %q, %v", got, err)
-				}
-			} else if _, err := os.Stat(dotPath); !os.IsNotExist(err) {
-				t.Fatalf(".netrc was created: %v", err)
+			if tc.selected == ".netrc" {
+				assertFile(underscorePath, tc.underscore)
+			} else {
+				assertFile(dotPath, tc.dot)
 			}
 
 			changed, err := writer.Clear()
 			if err != nil || !changed {
 				t.Fatalf("Clear = %v, %v, want true", changed, err)
 			}
-			if tc.underscore == nil {
-				if _, err := os.Stat(underscorePath); !os.IsNotExist(err) {
-					t.Fatalf("created _netrc remains: %v", err)
-				}
-			} else {
-				got, err := os.ReadFile(underscorePath)
-				if err != nil || !bytes.Equal(got, tc.underscore) {
-					t.Fatalf("restored _netrc = %q, %v, want %q", got, err, tc.underscore)
-				}
-			}
-			if tc.dot != nil {
-				got, err := os.ReadFile(dotPath)
-				if err != nil || !bytes.Equal(got, tc.dot) {
-					t.Fatalf("clear changed .netrc: %q, %v", got, err)
-				}
-			}
+			assertFile(dotPath, tc.dot)
+			assertFile(underscorePath, tc.underscore)
 		})
 	}
 }

--- a/internal/devicepolicy/netrc_writer_windows_test.go
+++ b/internal/devicepolicy/netrc_writer_windows_test.go
@@ -34,7 +34,7 @@ func TestNetrcWriter_WindowsPathSelectionAndAlternateConflict(t *testing.T) {
 		}
 	})
 
-	t.Run("dot file wins when both exist", func(t *testing.T) {
+	t.Run("underscore file wins when both exist", func(t *testing.T) {
 		home := t.TempDir()
 		for _, name := range []string{".netrc", "_netrc"} {
 			if err := os.WriteFile(filepath.Join(home, name), []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
@@ -45,17 +45,17 @@ func TestNetrcWriter_WindowsPathSelectionAndAlternateConflict(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if filepath.Base(w.Location()) != ".netrc" {
-			t.Fatalf("Location = %q, want preferred .netrc", w.Location())
+		if filepath.Base(w.Location()) != "_netrc" {
+			t.Fatalf("Location = %q, want preferred _netrc", w.Location())
 		}
 	})
 
 	t.Run("unused alternate exact host fails closed", func(t *testing.T) {
 		home := t.TempDir()
-		if err := os.WriteFile(filepath.Join(home, ".netrc"), []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(home, ".netrc"), []byte("machine registry.stepsecurity.io login stale password old-secret\r\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(home, "_netrc"), []byte("machine registry.stepsecurity.io login stale password old-secret\r\n"), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(home, "_netrc"), []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		w, err := NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
@@ -158,69 +158,58 @@ func TestNetrcWriter_WindowsGoUsesCmdGoNetrcPrecedence(t *testing.T) {
 	}
 }
 
-func TestNetrcWriter_WindowsSeparateManagedFilesClearInEitherOrder(t *testing.T) {
-	for _, first := range []string{"go", "pypi"} {
-		t.Run(first+" first", func(t *testing.T) {
-			homeDir := t.TempDir()
-			dotPath := filepath.Join(homeDir, ".netrc")
-			underscorePath := filepath.Join(homeDir, "_netrc")
-			dotInitial := []byte("machine dot.example login user password keep\r\n")
-			underscoreInitial := []byte("machine underscore.example login user password keep\r\n")
-			if err := os.WriteFile(dotPath, dotInitial, 0o600); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(underscorePath, underscoreInitial, 0o600); err != nil {
-				t.Fatal(err)
-			}
-			home := newSecureTestHome(t, homeDir)
-			pypi, err := NewNetrcWriter(home, netrcTestPolicy(t))
-			if err != nil {
-				t.Fatal(err)
-			}
-			policy := goTestPolicy(t)
-			goWriter, err := newGoNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
-			if err != nil {
-				t.Fatal(err)
-			}
-			for _, writer := range []*NetrcWriter{pypi, goWriter} {
-				if _, err := writer.Write(writer.expected); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if single, err := hasSingleManagedNetrc(home); err != nil || single {
-				t.Fatalf("hasSingleManagedNetrc = %v, %v, want false", single, err)
-			}
-
-			writers := map[string]*NetrcWriter{"go": goWriter, "pypi": pypi}
-			if changed, err := writers[first].Clear(); err != nil || !changed {
-				t.Fatalf("first Clear = %v, %v", changed, err)
-			}
-			if single, err := hasSingleManagedNetrc(home); err != nil || !single {
-				t.Fatalf("hasSingleManagedNetrc after first clear = %v, %v, want true", single, err)
-			}
-			second := "go"
-			if first == second {
-				second = "pypi"
-			}
-			if changed, err := writers[second].Clear(); err != nil || !changed {
-				t.Fatalf("second Clear = %v, %v", changed, err)
-			}
-			for path, want := range map[string][]byte{dotPath: dotInitial, underscorePath: underscoreInitial} {
-				got, err := os.ReadFile(path)
-				if err != nil || !bytes.Equal(got, want) {
-					t.Fatalf("restored %s = %q, %v, want %q", path, got, err, want)
-				}
-			}
-		})
+func TestNetrcWriter_WindowsGoAndPyPIShareUnderscoreNetrc(t *testing.T) {
+	homeDir := t.TempDir()
+	dotPath := filepath.Join(homeDir, ".netrc")
+	underscorePath := filepath.Join(homeDir, "_netrc")
+	dotInitial := []byte("machine dot.example login user password keep\r\n")
+	underscoreInitial := []byte("machine underscore.example login user password keep\r\n")
+	if err := os.WriteFile(dotPath, dotInitial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(underscorePath, underscoreInitial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	home := newSecureTestHome(t, homeDir)
+	policy := netrcTestPolicy(t)
+	pypi, err := NewNetrcWriter(home, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goWriter, err := newGoNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, writer := range []*NetrcWriter{pypi, goWriter} {
+		if writer.Location() != underscorePath {
+			t.Fatalf("Location = %q, want shared %q", writer.Location(), underscorePath)
+		}
+		if _, err := writer.Write(writer.expected); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := os.ReadFile(dotPath)
+	if err != nil || !bytes.Equal(got, dotInitial) {
+		t.Fatalf(".netrc = %q, %v, want unchanged %q", got, err, dotInitial)
+	}
+	got, err = os.ReadFile(underscorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Count(got, []byte(dmgNetrcBegin)) != 1 || bytes.Count(got, []byte("machine registry.stepsecurity.io")) != 1 {
+		t.Fatalf("shared credential duplicated:\n%s", got)
+	}
+	if single, err := hasSingleManagedNetrc(home); err != nil || !single {
+		t.Fatalf("hasSingleManagedNetrc = %v, %v, want true", single, err)
 	}
 }
 
 func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
-	t.Run("managed underscore survives selection change", func(t *testing.T) {
+	t.Run("managed dot file survives selection change", func(t *testing.T) {
 		home := t.TempDir()
-		underscore := filepath.Join(home, "_netrc")
+		dot := filepath.Join(home, ".netrc")
 		initial := []byte("machine other.example login u password p\r\n")
-		if err := os.WriteFile(underscore, initial, 0o600); err != nil {
+		if err := os.WriteFile(dot, initial, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		writer, err := NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
@@ -230,9 +219,9 @@ func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
 		if _, err := writer.Write(netrcExpected); err != nil {
 			t.Fatal(err)
 		}
-		dot := filepath.Join(home, ".netrc")
-		dotContent := []byte("machine dot.example login u password p\r\n")
-		if err := os.WriteFile(dot, dotContent, 0o600); err != nil {
+		underscore := filepath.Join(home, "_netrc")
+		underscoreContent := []byte("machine underscore.example login u password p\r\n")
+		if err := os.WriteFile(underscore, underscoreContent, 0o600); err != nil {
 			t.Fatal(err)
 		}
 		writer, err = NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
@@ -243,16 +232,16 @@ func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
 		if err != nil || !changed {
 			t.Fatalf("Clear = %v, %v, want managed alternate cleared", changed, err)
 		}
-		got, err := os.ReadFile(underscore)
+		got, err := os.ReadFile(dot)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if string(got) != string(initial) {
-			t.Fatalf("underscore = %q, want restored %q", got, initial)
+			t.Fatalf("dot file = %q, want restored %q", got, initial)
 		}
-		got, err = os.ReadFile(dot)
-		if err != nil || string(got) != string(dotContent) {
-			t.Fatalf("dot file changed: %q, %v", got, err)
+		got, err = os.ReadFile(underscore)
+		if err != nil || string(got) != string(underscoreContent) {
+			t.Fatalf("underscore file changed: %q, %v", got, err)
 		}
 	})
 

--- a/internal/devicepolicy/netrc_writer_windows_test.go
+++ b/internal/devicepolicy/netrc_writer_windows_test.go
@@ -287,34 +287,6 @@ func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
 		}
 	})
 
-	t.Run("two managed files block clear", func(t *testing.T) {
-		home := t.TempDir()
-		underscore := filepath.Join(home, "_netrc")
-		if err := os.WriteFile(underscore, []byte("machine other.example login u password p\r\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		writer, err := NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := writer.Write(netrcExpected); err != nil {
-			t.Fatal(err)
-		}
-		managed, err := os.ReadFile(underscore)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(home, ".netrc"), managed, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		writer, err = NewNetrcWriter(newSecureTestHome(t, home), netrcTestPolicy(t))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := writer.Clear(); err == nil {
-			t.Fatal("Clear error = nil, want conflicting managed files")
-		}
-	})
 }
 
 func TestNetrcWriter_WindowsACLRejectsUnexpectedReader(t *testing.T) {

--- a/internal/devicepolicy/netrc_writer_windows_test.go
+++ b/internal/devicepolicy/netrc_writer_windows_test.go
@@ -158,6 +158,63 @@ func TestNetrcWriter_WindowsGoAlwaysUsesUnderscoreNetrc(t *testing.T) {
 	}
 }
 
+func TestNetrcWriter_WindowsSeparateManagedFilesClearInEitherOrder(t *testing.T) {
+	for _, first := range []string{"go", "pypi"} {
+		t.Run(first+" first", func(t *testing.T) {
+			homeDir := t.TempDir()
+			dotPath := filepath.Join(homeDir, ".netrc")
+			underscorePath := filepath.Join(homeDir, "_netrc")
+			dotInitial := []byte("machine dot.example login user password keep\r\n")
+			underscoreInitial := []byte("machine underscore.example login user password keep\r\n")
+			if err := os.WriteFile(dotPath, dotInitial, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(underscorePath, underscoreInitial, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			home := newSecureTestHome(t, homeDir)
+			pypi, err := NewNetrcWriter(home, netrcTestPolicy(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			policy := goTestPolicy(t)
+			goWriter, err := newGoNetrcWriter(home, policy.RegistryHost(), policy.DeviceToken())
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, writer := range []*NetrcWriter{pypi, goWriter} {
+				if _, err := writer.Write(writer.expected); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if single, err := hasSingleManagedNetrc(home); err != nil || single {
+				t.Fatalf("hasSingleManagedNetrc = %v, %v, want false", single, err)
+			}
+
+			writers := map[string]*NetrcWriter{"go": goWriter, "pypi": pypi}
+			if changed, err := writers[first].Clear(); err != nil || !changed {
+				t.Fatalf("first Clear = %v, %v", changed, err)
+			}
+			if single, err := hasSingleManagedNetrc(home); err != nil || !single {
+				t.Fatalf("hasSingleManagedNetrc after first clear = %v, %v, want true", single, err)
+			}
+			second := "go"
+			if first == second {
+				second = "pypi"
+			}
+			if changed, err := writers[second].Clear(); err != nil || !changed {
+				t.Fatalf("second Clear = %v, %v", changed, err)
+			}
+			for path, want := range map[string][]byte{dotPath: dotInitial, underscorePath: underscoreInitial} {
+				got, err := os.ReadFile(path)
+				if err != nil || !bytes.Equal(got, want) {
+					t.Fatalf("restored %s = %q, %v, want %q", path, got, err, want)
+				}
+			}
+		})
+	}
+}
+
 func TestNetrcWriter_WindowsClearFindsOwnedFile(t *testing.T) {
 	t.Run("managed underscore survives selection change", func(t *testing.T) {
 		home := t.TempDir()

--- a/internal/devicepolicy/pypi_coordinator.go
+++ b/internal/devicepolicy/pypi_coordinator.go
@@ -33,10 +33,11 @@ type PyPICoordinator struct {
 }
 
 type pypiComponents struct {
-	credential *pypiComponent
-	pip        *pypiComponent
-	uv         *pypiComponent
-	close      func() error
+	credential   *pypiComponent
+	pip          *pypiComponent
+	uv           *pypiComponent
+	hasGoSibling func() (bool, error)
+	close        func() error
 }
 
 type pypiComponent struct {
@@ -160,13 +161,23 @@ func (c *PyPICoordinator) clear(ctx context.Context, effective EffectivePolicy, 
 	}
 	effective.Enforcement = enforcementDMG
 	var errs []error
-	for _, component := range []*pypiComponent{components.pip, components.uv, components.credential} {
+	for _, component := range []*pypiComponent{components.pip, components.uv} {
 		result := c.runClear(ctx, effective, component)
 		if result.err != nil {
 			errs = append(errs, result.err)
 		}
 	}
-	return errors.Join(errs...)
+	if components.hasGoSibling != nil {
+		sibling, err := components.hasGoSibling()
+		if err != nil {
+			return errors.Join(errors.Join(errs...), fmt.Errorf("devicepolicy: inspect Go sibling marker: %w", err))
+		}
+		if sibling {
+			return errors.Join(errors.Join(errs...), c.clearOwnershipState(CategoryPackageConfig, PyPICredentialOwnershipTarget))
+		}
+	}
+	credentialResult := c.runClear(ctx, effective, components.credential)
+	return errors.Join(errors.Join(errs...), credentialResult.err)
 }
 
 func (c *PyPICoordinator) reconcileMDM(ctx context.Context, effective EffectivePolicy, policy PyPIPolicy, components *pypiComponents) error {
@@ -469,6 +480,7 @@ func buildPyPIComponents(ctx context.Context, exec executor.Executor, policy PyP
 	}
 	components := &pypiComponents{close: home.Close}
 	userExec := executor.NewUserAwareExecutor(exec, home.Username())
+	components.hasGoSibling = func() (bool, error) { return hasGoDMGMarker(exec, home) }
 
 	credentialExpected := renderNetrcEntry(policy.RegistryHost(), policy.DeviceToken())
 	credential, credentialErr := NewNetrcWriter(home, policy)

--- a/internal/devicepolicy/pypi_coordinator.go
+++ b/internal/devicepolicy/pypi_coordinator.go
@@ -480,7 +480,13 @@ func buildPyPIComponents(ctx context.Context, exec executor.Executor, policy PyP
 	}
 	components := &pypiComponents{close: home.Close}
 	userExec := executor.NewUserAwareExecutor(exec, home.Username())
-	components.hasGoSibling = func() (bool, error) { return hasGoDMGMarker(exec, home) }
+	components.hasGoSibling = func() (bool, error) {
+		sibling, err := hasGoDMGMarker(exec, home)
+		if err != nil || !sibling {
+			return sibling, err
+		}
+		return hasSingleManagedNetrc(home)
+	}
 
 	credentialExpected := renderNetrcEntry(policy.RegistryHost(), policy.DeviceToken())
 	credential, credentialErr := NewNetrcWriter(home, policy)

--- a/internal/devicepolicy/pypi_coordinator_windows_test.go
+++ b/internal/devicepolicy/pypi_coordinator_windows_test.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestPyPICoordinatorWindows_MDMUsesUnderscoreNetrcWhenBothExist(t *testing.T) {
+func TestGoAndPyPICoordinatorsWindows_MDMUseSeparateNetrcFiles(t *testing.T) {
 	withTempCache(t)
 	current, err := user.Current()
 	if err != nil {
@@ -39,19 +39,29 @@ func TestPyPICoordinatorWindows_MDMUsesUnderscoreNetrcWhenBothExist(t *testing.T
 	}
 	defer home.Close()
 
-	effective := coordinatorPolicy(`["pip"]`, "sha256:MDM", enforcementMDM)
-	policy, err := ParsePyPIPolicy(effective.Policy, "DEVICE-123")
+	pypiEffective := coordinatorPolicy(`["pip"]`, "sha256:PYPI-MDM", enforcementMDM)
+	pypiPolicy, err := ParsePyPIPolicy(pypiEffective.Policy, "DEVICE-123")
 	if err != nil {
 		t.Fatal(err)
 	}
-	pipExpected, err := renderPipSettings(policy)
+	pipExpected, err := renderPipSettings(pypiPolicy)
 	if err != nil {
 		t.Fatal(err)
 	}
-	credentialExpected := renderNetrcEntry(policy.RegistryHost(), policy.DeviceToken())
-	dotInitial := []byte("machine unrelated.example login user password keep\r\n")
-	underscoreInitial := []byte(mdmNetrcBegin + "\r\n" + strings.ReplaceAll(credentialExpected, "\n", "\r\n") + "\r\n" + mdmNetrcEnd + "\r\n")
+	goEffective := goCoordinatorPolicy("sha256:GO-MDM", enforcementMDM)
+	goPolicy, err := ParseGoPolicy(goEffective.Policy, "DEVICE-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goExpected, err := renderGoEnvSettings(goPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialExpected := renderNetrcEntry(pypiPolicy.RegistryHost(), pypiPolicy.DeviceToken())
+	dotInitial := []byte(mdmNetrcBegin + "\r\n" + strings.ReplaceAll(credentialExpected, "\n", "\r\n") + "\r\n" + mdmNetrcEnd + "\r\n")
+	underscoreInitial := append([]byte(nil), dotInitial...)
 	pipInitial := []byte(mdmPipBegin + "\r\n# [stepsecurity-pypi-pip-mdm] created=true\r\n[global]\r\n" + strings.ReplaceAll(pipExpected, "\n", "\r\n") + "\r\n" + mdmPipEnd + "\r\n")
+	goInitial := []byte(mdmGoEnvBegin + "\r\n" + strings.ReplaceAll(goExpected, "\n", "\r\n") + "\r\n" + goEnvEnd + "\r\n")
 	writeSecure := func(relative, backupPrefix string, data []byte) string {
 		t.Helper()
 		file, err := home.Open(relative, backupPrefix, secureuserfile.MaxBytes)
@@ -68,7 +78,8 @@ func TestPyPICoordinatorWindows_MDMUsesUnderscoreNetrcWhenBothExist(t *testing.T
 	}
 	dotPath := writeSecure(".netrc", netrcBackupPrefix, dotInitial)
 	underscorePath := writeSecure("_netrc", netrcBackupPrefix, underscoreInitial)
-	writeSecure(filepath.Join("AppData", "Roaming", "pip", "pip.ini"), pipBackupPrefix, pipInitial)
+	pipPath := writeSecure(filepath.Join("AppData", "Roaming", "pip", "pip.ini"), pipBackupPrefix, pipInitial)
+	goPath := writeSecure(filepath.Join("AppData", "Roaming", "go", "env"), goEnvBackupPrefix, goInitial)
 
 	type fileSnapshot struct {
 		data       []byte
@@ -95,18 +106,36 @@ func TestPyPICoordinatorWindows_MDMUsesUnderscoreNetrcWhenBothExist(t *testing.T
 	before := map[string]fileSnapshot{
 		dotPath:        snapshot(dotPath),
 		underscorePath: snapshot(underscorePath),
+		pipPath:        snapshot(pipPath),
+		goPath:         snapshot(goPath),
 	}
 
-	reporter := &coordinatorReporter{}
-	coordinator := &PyPICoordinator{
-		Fetcher: &coordinatorFetcher{policy: effective}, Reporter: reporter, Exec: exec,
+	pypiReporter := &coordinatorReporter{}
+	pypiCoordinator := &PyPICoordinator{
+		Fetcher: &coordinatorFetcher{policy: pypiEffective}, Reporter: pypiReporter, Exec: exec,
 		CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
 	}
-	if err := coordinator.Reconcile(context.Background()); err != nil {
+	if err := pypiCoordinator.Reconcile(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if len(reporter.reports) != 1 || reporter.reports[0].State != StateMDMManaged || reporter.reports[0].AppliedHash != "" {
-		t.Fatalf("reports = %+v, want mdm_managed without applied hash", reporter.reports)
+	goReporter := &coordinatorReporter{}
+	goCoordinator := &GoCoordinator{
+		Fetcher: &goCoordinatorFetcher{policy: goEffective}, Reporter: goReporter, Exec: exec,
+		CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+	}
+	if err := goCoordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for name, reports := range map[string][]ComplianceReport{"PyPI": pypiReporter.reports, "Go": goReporter.reports} {
+		if len(reports) != 1 {
+			t.Fatalf("%s reports = %d, want 1", name, len(reports))
+		}
+		if reports[0].State != StateMDMManaged {
+			t.Fatalf("%s state = %q, want %q", name, reports[0].State, StateMDMManaged)
+		}
+		if reports[0].AppliedHash != "" {
+			t.Fatalf("%s applied hash = %q, want empty", name, reports[0].AppliedHash)
+		}
 	}
 	for path, want := range before {
 		got := snapshot(path)
@@ -129,6 +158,113 @@ func TestPyPICoordinatorWindows_MDMUsesUnderscoreNetrcWhenBothExist(t *testing.T
 		return nil
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGoAndPyPICoordinatorsWindows_DMGIgnoresAlternateMDMMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		selected  string
+		alternate string
+		hash      string
+		reconcile func(executor.Executor, *coordinatorReporter) error
+	}{
+		{
+			name:      "PyPI ignores Go MDM marker",
+			selected:  ".netrc",
+			alternate: "_netrc",
+			hash:      "sha256:PYPI-DMG",
+			reconcile: func(exec executor.Executor, reporter *coordinatorReporter) error {
+				coordinator := &PyPICoordinator{
+					Fetcher: &coordinatorFetcher{policy: coordinatorPolicy(`["pip"]`, "sha256:PYPI-DMG", enforcementDMG)}, Reporter: reporter, Exec: exec,
+					CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+				}
+				return coordinator.Reconcile(context.Background())
+			},
+		},
+		{
+			name:      "Go ignores PyPI MDM marker",
+			selected:  "_netrc",
+			alternate: ".netrc",
+			hash:      "sha256:GO-DMG",
+			reconcile: func(exec executor.Executor, reporter *coordinatorReporter) error {
+				coordinator := &GoCoordinator{
+					Fetcher: &goCoordinatorFetcher{policy: goCoordinatorPolicy("sha256:GO-DMG", enforcementDMG)}, Reporter: reporter, Exec: exec,
+					CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+				}
+				return coordinator.Reconcile(context.Background())
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempCache(t)
+			current, err := user.Current()
+			if err != nil {
+				t.Fatal(err)
+			}
+			homeDir := t.TempDir()
+			current.HomeDir = homeDir
+			normalizeSecureTestUser(t, current)
+			mock := executor.NewMock()
+			mock.SetGOOS(model.PlatformWindows)
+			mock.SetUsername(current.Username)
+			mock.SetHomeDir(homeDir)
+			mock.SetEnv("APPDATA", filepath.Join(homeDir, "AppData", "Roaming"))
+			exec := &coordinatorUserExecutor{Mock: mock, user: current}
+			home, err := secureuserfile.OpenUserHome(exec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer home.Close()
+
+			writeSecure := func(name string, data []byte) string {
+				t.Helper()
+				file, err := home.Open(name, netrcBackupPrefix, secureuserfile.MaxBytes)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := home.EnsureParent(name); err != nil {
+					t.Fatal(err)
+				}
+				if err := file.Commit(data, secureuserfile.FileMode); err != nil {
+					t.Fatal(err)
+				}
+				return file.Location()
+			}
+			selectedPath := writeSecure(tc.selected, []byte("machine unrelated.example login user password keep\r\n"))
+			credential := renderNetrcEntry("registry.stepsecurity.io", "tenant-secret::dev:DEVICE-123")
+			alternateInitial := []byte(mdmNetrcBegin + "\r\n" + strings.ReplaceAll(credential, "\n", "\r\n") + "\r\n" + mdmNetrcEnd + "\r\n")
+			alternatePath := writeSecure(tc.alternate, alternateInitial)
+
+			reporter := &coordinatorReporter{}
+			if err := tc.reconcile(exec, reporter); err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(reporter.reports), 1; got != want {
+				t.Fatalf("reports = %d, want %d", got, want)
+			}
+			if got, want := reporter.reports[0].State, StateDriftDetected; got != want {
+				t.Fatalf("state = %q, want %q", got, want)
+			}
+			if got, want := reporter.reports[0].AppliedHash, tc.hash; got != want {
+				t.Fatalf("applied hash = %q, want %q", got, want)
+			}
+			selectedData, err := os.ReadFile(selectedPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(selectedData, []byte(dmgNetrcBegin)) {
+				t.Fatalf("selected file does not contain DMG marker:\n%s", selectedData)
+			}
+			alternateData, err := os.ReadFile(alternatePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(alternateData, alternateInitial) {
+				t.Fatalf("alternate file = %q, want unchanged %q", alternateData, alternateInitial)
+			}
+		})
 	}
 }
 

--- a/internal/devicepolicy/pypi_coordinator_windows_test.go
+++ b/internal/devicepolicy/pypi_coordinator_windows_test.go
@@ -3,16 +3,134 @@
 package devicepolicy
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/model"
 	"github.com/step-security/dev-machine-guard/internal/secureuserfile"
 	"golang.org/x/sys/windows"
 )
+
+func TestPyPICoordinatorWindows_MDMUsesUnderscoreNetrcWhenBothExist(t *testing.T) {
+	withTempCache(t)
+	current, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	homeDir := t.TempDir()
+	current.HomeDir = homeDir
+	normalizeSecureTestUser(t, current)
+	appData := filepath.Join(homeDir, "AppData", "Roaming")
+	mock := executor.NewMock()
+	mock.SetGOOS(model.PlatformWindows)
+	mock.SetUsername(current.Username)
+	mock.SetHomeDir(homeDir)
+	mock.SetEnv("APPDATA", appData)
+	exec := &coordinatorUserExecutor{Mock: mock, user: current}
+	home, err := secureuserfile.OpenUserHome(exec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer home.Close()
+
+	effective := coordinatorPolicy(`["pip"]`, "sha256:MDM", enforcementMDM)
+	policy, err := ParsePyPIPolicy(effective.Policy, "DEVICE-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pipExpected, err := renderPipSettings(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialExpected := renderNetrcEntry(policy.RegistryHost(), policy.DeviceToken())
+	dotInitial := []byte("machine unrelated.example login user password keep\r\n")
+	underscoreInitial := []byte(mdmNetrcBegin + "\r\n" + strings.ReplaceAll(credentialExpected, "\n", "\r\n") + "\r\n" + mdmNetrcEnd + "\r\n")
+	pipInitial := []byte(mdmPipBegin + "\r\n# [stepsecurity-pypi-pip-mdm] created=true\r\n[global]\r\n" + strings.ReplaceAll(pipExpected, "\n", "\r\n") + "\r\n" + mdmPipEnd + "\r\n")
+	writeSecure := func(relative, backupPrefix string, data []byte) string {
+		t.Helper()
+		file, err := home.Open(relative, backupPrefix, secureuserfile.MaxBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := home.EnsureParent(relative); err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Commit(data, secureuserfile.FileMode); err != nil {
+			t.Fatal(err)
+		}
+		return file.Location()
+	}
+	dotPath := writeSecure(".netrc", netrcBackupPrefix, dotInitial)
+	underscorePath := writeSecure("_netrc", netrcBackupPrefix, underscoreInitial)
+	writeSecure(filepath.Join("AppData", "Roaming", "pip", "pip.ini"), pipBackupPrefix, pipInitial)
+
+	type fileSnapshot struct {
+		data       []byte
+		info       os.FileInfo
+		securitySD string
+	}
+	snapshot := func(path string) fileSnapshot {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		descriptor, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT,
+			windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fileSnapshot{data: data, info: info, securitySD: descriptor.String()}
+	}
+	before := map[string]fileSnapshot{
+		dotPath:        snapshot(dotPath),
+		underscorePath: snapshot(underscorePath),
+	}
+
+	reporter := &coordinatorReporter{}
+	coordinator := &PyPICoordinator{
+		Fetcher: &coordinatorFetcher{policy: effective}, Reporter: reporter, Exec: exec,
+		CustomerID: "cust", DeviceID: "DEVICE-123", Platform: model.PlatformWindows,
+	}
+	if err := coordinator.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(reporter.reports) != 1 || reporter.reports[0].State != StateMDMManaged || reporter.reports[0].AppliedHash != "" {
+		t.Fatalf("reports = %+v, want mdm_managed without applied hash", reporter.reports)
+	}
+	for path, want := range before {
+		got := snapshot(path)
+		if !bytes.Equal(got.data, want.data) || !os.SameFile(got.info, want.info) || !got.info.ModTime().Equal(want.info.ModTime()) ||
+			got.info.Mode() != want.info.Mode() || got.securitySD != want.securitySD {
+			t.Fatalf("%s changed during MDM verification", path)
+		}
+	}
+	if _, err := os.Stat(CachePath()); !os.IsNotExist(err) {
+		t.Fatalf("MDM verification state residue: %v", err)
+	}
+	if err := filepath.WalkDir(homeDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := entry.Name()
+		if strings.Contains(name, ".dmg-") || strings.Contains(name, ".install") || strings.Contains(name, ".restore") {
+			t.Fatalf("temporary residue remains at %s", path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestPyPICoordinatorWindowsReclaimsEmptyCredentialLaneAfterWrongOwnerInit(t *testing.T) {
 	withTempCache(t)

--- a/internal/devicepolicy/pypi_coordinator_windows_test.go
+++ b/internal/devicepolicy/pypi_coordinator_windows_test.go
@@ -244,7 +244,7 @@ func TestGoAndPyPICoordinatorsWindows_DMGIgnoresAlternateMDMMarker(t *testing.T)
 			if got, want := len(reporter.reports), 1; got != want {
 				t.Fatalf("reports = %d, want %d", got, want)
 			}
-			if got, want := reporter.reports[0].State, StateDriftDetected; got != want {
+			if got, want := reporter.reports[0].State, StateCompliant; got != want {
 				t.Fatalf("state = %q, want %q", got, want)
 			}
 			if got, want := reporter.reports[0].AppliedHash, tc.hash; got != want {

--- a/internal/devicepolicy/verify.go
+++ b/internal/devicepolicy/verify.go
@@ -39,6 +39,16 @@ const (
 	CategoryPackageConfig = "package_config"
 	TargetNPM             = "npm"
 	TargetPyPI            = "pypi"
+	TargetGo              = "go"
+)
+
+// Go component targets are local ownership identities beneath the public
+// package_config/go policy. They are never used for fetches or reports.
+const (
+	GoCredentialOwnershipTarget = "go-credential" //#nosec G101 -- public ownership target identifier, not a credential.
+	GoEnvOwnershipTarget        = "go-env"
+	GoCredentialOwnershipValue  = "stepsecurity-go-credential" //#nosec G101 -- public ownership marker, not a credential.
+	GoEnvOwnershipValue         = "stepsecurity-go-env"
 )
 
 // PyPI component targets are local ownership identities beneath the public

--- a/internal/executor/user_aware.go
+++ b/internal/executor/user_aware.go
@@ -30,6 +30,9 @@ type UserAwareExecutor struct {
 
 var userEnvironmentKeys = []string{
 	"APPDATA",
+	"GOAUTH",
+	"GOENV",
+	"GOPROXY",
 	"NETRC",
 	"PIP_CONFIG_FILE",
 	"PIP_EXTRA_INDEX_URL",

--- a/internal/executor/user_aware_test.go
+++ b/internal/executor/user_aware_test.go
@@ -137,10 +137,11 @@ func TestUserAwareExecutor_GetenvUsesAllowlistedUserSnapshot(t *testing.T) {
 	inner := &userContextExecutor{
 		Executor: service,
 		runAsUser: func(_ context.Context, _, command string) (string, error) {
-			if !strings.Contains(command, "XDG_CONFIG_HOME") || !strings.Contains(command, "UV_INDEX_URL") {
+			if !strings.Contains(command, "XDG_CONFIG_HOME") || !strings.Contains(command, "UV_INDEX_URL") ||
+				!strings.Contains(command, "GOPROXY") || !strings.Contains(command, "GOENV") || !strings.Contains(command, "GOAUTH") {
 				t.Fatalf("environment snapshot command = %q", command)
 			}
-			return "XDG_CONFIG_HOME=/home/alice/.xdg\x00PIP_EXTRA_INDEX_URL=https://pip-extra.example/simple\x00UV_INDEX_URL=https://user.example/simple\x00UV_NO_INDEX=true\x00", nil
+			return "XDG_CONFIG_HOME=/home/alice/.xdg\x00PIP_EXTRA_INDEX_URL=https://pip-extra.example/simple\x00UV_INDEX_URL=https://user.example/simple\x00UV_NO_INDEX=true\x00GOPROXY=https://proxy.example/go\x00GOENV=off\x00GOAUTH=netrc\x00", nil
 		},
 	}
 	exec := NewUserAwareExecutor(inner, "alice")
@@ -155,6 +156,15 @@ func TestUserAwareExecutor_GetenvUsesAllowlistedUserSnapshot(t *testing.T) {
 	}
 	if got := exec.Getenv("UV_NO_INDEX"); got != "true" {
 		t.Fatalf("UV_NO_INDEX = %q, want resolved user value", got)
+	}
+	if got := exec.Getenv("GOPROXY"); got != "https://proxy.example/go" {
+		t.Fatalf("GOPROXY = %q, want resolved user value", got)
+	}
+	if got := exec.Getenv("GOENV"); got != "off" {
+		t.Fatalf("GOENV = %q, want resolved user value", got)
+	}
+	if got := exec.Getenv("GOAUTH"); got != "netrc" {
+		t.Fatalf("GOAUTH = %q, want resolved user value", got)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

- Adds strict `package_config/go` policy parsing and an isolated Go reconciliation lane.
- Manages the default Go environment file and the credential shared with PyPI using the existing secure file, ownership, rollback, and reporting seams.
- Supports DMG enforcement, MDM verification, reversible clear, drift repair, cross-target credential retention, and platform-specific path handling without executing Go.

## Type of change

- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation

## Testing

- [x] No secrets or credentials included
- [x] Lint passes: `make lint`
- [x] Tests pass: `make test`

Additional validation:

- Focused and full race tests
- `go vet`, `golangci-lint`, `go mod tidy -diff`, formatting, and diff checks
- Linux, macOS, and Windows builds
- Windows test compilation
- Smoke tests: 45/45
- Gosec: unchanged 24 pre-existing findings

Native Windows execution remains pending for CI or VM validation.

## Related Issues

None.
