### PR TITLE
feat(detector): detect Grok Build, Kimi Code, Muse Code, Hermes Agent, Oh My Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ See [SCAN_COVERAGE.md](SCAN_COVERAGE.md) for the full catalog of supported detec
 | Category             | Examples                                                                                 |
 | -------------------- | ---------------------------------------------------------------------------------------- |
 | IDEs & Desktop Apps  | VS Code, Cursor, Windsurf, Antigravity, Zed, Claude, Copilot, JetBrains suite (13 IDEs), Eclipse, Android Studio |
-| AI CLI Tools         | Claude Code, Codex, Gemini CLI, Kiro, GitHub Copilot CLI, Aider, OpenCode, Cursor Agent, Pi, Factory Droid, Amp |
+| AI CLI Tools         | Claude Code, Codex, Gemini CLI, Kiro, GitHub Copilot CLI, Aider, OpenCode, Cursor Agent, Pi, Factory Droid, Amp, Grok Build, Kimi Code, Muse Code, Hermes Agent, Oh My Pi |
 | AI Agents            | Claude Cowork, OpenClaw, ClawdBot, GPT-Engineer                                          |
 | AI Frameworks        | Ollama, LM Studio, LocalAI, Text Generation WebUI                                        |
 | MCP Server Configs   | Claude Desktop, Claude Code, Cursor, Windsurf, Antigravity, Zed, Open Interpreter, Codex, OpenCode |

--- a/SCAN_COVERAGE.md
+++ b/SCAN_COVERAGE.md
@@ -50,10 +50,15 @@ Detection is cross-platform — binaries are located via `$PATH` lookup and home
 | Pi                    | Earendil  | `pi`                        | `~/.pi/agent`                   |
 | Factory Droid         | Factory   | `droid`                     | `~/.factory`                    |
 | Amp                   | Sourcegraph| `amp`                      | `~/.config/amp`                 |
+| Grok Build            | xAI       | `grok`                      | `~/.grok`                       |
+| Kimi Code             | Moonshot  | `kimi`                      | `~/.kimi-code`                  |
+| Muse Code             | Meta      | `muse`                      | `~/.config/muse`                |
+| Hermes Agent          | Nous Research | `hermes`                | `~/AppData/Local/hermes`, `~/.hermes` |
+| Oh My Pi              | Stencil   | `omp`                       | `~/.omp/agent`                  |
 
 † `gh copilot` launches this same `@github/copilot` CLI, downloading it into gh's own data directory when it isn't already on `$PATH` — so that install never lands on `$PATH`. After the two binary names miss, Copilot is also looked for at `~/.local/share/gh/copilot/copilot`, `~/.local/bin/copilot`, `~/AppData/Local/GitHub CLI/copilot/copilot`, `~/AppData/Local/Microsoft/WinGet/Links/copilot.exe`, `~/AppData/Roaming/npm/copilot.cmd`, and the `gh-copilot` extension directory under both `~/.local/share/gh/extensions` and `~/AppData/Local/GitHub CLI/extensions`. A non-default `$XDG_DATA_HOME` is not followed, and WinGet's hashed `Packages\GitHub.Copilot_<hash>\` payload directory is not globbed — only its `Links` shim.
 
-Pi, Factory Droid and Amp share their binary names with unrelated popular tools, so a `$PATH` hit alone does not report them — each is confirmed from an on-disk artifact (a package manifest, an installer anchor directory, a Homebrew cask root, a winget or pacman package entry), and is searched for in the common global-install prefixes as well as on `$PATH`. Pi and Amp are never executed because macOS Gatekeeper prompts on their binaries; their versions come from disk or are reported as `unknown`.
+Pi, Factory Droid, Amp, Grok Build, Kimi Code, Muse Code, Hermes Agent and Oh My Pi share their binary names with unrelated popular tools, so a `$PATH` hit alone does not report them — each is confirmed from an on-disk artifact (a package manifest, an installer anchor directory plus a corroborating sidecar, virtualenv or size floor, a Homebrew Cellar or cask root, a winget or pacman package entry), and is searched for in the common global-install prefixes (including mise's Oh My Pi install tree) as well as on `$PATH`. Of these eight, all but Factory Droid are never executed — macOS Gatekeeper prompts on their binaries — so their versions come from disk (a manifest, a versioned filename, a Python `dist-info` directory name, a Homebrew version segment) or are reported as `unknown`. Every winget-installed one reports `unknown`. No agent's config, auth, session or log files are read.
 
 ## General-Purpose AI Agents
 
@@ -99,7 +104,7 @@ On Windows, `~` refers to the user's home directory (`%USERPROFILE%`). Claude De
 
 ## AI Agent Skills
 
-Dev Machine Guard inventories every installed **agent skill** — a directory containing a `SKILL.md` manifest — across Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot, Pi, Factory, Amp, the cross-agent `~/.agents` convention, and skills installed via [skills.sh](https://skills.sh). It probes each agent's global, system, project, and plugin skill directories; skills.sh lock files add upstream provenance (joined by symlink-resolved path). Detection is pure filesystem reads (no subprocesses), bounded by a 60-second budget and per-root caps.
+Dev Machine Guard inventories every installed **agent skill** — a directory containing a `SKILL.md` manifest — across Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot, Pi, Factory, Amp, Grok Build (`~/.grok/skills`, `.grok/skills`), Kimi Code (`~/.kimi-code/skills`, `.kimi-code/skills`), Muse Code (`~/.config/muse/skills`), Hermes Agent (`~/.hermes/skills` or `%LOCALAPPDATA%\hermes\skills`, `.hermes/skills`), Oh My Pi (`~/.omp/agent/skills`, `~/.omp/agent/managed-skills`, `.omp/skills`), the cross-agent `~/.agents` convention, and skills installed via [skills.sh](https://skills.sh). It probes each agent's global, system, project, and plugin skill directories; skills.sh lock files add upstream provenance (joined by symlink-resolved path). Detection is pure filesystem reads (no subprocesses), bounded by a 60-second budget and per-root caps.
 
 **Privacy: only metadata and a single SHA-256 hash of each `SKILL.md` are collected — no other file is ever read, and file contents are never transmitted.** The file census (counts, sizes, timestamps) comes entirely from directory listings and `stat`. For skills installed from a local path, the on-disk source path is never serialized — only the skill's alias.
 

--- a/internal/detector/aicli.go
+++ b/internal/detector/aicli.go
@@ -219,6 +219,76 @@ var cliToolDefinitions = []cliToolSpec{
 		ResolveFunc:       resolveAmp,
 		StaticVersionOnly: true,
 	},
+	{
+		Name:   "grok-build",
+		Vendor: "xAI",
+		// Anchor first so binary_path reports the installer's own link even when
+		// ~/.local/bin/grok or an npm prefix also resolves to it. `agent` is a
+		// second launcher name Grok installs; it is generic and never searched.
+		Binaries: []string{
+			"~/.grok/bin/grok", "~/.grok/bin/grok.exe",
+			"grok", "~/.local/bin/grok",
+			"~/AppData/Roaming/npm/grok.cmd",
+			"~/AppData/Local/Microsoft/WinGet/Links/grok.exe",
+		},
+		ConfigDirs:        []string{"~/.grok"},
+		ResolveFunc:       resolveGrok,
+		StaticVersionOnly: true,
+	},
+	{
+		Name:   "kimi-code",
+		Vendor: "Moonshot",
+		Binaries: []string{
+			"~/.kimi-code/bin/kimi", "~/.kimi-code/bin/kimi.exe",
+			"kimi", "~/.local/bin/kimi",
+			"/opt/homebrew/opt/kimi-code/bin/kimi", "/usr/local/opt/kimi-code/bin/kimi",
+			"/home/linuxbrew/.linuxbrew/opt/kimi-code/bin/kimi",
+			"~/AppData/Roaming/npm/kimi.cmd",
+			"~/AppData/Local/Microsoft/WinGet/Links/kimi.exe",
+		},
+		ConfigDirs:        []string{"~/.kimi-code"},
+		ResolveFunc:       resolveKimi,
+		StaticVersionOnly: true,
+	},
+	{
+		Name:   "muse-code",
+		Vendor: "Meta",
+		Binaries: []string{
+			"~/.local/bin/muse", "muse",
+			"/opt/homebrew/opt/muse-code/bin/muse", // not created by the cask; harmless
+		},
+		ConfigDirs:        []string{"~/.config/muse"},
+		ResolveFunc:       resolveMuse,
+		StaticVersionOnly: true,
+	},
+	{
+		Name:   "hermes-agent",
+		Vendor: "Nous Research",
+		Binaries: []string{
+			"~/.local/bin/hermes", "/usr/local/bin/hermes", "hermes",
+			"/opt/homebrew/opt/hermes-agent/bin/hermes", "/usr/local/opt/hermes-agent/bin/hermes",
+			"/home/linuxbrew/.linuxbrew/opt/hermes-agent/bin/hermes",
+			"~/AppData/Local/hermes/bin/hermes.exe", "~/AppData/Local/hermes/bin/hermes.cmd",
+		},
+		ConfigDirs:        []string{"~/AppData/Local/hermes", "~/.hermes"},
+		ResolveFunc:       resolveHermes,
+		StaticVersionOnly: true,
+	},
+	{
+		Name:   "oh-my-pi",
+		Vendor: "Stencil",
+		Binaries: []string{
+			"omp", "~/.local/bin/omp", "~/.bun/bin/omp", "~/.bun/bin/omp.exe",
+			"/opt/homebrew/opt/omp/bin/omp", "/usr/local/opt/omp/bin/omp",
+			"/home/linuxbrew/.linuxbrew/opt/omp/bin/omp",
+			"~/AppData/Local/omp/omp.exe",
+			"~/AppData/Roaming/npm/omp.cmd",
+			"~/AppData/Local/Microsoft/WinGet/Links/omp.exe",
+		},
+		ConfigDirs:        []string{"~/.omp/agent"},
+		ResolveFunc:       resolveOMP,
+		StaticVersionOnly: true,
+	},
 }
 
 // AICLIDetector detects AI CLI tools.
@@ -468,7 +538,8 @@ func resolveEnvPath(exec executor.Executor, path string) string {
 }
 
 // ---------------------------------------------------------------------------
-// Shared helpers for the ResolveFunc ladders (pi, factory, amp).
+// Shared helpers for the ResolveFunc ladders (pi, factory, amp here; the
+// wave-2 agents in aicli_agents2.go).
 //
 // Every path manipulation below is separator-agnostic, and that is a
 // correctness requirement rather than tidiness: these ladders run against a
@@ -750,6 +821,10 @@ func aiCLIBinaryCandidateDirs(exec executor.Executor, homeDir string) []string {
 		// all that manager needs. The rest are real install trees, globbed.
 		dirs = append(dirs, globDirs(exec, home(".local", "share", "fnm", "node-versions", "*", "installation", "bin"))...)
 		dirs = append(dirs, globDirs(exec, home(".local", "share", "mise", "installs", "node", "*", "bin"))...)
+		// mise's github backend keeps each Oh My Pi release in its own version
+		// dir with the binary at the root; the shim on PATH resolves to the
+		// mise binary itself, so this is the only way that channel is seen.
+		dirs = append(dirs, globDirs(exec, home(".local", "share", "mise", "installs", "github-can1357-oh-my-pi", "*"))...)
 		dirs = append(dirs, globDirs(exec, home(".volta", "tools", "image", "packages", "*", "bin"))...)
 		dirs = append(dirs, globDirs(exec, home(".volta", "tools", "image", "packages", "*", "*", "bin"))...)
 		dirs = append(dirs, globDirs(exec, home(".asdf", "installs", "nodejs", "*", "bin"))...)

--- a/internal/detector/aicli_agents2.go
+++ b/internal/detector/aicli_agents2.go
@@ -1,0 +1,481 @@
+package detector
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/model"
+	"github.com/step-security/dev-machine-guard/internal/progress"
+	"github.com/step-security/dev-machine-guard/internal/tcc"
+	"github.com/step-security/dev-machine-guard/internal/versionmeta"
+)
+
+// ---------------------------------------------------------------------------
+// Identity ladders for Grok Build, Kimi Code, Muse Code, Hermes Agent and Oh My
+// Pi. Same contract as resolvePi/resolveFactory/resolveAmp: first match wins,
+// nothing is ever executed, every reject is Debug-logged with path and reason,
+// and a state directory (~/.grok, ~/.kimi-code, ~/.hermes, ~/.omp,
+// ~/.config/muse) never accepts a candidate by itself.
+//
+// `grok`, `kimi`, `muse` and `hermes` are all shared binary names — a Homebrew
+// core regex tool, a MIDI sequencer in every Debian archive, unrelated npm and
+// crates.io packages — so a PATH hit proves nothing. Identity comes from an npm
+// manifest, an installer anchor plus a corroborator, a Homebrew root, a winget
+// package directory or a pacman ownership record. The only file reads below
+// are package.json (npmIdentity), .bunx (bunxTarget), pacman `files`
+// manifests (pacmanPackageOwns) and Muse's 14-byte .muse-version sidecar.
+// ---------------------------------------------------------------------------
+
+const (
+	grokPackageName = "@xai-official/grok"
+	kimiPackageName = "@moonshot-ai/kimi-code"
+	ompPackageName  = "@oh-my-pi/pi-coding-agent"
+
+	// kimiMinBinaryBytes is the floor for the Kimi Code installer binary at
+	// ~/.kimi-code/bin/kimi, measured at 151–181 MB across platforms. 64 MiB
+	// leaves 2× headroom below and is what stops a stray script dropped at
+	// that path from counting.
+	kimiMinBinaryBytes int64 = 64 << 20
+
+	// ompMinBinaryBytes is the floor for the Oh My Pi standalone binary,
+	// measured at 135–161 MB. Required on the Homebrew channel too, because a
+	// third-party tap token is attacker-choosable.
+	ompMinBinaryBytes int64 = 64 << 20
+
+	// museVersionMaxBytes caps the .muse-version read. The real sidecar is a
+	// 14-byte version string.
+	museVersionMaxBytes int64 = 64
+)
+
+// museVersionRE is Muse Code's release format: semver plus an -R<build>[.n]
+// suffix, e.g. 1.0.3-R2198.1.
+var museVersionRE = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+-R[0-9]+(\.[0-9]+)?$`)
+
+// kimiLegacyVenvs are the uv-tool and pipx virtualenvs the Python-era Kimi CLI
+// installs into; ~/.local/bin/kimi is a symlink into one of them.
+var kimiLegacyVenvs = []string{
+	"~/.local/share/uv/tools/kimi-cli",
+	"~/.local/share/pipx/venvs/kimi-cli",
+	"~/AppData/Local/uv/tools/kimi-cli",
+	"~/AppData/Local/pipx/venvs/kimi-cli",
+}
+
+// hermesLayouts pairs each installer launcher location with the venv the same
+// installer writes. The launcher is a tiny bash script (not a symlink, so
+// resolved == found) and is never read: the launcher-plus-venv pair is the
+// installer's own signature, and an unrelated ~/.local/bin/hermes with no venv
+// beside it is rejected.
+var hermesLayouts = []struct{ launcher, venv string }{
+	{"~/.local/bin/hermes", "~/.hermes/hermes-agent/venv"},
+	{"/usr/local/bin/hermes", "/usr/local/lib/hermes-agent/venv"},
+	{"~/AppData/Local/hermes/bin", "~/AppData/Local/hermes/hermes-agent/venv"},
+}
+
+// ompMiseRoot is mise's install root for the github:can1357/oh-my-pi backend;
+// each release lives in its own version directory under it. Windows never
+// reaches the mise rule: aiCLIBinaryCandidateDirs globs the tree only on
+// darwin/linux, and the Windows PATH shim resolves to mise.exe.
+const ompMiseRoot = "~/.local/share/mise/installs/github-can1357-oh-my-pi"
+
+// versionFromFilename returns the version token that follows prefix in a
+// versioned binary name — grok-1.0.13, grok-1.0.13-linux-aarch64,
+// grok-1.0.13.exe, muse-bin-1.0.3-R2198.1 — stopping at the first platform
+// token, and "" unless the result is version-shaped (grok-macos-aarch64 is the
+// unversioned bootstrap and yields "").
+func versionFromFilename(base, prefix string) string {
+	if n := len(base) - len(".exe"); n > 0 && strings.EqualFold(base[n:], ".exe") {
+		base = base[:n]
+	}
+	rest, ok := strings.CutPrefix(base, prefix)
+	if !ok {
+		return ""
+	}
+	tokens := strings.Split(rest, "-")
+	end := 0
+	for end < len(tokens) && !isOSToken(tokens[end]) {
+		end++
+	}
+	v := strings.Join(tokens[:end], "-")
+	if !versionmeta.IsVersionLike(v) {
+		return ""
+	}
+	return v
+}
+
+func isOSToken(s string) bool {
+	switch strings.ToLower(s) {
+	case "macos", "darwin", "linux", "windows":
+		return true
+	}
+	return false
+}
+
+// distInfoVersion returns the version of the Python distribution dist installed
+// in venv, read from the NAME of its single <dist>-<v>.dist-info directory —
+// one Glob, nothing opened. "" when the glob finds zero or several matches.
+func distInfoVersion(exec executor.Executor, log *progress.Logger, venv, dist string) string {
+	sitePackages := joinPath(venv, "lib", "python*", "site-packages")
+	if exec.GOOS() == model.PlatformWindows {
+		sitePackages = joinPath(venv, "Lib", "site-packages")
+	}
+	matches, err := exec.Glob(joinPath(sitePackages, dist+"-*.dist-info"))
+	if err != nil || len(matches) != 1 {
+		log.Debug("%s: %d dist-info directories under %s, need exactly one; no dist-info version", dist, len(matches), sitePackages)
+		return ""
+	}
+	v := strings.TrimSuffix(strings.TrimPrefix(pathBase(matches[0]), dist+"-"), ".dist-info")
+	if !versionmeta.IsVersionLike(v) {
+		return ""
+	}
+	return v
+}
+
+// brewKeg returns the Cellar/<formula>/<version> directory enclosing resolved,
+// "" when resolved is not under a Cellar. Homebrew paths are always absolute
+// POSIX paths.
+func brewKeg(resolved string) string {
+	segments := splitPathAny(resolved)
+	for i := 0; i < len(segments)-2; i++ {
+		if segments[i] == "Cellar" {
+			return "/" + strings.Join(segments[:i+3], "/")
+		}
+	}
+	return ""
+}
+
+// grokCopyVersion recovers the version of the Windows ~\.grok\bin\grok.exe,
+// which the installer writes as a COPY of grok-<v>.exe rather than a link. When
+// exactly one versioned sibling exists and is the same size, it is the source
+// of the copy. This is the one place a size equality is correct: it compares a
+// file with its own copy, not with a published artifact.
+func grokCopyVersion(exec executor.Executor, log *progress.Logger, resolved string) string {
+	dir := pathDir(resolved)
+	matches, err := exec.Glob(joinPath(dir, "grok-*.exe"))
+	if err != nil || len(matches) != 1 {
+		log.Debug("grok-build: %d versioned grok-*.exe siblings beside %s, need exactly one; version unknown", len(matches), resolved)
+		return ""
+	}
+	copyInfo, err := exec.Stat(resolved)
+	if err != nil {
+		return ""
+	}
+	srcInfo, err := exec.Stat(matches[0])
+	if err != nil || srcInfo.Size() != copyInfo.Size() {
+		log.Debug("grok-build: %s is not the same size as %s; version unknown", resolved, matches[0])
+		return ""
+	}
+	return versionFromFilename(pathBase(matches[0]), "grok-")
+}
+
+// resolveGrok proves an xAI Grok Build install. The colliders are the unrelated
+// `grok` regex log parser (Homebrew core, Debian, Arch) and cargo crates of the
+// same name; none of them lives under ~/.grok or ships the @xai-official/grok
+// manifest. ~/.grok/config.toml names the installer channel but is never read:
+// the filename rule below already distinguishes the channels that matter.
+func resolveGrok(_ context.Context, exec executor.Executor, log *progress.Logger, skipper *tcc.Skipper, spec cliToolSpec, homeDir string) (cliResolution, bool) {
+	return resolveVerified(exec, log, skipper, spec, homeDir, func(found, resolved string) (string, bool) {
+		// Rule 1 — npm: the Unix trampoline symlink, the Windows grok.cmd
+		// shim and every npm/pnpm/yarn/volta prefix candidatePaths probes.
+		name, version, ok := npmIdentity(exec, found, resolved, grokPackageName)
+		if ok {
+			return version, true
+		}
+
+		// Rule 2 — Grok's own home. ~/.grok/bin/grok links to grok-<v> after
+		// an npm postinstall, to ../downloads/grok-<v>-<os>-<arch> after a
+		// self-update, and to the unversioned grok-<os>-<arch> bootstrap on a
+		// fresh script install (reported unknown). On Windows the .exe is a
+		// copy, so its version comes from the same-size versioned sibling.
+		if underHomeDir(exec, homeDir, resolved, "~/.grok/bin") || underHomeDir(exec, homeDir, resolved, "~/.grok/downloads") {
+			if v := versionFromFilename(pathBase(resolved), "grok-"); v != "" {
+				return v, true
+			}
+			if exec.GOOS() == model.PlatformWindows {
+				return grokCopyVersion(exec, log, resolved), true
+			}
+			return "", true
+		}
+
+		// Rule 3 — winget portable.
+		if exec.GOOS() == model.PlatformWindows && wingetPackage(resolved, "xAI.GrokBuild") {
+			return "", true
+		}
+
+		// Rule 4 — pacman. /usr/bin/grok is the log parser on every distro
+		// unless an AUR grok-build package owns it.
+		if cleanPath(resolved) == "/usr/bin/grok" {
+			if pacmanPackageOwns(exec, []string{"grok-build", "grok-build-bin", "grok-build-git"}, "usr/bin/grok") {
+				return "", true
+			}
+			log.Debug("grok-build: rejecting %s — no installed grok-build package owns usr/bin/grok; the distro `grok` is the unrelated regex log parser", found)
+			return "", false
+		}
+
+		// Rule 5 — reject.
+		if root, pkg := brewRoot(resolved); root == "Cellar" && pkg == "grok" {
+			log.Debug("grok-build: rejecting %s — Homebrew Cellar/grok is the regex log-parser formula, not Grok Build", found)
+			return "", false
+		}
+		if underHomeDir(exec, homeDir, resolved, "~/.cargo") {
+			log.Debug("grok-build: rejecting %s — under ~/.cargo, a cargo-installed grok crate", found)
+			return "", false
+		}
+		if name != "" {
+			log.Debug("grok-build: rejecting %s — npm package is %q, not %s", found, name, grokPackageName)
+		} else {
+			log.Debug("grok-build: rejecting %s — no Grok Build channel claims it (resolved %s)", found, resolved)
+		}
+		return "", false
+	})
+}
+
+// resolveKimi proves a Moonshot Kimi Code install, including the Python-era
+// Kimi CLI it replaced: same vendor, same product line, and the new installer
+// migrates the old one, so both report as kimi-code (the 1.x versus 0.x
+// version tells them apart). The Homebrew cask `kimi` is a desktop app and
+// never produces a `kimi` binary.
+func resolveKimi(_ context.Context, exec executor.Executor, log *progress.Logger, skipper *tcc.Skipper, spec cliToolSpec, homeDir string) (cliResolution, bool) {
+	return resolveVerified(exec, log, skipper, spec, homeDir, func(found, resolved string) (string, bool) {
+		// Rule 1 — npm and the Homebrew formula, whose binary resolves into
+		// Cellar/kimi-code/<v>/libexec/lib/node_modules/@moonshot-ai/kimi-code
+		// and so carries the same manifest.
+		name, version, ok := npmIdentity(exec, found, resolved, kimiPackageName)
+		if ok {
+			return version, true
+		}
+
+		// Rule 2 — the installer anchor, corroborated by the size floor. No
+		// on-disk version source: reported unknown.
+		if underHomeDir(exec, homeDir, resolved, "~/.kimi-code/bin") {
+			if fileAtLeast(exec, found, kimiMinBinaryBytes) {
+				return "", true
+			}
+			log.Debug("kimi-code: rejecting %s — at the installer target but under %d bytes", found, kimiMinBinaryBytes)
+			return "", false
+		}
+
+		// Rule 3 — the legacy Python CLI's uv-tool or pipx venv, which
+		// ~/.local/bin/kimi symlinks into. Version from the dist-info name.
+		for _, venv := range kimiLegacyVenvs {
+			if underHomeDir(exec, homeDir, resolved, venv) {
+				return distInfoVersion(exec, log, expandTildePath(venv, homeDir), "kimi_cli"), true
+			}
+		}
+
+		// Rule 4 — winget portable, both identifiers.
+		if exec.GOOS() == model.PlatformWindows &&
+			(wingetPackage(resolved, "MoonshotAI.KimiCodeCLI") || wingetPackage(resolved, "MoonshotAI.KimiCLI")) {
+			return "", true
+		}
+
+		// Rule 5 — reject.
+		if underHomeDir(exec, homeDir, resolved, "~/.cargo") {
+			log.Debug("kimi-code: rejecting %s — under ~/.cargo, a cargo-installed kimi crate", found)
+			return "", false
+		}
+		if root, pkg := brewRoot(resolved); root == "Cellar" && pkg == "kimi" {
+			log.Debug("kimi-code: rejecting %s — Homebrew Cellar/kimi is not the kimi-code formula", found)
+			return "", false
+		}
+		if name != "" {
+			log.Debug("kimi-code: rejecting %s — npm package is %q, not %s", found, name, kimiPackageName)
+		} else {
+			log.Debug("kimi-code: rejecting %s — no Kimi Code channel claims it (resolved %s)", found, resolved)
+		}
+		return "", false
+	})
+}
+
+// resolveMuse proves a Meta Muse Code install. The launcher is a 33 KB script
+// beside a .muse-version sidecar and the muse-bin-<v> payload it names; the
+// colliders — Debian's MusE MIDI sequencer at /usr/bin/muse, the crates.io
+// `muse` commit-message CLI and the unrelated npm `muse` — have neither.
+func resolveMuse(_ context.Context, exec executor.Executor, log *progress.Logger, skipper *tcc.Skipper, spec cliToolSpec, homeDir string) (cliResolution, bool) {
+	return resolveVerified(exec, log, skipper, spec, homeDir, func(found, resolved string) (string, bool) {
+		// The npm and cargo colliders first: rule 1 probes for siblings in
+		// the resolved directory, and a collider's directory is never probed.
+		if versionmeta.NodeModulesPackageRoot(resolved) != "" {
+			log.Debug("muse-code: rejecting %s — under node_modules; npm `muse` is unrelated and Muse Code has no npm package", found)
+			return "", false
+		}
+		if underHomeDir(exec, homeDir, resolved, "~/.cargo") {
+			log.Debug("muse-code: rejecting %s — under ~/.cargo, the cargo-installed muse commit-message CLI", found)
+			return "", false
+		}
+
+		// Rule 1 — launcher plus sidecar, directory-relative so a relocated
+		// MUSE_INSTALL_DIR on PATH still resolves. The sidecar is read only
+		// under the size cap, and it accepts only when the muse-bin-<v> it
+		// names is actually there. Without a sidecar, a single muse-bin-*
+		// sibling still identifies the install.
+		dir := pathDir(resolved)
+		sidecar := joinPath(dir, ".muse-version")
+		if info, err := exec.Stat(sidecar); err == nil {
+			if info.Size() > museVersionMaxBytes {
+				log.Debug("muse-code: rejecting %s — %s is %d bytes, over the %d-byte cap", found, sidecar, info.Size(), museVersionMaxBytes)
+				return "", false
+			}
+			data, err := exec.ReadFile(sidecar)
+			v := strings.TrimSpace(string(data))
+			if err != nil || int64(len(data)) > museVersionMaxBytes || !museVersionRE.MatchString(v) {
+				log.Debug("muse-code: rejecting %s — %s does not carry a Muse release version", found, sidecar)
+				return "", false
+			}
+			if !exec.FileExists(joinPath(dir, "muse-bin-"+v)) {
+				log.Debug("muse-code: rejecting %s — %s names %s but no muse-bin-%s sits beside it", found, sidecar, v, v)
+				return "", false
+			}
+			return v, true
+		}
+		if bins, err := exec.Glob(joinPath(dir, "muse-bin-*")); err == nil && len(bins) > 0 {
+			if len(bins) == 1 {
+				return versionFromFilename(pathBase(bins[0]), "muse-bin-"), true
+			}
+			log.Debug("muse-code: %d muse-bin-* siblings beside %s and no .muse-version; version unknown", len(bins), found)
+			return "", true
+		}
+
+		// Rule 2 — homebrew/cask muse-code. No version here: getVersion
+		// recovers it from the Caskroom segment, statically.
+		if root, pkg := brewRoot(resolved); root == "Caskroom" && pkg == "muse-code" {
+			return "", true
+		}
+		if root, pkg := brewRoot(resolved); root == "Cellar" && pkg == "muse" {
+			log.Debug("muse-code: rejecting %s — Homebrew Cellar/muse is not the muse-code cask", found)
+			return "", false
+		}
+
+		// Rule 3 — pacman. Ubuntu's and Arch's `muse` package is the MusE
+		// sequencer; only the AUR muse-code packages make /usr/bin/muse ours.
+		if cleanPath(resolved) == "/usr/bin/muse" {
+			if pacmanPackageOwns(exec, []string{"muse-code-bin", "muse-code"}, "usr/bin/muse") {
+				return "", true
+			}
+			log.Debug("muse-code: rejecting %s — no installed muse-code package owns usr/bin/muse; the distro `muse` is the MusE sequencer", found)
+			return "", false
+		}
+
+		// Rule 4 — reject.
+		log.Debug("muse-code: rejecting %s — no Muse Code channel claims it (resolved %s)", found, resolved)
+		return "", false
+	})
+}
+
+// resolveHermes proves a Nous Research Hermes Agent install. The colliders are
+// npm `hermes` and PyPI `hermes`, plus an unofficial npm `hermes-agent`
+// bridge; none of them writes the installer's venv.
+func resolveHermes(_ context.Context, exec executor.Executor, log *progress.Logger, skipper *tcc.Skipper, spec cliToolSpec, homeDir string) (cliResolution, bool) {
+	return resolveVerified(exec, log, skipper, spec, homeDir, func(found, resolved string) (string, bool) {
+		// Rules 1 and 2 — the installer's launcher-plus-venv pairs (user,
+		// root and Windows layouts). The launcher is never read; the venv
+		// directory beside it is the corroborator, and its dist-info name is
+		// the version.
+		for _, layout := range hermesLayouts {
+			if !underHomeDir(exec, homeDir, resolved, layout.launcher) {
+				continue
+			}
+			venv := expandTildePath(layout.venv, homeDir)
+			if exec.DirExists(venv) {
+				return distInfoVersion(exec, log, venv, "hermes_agent"), true
+			}
+			log.Debug("hermes-agent: rejecting %s — the installer launcher is there but %s is not", found, venv)
+			return "", false
+		}
+
+		// Rule 3 — Homebrew formula. The keg's own venv carries the upstream
+		// version (0.21.0, consistent with the other channels); when it is
+		// missing, getVersion falls back to the Cellar segment (2026.8.31).
+		if root, pkg := brewRoot(resolved); root == "Cellar" && pkg == "hermes-agent" {
+			return distInfoVersion(exec, log, joinPath(brewKeg(resolved), "libexec"), "hermes_agent"), true
+		}
+
+		// Rule 4 — reject.
+		if versionmeta.NodeModulesPackageRoot(resolved) != "" {
+			log.Debug("hermes-agent: rejecting %s — under node_modules; npm `hermes` and the unofficial hermes-agent bridge are not the installer", found)
+			return "", false
+		}
+		if underHomeDir(exec, homeDir, resolved, "~/.cargo") {
+			log.Debug("hermes-agent: rejecting %s — under ~/.cargo, a cargo-installed hermes crate", found)
+			return "", false
+		}
+		log.Debug("hermes-agent: rejecting %s — no Hermes Agent channel claims it (resolved %s)", found, resolved)
+		return "", false
+	})
+}
+
+// resolveOMP proves a Stencil Oh My Pi install. `omp` has no popular collider,
+// but the Homebrew tap and the standalone anchors are attacker-choosable
+// paths, so both carry the size floor.
+func resolveOMP(_ context.Context, exec executor.Executor, log *progress.Logger, skipper *tcc.Skipper, spec cliToolSpec, homeDir string) (cliResolution, bool) {
+	return resolveVerified(exec, log, skipper, spec, homeDir, func(found, resolved string) (string, bool) {
+		// Rule 1 — npm, pnpm, yarn, Bun and the Windows .cmd shim (which
+		// names bun.exe as its runner; NPMShimPackageRoot only needs the
+		// node_modules path).
+		name, version, ok := npmIdentity(exec, found, resolved, ompPackageName)
+		if ok {
+			return version, true
+		}
+
+		// Rule 2 — the Windows Bun shim, exactly as resolvePi rule 2b.
+		if exec.GOOS() == model.PlatformWindows {
+			if target := bunxTarget(exec, found, homeDir); target != "" {
+				if _, bunVersion, bunOK := npmIdentity(exec, target, target, ompPackageName); bunOK {
+					return bunVersion, true
+				}
+			}
+		}
+
+		// Rule 3 — Homebrew formula, corroborated by the floor. getVersion
+		// recovers the Cellar segment.
+		if root, pkg := brewRoot(resolved); root == "Cellar" && pkg == "omp" {
+			if fileAtLeast(exec, found, ompMinBinaryBytes) {
+				return "", true
+			}
+			log.Debug("oh-my-pi: rejecting %s — Homebrew Cellar/omp but under %d bytes", found, ompMinBinaryBytes)
+			return "", false
+		}
+
+		// Rule 4 — mise. resolveVerified already followed the shim-free
+		// candidate from aiCLIBinaryCandidateDirs through EvalSymlinks, so an
+		// alias dir (18, 18.1, latest) arrives as its real version dir.
+		if underHomeDir(exec, homeDir, resolved, ompMiseRoot) {
+			return miseVersionSegment(resolved), true
+		}
+
+		// Rule 5 — standalone anchors with the floor; no version on disk.
+		if underHomeDir(exec, homeDir, resolved, "~/.local/bin/omp") || underHomeDir(exec, homeDir, resolved, "~/AppData/Local/omp/omp.exe") {
+			if fileAtLeast(exec, found, ompMinBinaryBytes) {
+				return "", true
+			}
+			log.Debug("oh-my-pi: rejecting %s — at the standalone anchor but under %d bytes", found, ompMinBinaryBytes)
+			return "", false
+		}
+
+		// Rule 6 — winget portable.
+		if exec.GOOS() == model.PlatformWindows && wingetPackage(resolved, "can1357.oh-my-pi") {
+			return "", true
+		}
+
+		// Rule 7 — reject.
+		if name != "" {
+			log.Debug("oh-my-pi: rejecting %s — npm package is %q, not %s", found, name, ompPackageName)
+		} else {
+			log.Debug("oh-my-pi: rejecting %s — no Oh My Pi channel claims it (resolved %s)", found, resolved)
+		}
+		return "", false
+	})
+}
+
+// miseVersionSegment returns the version directory segment that follows the
+// mise install root in resolved, "" when that segment is not version-shaped.
+func miseVersionSegment(resolved string) string {
+	segments := splitPathAny(resolved)
+	for i := 0; i < len(segments)-1; i++ {
+		if segments[i] == "github-can1357-oh-my-pi" && versionmeta.IsVersionLike(segments[i+1]) {
+			return segments[i+1]
+		}
+	}
+	return ""
+}

--- a/internal/detector/aicli_agents2_test.go
+++ b/internal/detector/aicli_agents2_test.go
@@ -1,0 +1,965 @@
+package detector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/step-security/dev-machine-guard/internal/executor"
+	"github.com/step-security/dev-machine-guard/internal/model"
+	"github.com/step-security/dev-machine-guard/internal/progress"
+)
+
+// Cases for the five wave-2 ladders (grok-build, kimi-code, muse-code,
+// hermes-agent, oh-my-pi), on the harness aicli_agents_test.go owns. Every case
+// traps exec: all five specs are StaticVersionOnly, so no channel — accept or
+// reject — may launch anything.
+
+const (
+	kimiRealBytes int64 = 151 << 20 // measured installer binary, low end
+	ompRealBytes  int64 = 135 << 20 // measured standalone binary, low end
+	museVersion         = "1.0.3-R2198.1"
+	hermesVersion       = "0.21.0"
+	ompVersion          = "18.1.10"
+)
+
+// distInfoGlob is the pattern distInfoVersion issues for venv, in the goos
+// spelling — what a case must SetGlob and allow.
+func distInfoGlob(goos, venv, dist string) string {
+	if goos == model.PlatformWindows {
+		return joinPath(venv, "Lib", "site-packages", dist+"-*.dist-info")
+	}
+	return joinPath(venv, "lib", "python*", "site-packages", dist+"-*.dist-info")
+}
+
+// addDistInfo registers exactly one <dist>-<v>.dist-info under venv and returns
+// the pattern the case must allow.
+func addDistInfo(m *executor.Mock, goos, venv, dist, version string) string {
+	pattern := distInfoGlob(goos, venv, dist)
+	m.SetGlob(pattern, []string{joinPath(pathDir(pattern), dist+"-"+version+".dist-info")})
+	return pattern
+}
+
+// addMuseInstall lays down the installer's directory: the launcher script, the
+// .muse-version sidecar and the muse-bin-<v> payload.
+func addMuseInstall(m *executor.Mock, dir, version string) {
+	addFile(m, joinPath(dir, "muse"), []byte("#!/usr/bin/env bash\n"))
+	addFile(m, joinPath(dir, ".muse-version"), []byte(version+"\n"))
+	addBinary(m, joinPath(dir, "muse-bin-"+version), 90<<20)
+}
+
+func TestVersionFromFilename(t *testing.T) {
+	tests := []struct{ base, prefix, want string }{
+		{"grok-1.0.13", "grok-", "1.0.13"},
+		{"grok-1.0.13-linux-aarch64", "grok-", "1.0.13"},
+		{"grok-1.0.13-macos-aarch64", "grok-", "1.0.13"},
+		{"grok-1.0.13.exe", "grok-", "1.0.13"},
+		{"grok-1.0.13-windows-x64.EXE", "grok-", "1.0.13"},
+		{"grok-macos-aarch64", "grok-", ""}, // unversioned bootstrap
+		{"grok", "grok-", ""},
+		{"grok.exe", "grok-", ""},
+		{"muse-bin-1.0.3-R2198.1", "muse-bin-", "1.0.3-R2198.1"},
+		{"muse-bin-", "muse-bin-", ""},
+		{"kimi-1.0.13", "grok-", ""},
+	}
+	for _, tc := range tests {
+		if got := versionFromFilename(tc.base, tc.prefix); got != tc.want {
+			t.Errorf("versionFromFilename(%q, %q) = %q, want %q", tc.base, tc.prefix, got, tc.want)
+		}
+	}
+}
+
+func TestDistInfoVersion(t *testing.T) {
+	venv := "/home/u/.local/share/uv/tools/kimi-cli"
+	pattern := distInfoGlob(model.PlatformLinux, venv, "kimi_cli")
+	sp := pathDir(pattern)
+
+	t.Run("one match yields its version", func(t *testing.T) {
+		m, _ := newAICLIMock(model.PlatformLinux)
+		m.SetGlob(pattern, []string{sp + "/kimi_cli-1.49.0.dist-info"})
+		if got := distInfoVersion(m, progress.NewNoop(), venv, "kimi_cli"); got != "1.49.0" {
+			t.Errorf("got %q, want 1.49.0", got)
+		}
+	})
+	t.Run("two matches yield nothing", func(t *testing.T) {
+		m, _ := newAICLIMock(model.PlatformLinux)
+		m.SetGlob(pattern, []string{sp + "/kimi_cli-1.49.0.dist-info", sp + "/kimi_cli-1.50.0.dist-info"})
+		if got := distInfoVersion(m, progress.NewNoop(), venv, "kimi_cli"); got != "" {
+			t.Errorf("got %q, want \"\"", got)
+		}
+	})
+	t.Run("no match yields nothing and nothing else is touched", func(t *testing.T) {
+		m, _ := newAICLIMock(model.PlatformLinux)
+		rec := &recExec{Mock: m, t: t, trapExec: true}
+		if got := distInfoVersion(rec, progress.NewNoop(), venv, "kimi_cli"); got != "" {
+			t.Errorf("got %q, want \"\"", got)
+		}
+		if len(rec.reads) != 0 || len(rec.globs) != 1 {
+			t.Errorf("reads=%v globs=%v; want no reads and one glob", rec.reads, rec.globs)
+		}
+	})
+	t.Run("windows uses Lib/site-packages", func(t *testing.T) {
+		m, _ := newAICLIMock(model.PlatformWindows)
+		wv := `C:\Users\u\AppData\Local\hermes\hermes-agent\venv`
+		wp := distInfoGlob(model.PlatformWindows, wv, "hermes_agent")
+		m.SetGlob(wp, []string{wv + `\Lib\site-packages\hermes_agent-0.21.0.dist-info`})
+		if got := distInfoVersion(m, progress.NewNoop(), wv, "hermes_agent"); got != "0.21.0" {
+			t.Errorf("got %q, want 0.21.0", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// grok-build
+// ---------------------------------------------------------------------------
+
+func TestAICLIAgents_Grok(t *testing.T) {
+	runAICLICases(t, []aicliCase{
+		{
+			name: "(g1) script install: the bootstrap link carries no version and reports unknown",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, home string) {
+				link := joinPath(home, ".grok", "bin", "grok")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(home, ".grok", "bin", "grok-macos-aarch64"))
+				setConfigDir(m, home, "~/.grok")
+			},
+			want: []aicliWant{{tool: "grok-build", binary: "/Users/u/.grok/bin/grok", version: "unknown", configRel: "~/.grok"}},
+		},
+		{
+			name: "(g2) after npm postinstall the link names its version",
+			setup: func(m *executor.Mock, home string) {
+				link := joinPath(home, ".grok", "bin", "grok")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(home, ".grok", "bin", "grok-1.0.13"))
+			},
+			want: []aicliWant{{tool: "grok-build", binary: "/home/u/.grok/bin/grok", version: "1.0.13"}},
+		},
+		{
+			name: "(g3) after a self-update the link points into downloads with a platform suffix",
+			setup: func(m *executor.Mock, home string) {
+				link := joinPath(home, ".grok", "bin", "grok")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(home, ".grok", "downloads", "grok-1.0.13-linux-aarch64"))
+			},
+			want: []aicliWant{{tool: "grok-build", binary: "/home/u/.grok/bin/grok", version: "1.0.13"}},
+		},
+		{
+			name: "(g4) the npm prefix trampoline accepts from its manifest",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("grok", "/usr/local/bin/grok")
+				addNPMGlobal(m, "/usr/local/bin/grok", "/usr/local/lib/node_modules/@xai-official/grok", grokPackageName, "1.0.13")
+			},
+			want: []aicliWant{{tool: "grok-build", binary: "/usr/local/bin/grok", version: "1.0.13"}},
+		},
+		{
+			name: "(g4a) the anchor wins over a PATH hit that resolves to the same file",
+			setup: func(m *executor.Mock, home string) {
+				link := joinPath(home, ".grok", "bin", "grok")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(home, ".grok", "bin", "grok-1.0.13"))
+				local := joinPath(home, ".local", "bin", "grok")
+				m.SetPath("grok", local)
+				addFile(m, local, []byte{})
+				m.SetSymlink(local, joinPath(home, ".grok", "bin", "grok-1.0.13"))
+			},
+			want: []aicliWant{{tool: "grok-build", binary: "/home/u/.grok/bin/grok", version: "1.0.13"}},
+		},
+		{
+			name: "(g5) /usr/bin/grok owned by an AUR grok-build package accepts",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("grok", "/usr/bin/grok")
+				addFile(m, "/usr/bin/grok", []byte{})
+				m.SetGlob("/var/lib/pacman/local/*-*", []string{"/var/lib/pacman/local/grok-build-bin-1.0.13-1"})
+				addFile(m, "/var/lib/pacman/local/grok-build-bin-1.0.13-1/files", pacmanFiles("usr/bin/grok"))
+			},
+			want: []aicliWant{{tool: "grok-build", binary: "/usr/bin/grok", version: "unknown"}},
+		},
+		{
+			name: "(g5r) /usr/bin/grok owned by the distro grok is the unrelated log parser",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("grok", "/usr/bin/grok")
+				addFile(m, "/usr/bin/grok", []byte{})
+				m.SetGlob("/var/lib/pacman/local/*-*", []string{"/var/lib/pacman/local/grok-1.20.2-1"})
+				addFile(m, "/var/lib/pacman/local/grok-1.20.2-1/files", pacmanFiles("usr/bin/grok"))
+			},
+			wantDebug: []string{"no installed grok-build package owns usr/bin/grok"},
+		},
+		{
+			name: "(g6r) Homebrew Cellar/grok is the regex formula",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("grok", "/opt/homebrew/bin/grok")
+				addFile(m, "/opt/homebrew/bin/grok", []byte{})
+				m.SetSymlink("/opt/homebrew/bin/grok", "/opt/homebrew/Cellar/grok/1.20.2/bin/grok")
+			},
+			wantDebug: []string{"Homebrew Cellar/grok is the regex log-parser formula"},
+		},
+		{
+			name: "(g7r) the cargo grok is rejected",
+			setup: func(m *executor.Mock, home string) {
+				cargo := joinPath(home, ".cargo", "bin", "grok")
+				m.SetPath("grok", cargo)
+				addFile(m, cargo, []byte{})
+			},
+			wantDebug: []string{"under ~/.cargo"},
+		},
+		{
+			name: "(g8r) an npm package of another name is rejected by name",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("grok", "/usr/local/bin/grok")
+				addNPMGlobal(m, "/usr/local/bin/grok", "/usr/local/lib/node_modules/grok", "grok", "0.1.0")
+			},
+			wantDebug: []string{`npm package is "grok", not ` + grokPackageName},
+		},
+		{
+			name: "(g9r) a plain ~/.local/bin/grok script with no corroborator is rejected",
+			setup: func(m *executor.Mock, home string) {
+				addFile(m, joinPath(home, ".local", "bin", "grok"), []byte("#!/bin/sh\n"))
+			},
+			wantDebug: []string{"no Grok Build channel claims it"},
+		},
+		{
+			name: "(g10) ~/.grok and its generic `agent` launcher alone are not an install",
+			setup: func(m *executor.Mock, home string) {
+				setConfigDir(m, home, "~/.grok")
+				addFile(m, joinPath(home, ".grok", "bin", "agent"), []byte{})
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// kimi-code
+// ---------------------------------------------------------------------------
+
+func TestAICLIAgents_Kimi(t *testing.T) {
+	runAICLICases(t, []aicliCase{
+		{
+			name: "(k1) the installer binary at or above the floor accepts with version unknown",
+			setup: func(m *executor.Mock, home string) {
+				addBinary(m, joinPath(home, ".kimi-code", "bin", "kimi"), kimiRealBytes)
+				setConfigDir(m, home, "~/.kimi-code")
+			},
+			want: []aicliWant{{tool: "kimi-code", binary: "/home/u/.kimi-code/bin/kimi", version: "unknown", configRel: "~/.kimi-code"}},
+		},
+		{
+			name: "(k1r) a script at the installer target is under the floor and rejected",
+			setup: func(m *executor.Mock, home string) {
+				addBinary(m, joinPath(home, ".kimi-code", "bin", "kimi"), 40<<10)
+			},
+			wantDebug: []string{"at the installer target but under"},
+		},
+		{
+			name: "(k2) the npm prefix accepts from its manifest",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("kimi", "/usr/local/bin/kimi")
+				addNPMGlobal(m, "/usr/local/bin/kimi", "/usr/local/lib/node_modules/@moonshot-ai/kimi-code", kimiPackageName, "0.12.0")
+			},
+			want: []aicliWant{{tool: "kimi-code", binary: "/usr/local/bin/kimi", version: "0.12.0"}},
+		},
+		{
+			name: "(k3) the Homebrew formula resolves into its libexec node_modules and needs no brew rule",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("kimi", "/opt/homebrew/bin/kimi")
+				addNPMGlobal(m, "/opt/homebrew/bin/kimi",
+					"/opt/homebrew/Cellar/kimi-code/0.12.0/libexec/lib/node_modules/@moonshot-ai/kimi-code", kimiPackageName, "0.12.0")
+			},
+			want: []aicliWant{{tool: "kimi-code", binary: "/opt/homebrew/bin/kimi", version: "0.12.0"}},
+		},
+		{
+			name: "(k3b) an unlinked brew install is reached through the opt anchor",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				addNPMGlobal(m, "/opt/homebrew/opt/kimi-code/bin/kimi",
+					"/opt/homebrew/Cellar/kimi-code/0.12.0/libexec/lib/node_modules/@moonshot-ai/kimi-code", kimiPackageName, "0.12.0")
+			},
+			want: []aicliWant{{tool: "kimi-code", binary: "/opt/homebrew/opt/kimi-code/bin/kimi", version: "0.12.0"}},
+		},
+		{
+			name: "(k4) the legacy uv-tool venv accepts with its dist-info version",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, home string) {
+				venv := joinPath(home, ".local", "share", "uv", "tools", "kimi-cli")
+				link := joinPath(home, ".local", "bin", "kimi")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(venv, "bin", "kimi"))
+				addDistInfo(m, model.PlatformDarwin, venv, "kimi_cli", "1.49.0")
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformDarwin, "/Users/u/.local/share/uv/tools/kimi-cli", "kimi_cli")},
+			want:       []aicliWant{{tool: "kimi-code", binary: "/Users/u/.local/bin/kimi", version: "1.49.0"}},
+		},
+		{
+			name: "(k4b) the pipx venv accepts too; two dist-info dirs degrade to unknown",
+			setup: func(m *executor.Mock, home string) {
+				venv := joinPath(home, ".local", "share", "pipx", "venvs", "kimi-cli")
+				link := joinPath(home, ".local", "bin", "kimi")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(venv, "bin", "kimi"))
+				pattern := distInfoGlob(model.PlatformLinux, venv, "kimi_cli")
+				m.SetGlob(pattern, []string{pathDir(pattern) + "/kimi_cli-1.48.0.dist-info", pathDir(pattern) + "/kimi_cli-1.49.0.dist-info"})
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformLinux, "/home/u/.local/share/pipx/venvs/kimi-cli", "kimi_cli")},
+			want:       []aicliWant{{tool: "kimi-code", binary: "/home/u/.local/bin/kimi", version: "unknown"}},
+			wantDebug:  []string{"2 dist-info directories"},
+		},
+		{
+			name: "(k5r) the cargo kimi is rejected",
+			setup: func(m *executor.Mock, home string) {
+				cargo := joinPath(home, ".cargo", "bin", "kimi")
+				m.SetPath("kimi", cargo)
+				addFile(m, cargo, []byte{})
+			},
+			wantDebug: []string{"under ~/.cargo"},
+		},
+		{
+			name: "(k6r) Homebrew Cellar/kimi is not the kimi-code formula",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("kimi", "/opt/homebrew/bin/kimi")
+				addFile(m, "/opt/homebrew/bin/kimi", []byte{})
+				m.SetSymlink("/opt/homebrew/bin/kimi", "/opt/homebrew/Cellar/kimi/2.0.0/bin/kimi")
+			},
+			wantDebug: []string{"Homebrew Cellar/kimi is not the kimi-code formula"},
+		},
+		{
+			name: "(k7r) a plain ~/.local/bin/kimi script is rejected; ~/.kimi-code alone is not an install",
+			setup: func(m *executor.Mock, home string) {
+				addFile(m, joinPath(home, ".local", "bin", "kimi"), []byte("#!/bin/sh\n"))
+				setConfigDir(m, home, "~/.kimi-code")
+			},
+			wantDebug: []string{"no Kimi Code channel claims it"},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// muse-code
+// ---------------------------------------------------------------------------
+
+func TestAICLIAgents_Muse(t *testing.T) {
+	runAICLICases(t, []aicliCase{
+		{
+			name: "(m1) launcher with sidecar and matching muse-bin accepts with the sidecar version",
+			setup: func(m *executor.Mock, home string) {
+				addMuseInstall(m, joinPath(home, ".local", "bin"), museVersion)
+				setConfigDir(m, home, "~/.config/muse")
+			},
+			want: []aicliWant{{tool: "muse-code", binary: "/home/u/.local/bin/muse", version: museVersion, configRel: "~/.config/muse"}},
+		},
+		{
+			name: "(m1b) a relocated MUSE_INSTALL_DIR on PATH is directory-relative and still accepts",
+			setup: func(m *executor.Mock, _ string) {
+				addMuseInstall(m, "/opt/muse", museVersion)
+				m.SetPath("muse", "/opt/muse/muse")
+			},
+			want: []aicliWant{{tool: "muse-code", binary: "/opt/muse/muse", version: museVersion}},
+		},
+		{
+			name: "(m2r) sidecar without its muse-bin payload is rejected",
+			setup: func(m *executor.Mock, home string) {
+				bin := joinPath(home, ".local", "bin")
+				addFile(m, joinPath(bin, "muse"), []byte("#!/usr/bin/env bash\n"))
+				addFile(m, joinPath(bin, ".muse-version"), []byte(museVersion+"\n"))
+			},
+			wantDebug: []string{"no muse-bin-" + museVersion + " sits beside it"},
+		},
+		{
+			name: "(m2b) a sidecar that is not a Muse release string is rejected",
+			setup: func(m *executor.Mock, home string) {
+				bin := joinPath(home, ".local", "bin")
+				addFile(m, joinPath(bin, "muse"), []byte("#!/usr/bin/env bash\n"))
+				addFile(m, joinPath(bin, ".muse-version"), []byte("1.0.3\n"))
+				addBinary(m, joinPath(bin, "muse-bin-1.0.3"), 90<<20)
+			},
+			wantDebug: []string{"does not carry a Muse release version"},
+		},
+		{
+			name: "(m2c) an oversized sidecar is refused before it is read",
+			setup: func(m *executor.Mock, home string) {
+				bin := joinPath(home, ".local", "bin")
+				addFile(m, joinPath(bin, "muse"), []byte("#!/usr/bin/env bash\n"))
+				addBinary(m, joinPath(bin, ".muse-version"), museVersionMaxBytes+1)
+			},
+			wantDebug: []string{"over the 64-byte cap"},
+		},
+		{
+			name: "(m3) launcher with a single muse-bin and no sidecar accepts from the filename",
+			setup: func(m *executor.Mock, home string) {
+				bin := joinPath(home, ".local", "bin")
+				addFile(m, joinPath(bin, "muse"), []byte("#!/usr/bin/env bash\n"))
+				addBinary(m, joinPath(bin, "muse-bin-"+museVersion), 90<<20)
+				m.SetGlob(joinPath(bin, "muse-bin-*"), []string{joinPath(bin, "muse-bin-"+museVersion)})
+			},
+			allowGlobs: []string{"/home/u/.local/bin/muse-bin-*"},
+			want:       []aicliWant{{tool: "muse-code", binary: "/home/u/.local/bin/muse", version: museVersion}},
+		},
+		{
+			name: "(m3b) two muse-bin payloads and no sidecar accept with version unknown",
+			setup: func(m *executor.Mock, home string) {
+				bin := joinPath(home, ".local", "bin")
+				addFile(m, joinPath(bin, "muse"), []byte("#!/usr/bin/env bash\n"))
+				m.SetGlob(joinPath(bin, "muse-bin-*"), []string{joinPath(bin, "muse-bin-1.0.2-R2040.1"), joinPath(bin, "muse-bin-"+museVersion)})
+			},
+			allowGlobs: []string{"/home/u/.local/bin/muse-bin-*"},
+			want:       []aicliWant{{tool: "muse-code", binary: "/home/u/.local/bin/muse", version: "unknown"}},
+		},
+		{
+			name: "(m4) the homebrew cask accepts and its version comes from the Caskroom segment",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("muse", "/opt/homebrew/bin/muse")
+				addFile(m, "/opt/homebrew/bin/muse", []byte{})
+				m.SetSymlink("/opt/homebrew/bin/muse", "/opt/homebrew/Caskroom/muse-code/1.0.2-R2040.1/muse")
+			},
+			allowGlobs: []string{"/opt/homebrew/Caskroom/muse-code/1.0.2-R2040.1/muse-bin-*"},
+			want:       []aicliWant{{tool: "muse-code", binary: "/opt/homebrew/bin/muse", version: "1.0.2-R2040.1"}},
+		},
+		{
+			name: "(m5) /usr/bin/muse owned by the AUR muse-code-bin accepts",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("muse", "/usr/bin/muse")
+				addFile(m, "/usr/bin/muse", []byte{})
+				m.SetGlob("/var/lib/pacman/local/*-*", []string{"/var/lib/pacman/local/muse-code-bin-1.0.3-1"})
+				addFile(m, "/var/lib/pacman/local/muse-code-bin-1.0.3-1/files", pacmanFiles("usr/bin/muse"))
+			},
+			allowGlobs: []string{"/usr/bin/muse-bin-*"},
+			want:       []aicliWant{{tool: "muse-code", binary: "/usr/bin/muse", version: "unknown"}},
+		},
+		{
+			name: "(m5r) /usr/bin/muse owned by the distro muse is the MusE sequencer",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("muse", "/usr/bin/muse")
+				addFile(m, "/usr/bin/muse", []byte{})
+				m.SetGlob("/var/lib/pacman/local/*-*", []string{"/var/lib/pacman/local/muse-4.2.1-1"})
+				addFile(m, "/var/lib/pacman/local/muse-4.2.1-1/files", pacmanFiles("usr/bin/muse"))
+			},
+			allowGlobs: []string{"/usr/bin/muse-bin-*"},
+			wantDebug:  []string{"the distro `muse` is the MusE sequencer"},
+		},
+		{
+			name: "(m6r) the npm muse is rejected before its directory is probed",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("muse", "/usr/local/bin/muse")
+				addNPMGlobal(m, "/usr/local/bin/muse", "/usr/local/lib/node_modules/muse", "muse", "3.1.0")
+			},
+			noReadPrefix: []string{"/usr/local/lib/node_modules/muse/dist"},
+			wantDebug:    []string{"under node_modules; npm `muse` is unrelated"},
+		},
+		{
+			name: "(m7r) the cargo muse is rejected",
+			setup: func(m *executor.Mock, home string) {
+				cargo := joinPath(home, ".cargo", "bin", "muse")
+				m.SetPath("muse", cargo)
+				addFile(m, cargo, []byte{})
+			},
+			wantDebug: []string{"under ~/.cargo"},
+		},
+		{
+			name: "(m8r) a bare ~/.local/bin/muse with neither sidecar nor payload is rejected",
+			setup: func(m *executor.Mock, home string) {
+				addFile(m, joinPath(home, ".local", "bin", "muse"), []byte("#!/bin/sh\n"))
+				setConfigDir(m, home, "~/.config/muse")
+			},
+			allowGlobs: []string{"/home/u/.local/bin/muse-bin-*"},
+			wantDebug:  []string{"no Muse Code channel claims it"},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// hermes-agent
+// ---------------------------------------------------------------------------
+
+func TestAICLIAgents_Hermes(t *testing.T) {
+	const keg = "/opt/homebrew/Cellar/hermes-agent/2026.8.31"
+	runAICLICases(t, []aicliCase{
+		{
+			name: "(h1) the user launcher with its venv accepts with the dist-info version; the launcher is never read",
+			setup: func(m *executor.Mock, home string) {
+				addFile(m, joinPath(home, ".local", "bin", "hermes"), []byte("#!/bin/bash\nexec ~/.hermes/hermes-agent/venv/bin/hermes \"$@\"\n"))
+				venv := joinPath(home, ".hermes", "hermes-agent", "venv")
+				m.SetDir(venv)
+				addDistInfo(m, model.PlatformLinux, venv, "hermes_agent", hermesVersion)
+				setConfigDir(m, home, "~/.hermes")
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformLinux, "/home/u/.hermes/hermes-agent/venv", "hermes_agent")},
+			want:       []aicliWant{{tool: "hermes-agent", binary: "/home/u/.local/bin/hermes", version: hermesVersion, configRel: "~/.hermes"}},
+		},
+		{
+			name: "(h1r) the same launcher without the venv is rejected",
+			setup: func(m *executor.Mock, home string) {
+				addFile(m, joinPath(home, ".local", "bin", "hermes"), []byte("#!/bin/bash\n"))
+				setConfigDir(m, home, "~/.hermes")
+			},
+			wantDebug: []string{"the installer launcher is there but /home/u/.hermes/hermes-agent/venv is not"},
+		},
+		{
+			name: "(h1v) the venv alone, with no launcher, is not an install",
+			setup: func(m *executor.Mock, home string) {
+				m.SetDir(joinPath(home, ".hermes", "hermes-agent", "venv"))
+				setConfigDir(m, home, "~/.hermes")
+			},
+		},
+		{
+			name: "(h2) the root layout pairs /usr/local/bin/hermes with /usr/local/lib/hermes-agent/venv",
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, "/usr/local/bin/hermes", []byte("#!/bin/bash\n"))
+				m.SetDir("/usr/local/lib/hermes-agent/venv")
+				addDistInfo(m, model.PlatformLinux, "/usr/local/lib/hermes-agent/venv", "hermes_agent", hermesVersion)
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformLinux, "/usr/local/lib/hermes-agent/venv", "hermes_agent")},
+			want:       []aicliWant{{tool: "hermes-agent", binary: "/usr/local/bin/hermes", version: hermesVersion}},
+		},
+		{
+			name: "(h3) the Homebrew keg accepts with the venv's upstream version when its dist-info exists",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("hermes", "/opt/homebrew/bin/hermes")
+				addFile(m, "/opt/homebrew/bin/hermes", []byte{})
+				m.SetSymlink("/opt/homebrew/bin/hermes", keg+"/bin/hermes")
+				addDistInfo(m, model.PlatformDarwin, keg+"/libexec", "hermes_agent", hermesVersion)
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformDarwin, keg+"/libexec", "hermes_agent")},
+			want:       []aicliWant{{tool: "hermes-agent", binary: "/opt/homebrew/bin/hermes", version: hermesVersion}},
+		},
+		{
+			name: "(h3b) without a dist-info the keg falls back to its Cellar version segment",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("hermes", "/opt/homebrew/bin/hermes")
+				addFile(m, "/opt/homebrew/bin/hermes", []byte{})
+				m.SetSymlink("/opt/homebrew/bin/hermes", keg+"/bin/hermes")
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformDarwin, keg+"/libexec", "hermes_agent")},
+			want:       []aicliWant{{tool: "hermes-agent", binary: "/opt/homebrew/bin/hermes", version: "2026.8.31"}},
+		},
+		{
+			name: "(h4r) the npm hermes is rejected",
+			setup: func(m *executor.Mock, home string) {
+				addNPMGlobal(m, joinPath(home, ".local", "bin", "hermes"), joinPath(home, ".local", "lib", "node_modules", "hermes"), "hermes", "0.3.0")
+			},
+			wantDebug: []string{"under node_modules; npm `hermes`"},
+		},
+		{
+			name: "(h5r) the cargo hermes is rejected",
+			setup: func(m *executor.Mock, home string) {
+				cargo := joinPath(home, ".cargo", "bin", "hermes")
+				m.SetPath("hermes", cargo)
+				addFile(m, cargo, []byte{})
+			},
+			wantDebug: []string{"under ~/.cargo"},
+		},
+		{
+			name: "(h6r) a hermes on PATH somewhere else is rejected",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("hermes", "/opt/hermes/hermes")
+				addFile(m, "/opt/hermes/hermes", []byte("#!/bin/sh\n"))
+			},
+			wantDebug: []string{"no Hermes Agent channel claims it"},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// oh-my-pi
+// ---------------------------------------------------------------------------
+
+func TestAICLIAgents_OMP(t *testing.T) {
+	runAICLICases(t, []aicliCase{
+		{
+			name: "(o1) the npm prefix accepts from its manifest",
+			setup: func(m *executor.Mock, home string) {
+				m.SetPath("omp", "/usr/local/bin/omp")
+				addNPMGlobal(m, "/usr/local/bin/omp", "/usr/local/lib/node_modules/@oh-my-pi/pi-coding-agent", ompPackageName, ompVersion)
+				setConfigDir(m, home, "~/.omp/agent")
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: "/usr/local/bin/omp", version: ompVersion, configRel: "~/.omp/agent"}},
+		},
+		{
+			name: "(o1b) the ~/.local/bin npm symlink is an npm channel, not the standalone anchor",
+			setup: func(m *executor.Mock, home string) {
+				addNPMGlobal(m, joinPath(home, ".local", "bin", "omp"), joinPath(home, ".local", "lib", "node_modules", "@oh-my-pi", "pi-coding-agent"), ompPackageName, ompVersion)
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: "/home/u/.local/bin/omp", version: ompVersion}},
+		},
+		{
+			name: "(o2) the Bun global symlink accepts",
+			setup: func(m *executor.Mock, home string) {
+				addNPMGlobal(m, joinPath(home, ".bun", "bin", "omp"), joinPath(home, ".bun", "install", "global", "node_modules", "@oh-my-pi", "pi-coding-agent"), ompPackageName, ompVersion)
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: "/home/u/.bun/bin/omp", version: ompVersion}},
+		},
+		{
+			name: "(o3) the Homebrew formula at or above the floor accepts with the Cellar version",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("omp", "/opt/homebrew/bin/omp")
+				addBinary(m, "/opt/homebrew/bin/omp", ompRealBytes)
+				m.SetSymlink("/opt/homebrew/bin/omp", "/opt/homebrew/Cellar/omp/18.1.10/bin/omp")
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: "/opt/homebrew/bin/omp", version: ompVersion}},
+		},
+		{
+			name: "(o3r) a tap token is attacker-choosable, so a small Cellar/omp is rejected",
+			goos: model.PlatformDarwin,
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("omp", "/opt/homebrew/bin/omp")
+				addBinary(m, "/opt/homebrew/bin/omp", 2<<20)
+				m.SetSymlink("/opt/homebrew/bin/omp", "/opt/homebrew/Cellar/omp/18.1.10/bin/omp")
+			},
+			wantDebug: []string{"Homebrew Cellar/omp but under"},
+		},
+		{
+			name: "(o4) the mise install tree is globbed; the alias dir resolves to the real version dir",
+			setup: func(m *executor.Mock, home string) {
+				root := joinPath(home, ".local", "share", "mise", "installs", "github-can1357-oh-my-pi")
+				real := joinPath(root, ompVersion)
+				alias := joinPath(root, "latest")
+				m.SetGlob(joinPath(root, "*"), []string{real, alias})
+				addBinary(m, joinPath(real, "omp"), ompRealBytes)
+				addFile(m, joinPath(alias, "omp"), []byte{})
+				m.SetSymlink(joinPath(alias, "omp"), joinPath(real, "omp"))
+				// The shim on PATH resolves to mise itself and proves nothing.
+				shim := joinPath(home, ".local", "share", "mise", "shims", "omp")
+				m.SetPath("omp", shim)
+				addFile(m, shim, []byte{})
+				m.SetSymlink(shim, joinPath(home, ".local", "share", "mise", "bin", "mise"))
+			},
+			// globDirs sorts descending, so "latest" is probed before "18.1.10";
+			// its resolved form is the real dir, and the real dir then dedups.
+			want:      []aicliWant{{tool: "oh-my-pi", binary: "/home/u/.local/share/mise/installs/github-can1357-oh-my-pi/latest/omp", version: ompVersion}},
+			wantDebug: []string{"no Oh My Pi channel claims it (resolved /home/u/.local/share/mise/bin/mise)"},
+		},
+		{
+			name: "(o4b) a mise version dir alone accepts with that version",
+			setup: func(m *executor.Mock, home string) {
+				root := joinPath(home, ".local", "share", "mise", "installs", "github-can1357-oh-my-pi")
+				real := joinPath(root, ompVersion)
+				m.SetGlob(joinPath(root, "*"), []string{real})
+				addBinary(m, joinPath(real, "omp"), ompRealBytes)
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: "/home/u/.local/share/mise/installs/github-can1357-oh-my-pi/18.1.10/omp", version: ompVersion}},
+		},
+		{
+			name: "(o5) the standalone ~/.local/bin/omp at or above the floor accepts with version unknown",
+			setup: func(m *executor.Mock, home string) {
+				addBinary(m, joinPath(home, ".local", "bin", "omp"), ompRealBytes)
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: "/home/u/.local/bin/omp", version: "unknown"}},
+		},
+		{
+			name: "(o5r) a script at the standalone anchor is under the floor and rejected",
+			setup: func(m *executor.Mock, home string) {
+				addBinary(m, joinPath(home, ".local", "bin", "omp"), 4<<10)
+				setConfigDir(m, home, "~/.omp/agent")
+			},
+			wantDebug: []string{"at the standalone anchor but under"},
+		},
+		{
+			name: "(o6r) an npm package of another name is rejected by name",
+			setup: func(m *executor.Mock, _ string) {
+				m.SetPath("omp", "/usr/local/bin/omp")
+				addNPMGlobal(m, "/usr/local/bin/omp", "/usr/local/lib/node_modules/omp", "omp", "1.0.0")
+			},
+			wantDebug: []string{`npm package is "omp", not ` + ompPackageName},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Windows-shaped cases
+// ---------------------------------------------------------------------------
+
+func TestAICLIAgents2_Windows(t *testing.T) {
+	npmDir := `C:\Users\u\AppData\Roaming\npm`
+	linksDir := `C:\Users\u\AppData\Local\Microsoft\WinGet\Links`
+	pkgsDir := `C:\Users\u\AppData\Local\Microsoft\WinGet\Packages`
+	grokBin := `C:\Users\u\.grok\bin`
+	hermesVenv := `C:\Users\u\AppData\Local\hermes\hermes-agent\venv`
+
+	runAICLICases(t, []aicliCase{
+		{
+			name: "(w1) the grok.cmd npm shim accepts",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, npmDir+`\grok.cmd`, winNPMShim(`node_modules\@xai-official\grok\dist\cli.js`))
+				addManifest(m, npmDir+`\node_modules\@xai-official\grok`, grokPackageName, "1.0.13")
+			},
+			want: []aicliWant{{tool: "grok-build", binary: npmDir + `\grok.cmd`, version: "1.0.13"}},
+		},
+		{
+			name: "(w2) the home copy takes its version from the single same-size versioned sibling",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, home string) {
+				addBinary(m, grokBin+`\grok.exe`, 95_000_000)
+				addBinary(m, grokBin+`\grok-1.0.13.exe`, 95_000_000)
+				m.SetGlob(grokBin+`\grok-*.exe`, []string{grokBin + `\grok-1.0.13.exe`})
+				setConfigDir(m, home, "~/.grok")
+			},
+			allowGlobs: []string{grokBin + `\grok-*.exe`},
+			want:       []aicliWant{{tool: "grok-build", binary: grokBin + `\grok.exe`, version: "1.0.13", configRel: "~/.grok"}},
+		},
+		{
+			name: "(w2b) two versioned siblings leave the copy's version unknown",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addBinary(m, grokBin+`\grok.exe`, 95_000_000)
+				addBinary(m, grokBin+`\grok-1.0.12.exe`, 94_000_000)
+				addBinary(m, grokBin+`\grok-1.0.13.exe`, 95_000_000)
+				m.SetGlob(grokBin+`\grok-*.exe`, []string{grokBin + `\grok-1.0.12.exe`, grokBin + `\grok-1.0.13.exe`})
+			},
+			allowGlobs: []string{grokBin + `\grok-*.exe`},
+			want:       []aicliWant{{tool: "grok-build", binary: grokBin + `\grok.exe`, version: "unknown"}},
+			wantDebug:  []string{"2 versioned grok-*.exe siblings"},
+		},
+		{
+			name: "(w2c) a single sibling of a different size is not the copy's source",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addBinary(m, grokBin+`\grok.exe`, 95_000_000)
+				addBinary(m, grokBin+`\grok-1.0.13.exe`, 94_000_000)
+				m.SetGlob(grokBin+`\grok-*.exe`, []string{grokBin + `\grok-1.0.13.exe`})
+			},
+			allowGlobs: []string{grokBin + `\grok-*.exe`},
+			want:       []aicliWant{{tool: "grok-build", binary: grokBin + `\grok.exe`, version: "unknown"}},
+			wantDebug:  []string{"is not the same size as"},
+		},
+		{
+			name: "(w3) winget Grok Build accepts through the Links shim",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, linksDir+`\grok.exe`, []byte{})
+				m.SetSymlink(linksDir+`\grok.exe`, pkgsDir+`\xAI.GrokBuild_Microsoft.Winget.Source_8wekyb3d8bbwe\grok.exe`)
+			},
+			want: []aicliWant{{tool: "grok-build", binary: linksDir + `\grok.exe`, version: "unknown"}},
+		},
+		{
+			name: "(w4) the Kimi installer .exe at or above the floor accepts",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, home string) {
+				addBinary(m, `C:\Users\u\.kimi-code\bin\kimi.exe`, kimiRealBytes)
+				setConfigDir(m, home, "~/.kimi-code")
+			},
+			want: []aicliWant{{tool: "kimi-code", binary: `C:\Users\u\.kimi-code\bin\kimi.exe`, version: "unknown", configRel: "~/.kimi-code"}},
+		},
+		{
+			name: "(w5) winget Kimi accepts under either identifier",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, linksDir+`\kimi.exe`, []byte{})
+				m.SetSymlink(linksDir+`\kimi.exe`, pkgsDir+`\MoonshotAI.KimiCLI_Microsoft.Winget.Source_8wekyb3d8bbwe\kimi.exe`)
+			},
+			want: []aicliWant{{tool: "kimi-code", binary: linksDir + `\kimi.exe`, version: "unknown"}},
+		},
+		{
+			name: "(w5b) the newer winget identifier too",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, linksDir+`\kimi.exe`, []byte{})
+				m.SetSymlink(linksDir+`\kimi.exe`, pkgsDir+`\MoonshotAI.KimiCodeCLI_Microsoft.Winget.Source_8wekyb3d8bbwe\kimi.exe`)
+			},
+			want: []aicliWant{{tool: "kimi-code", binary: linksDir + `\kimi.exe`, version: "unknown"}},
+		},
+		{
+			name: "(w5r) another publisher's kimi in WinGet is rejected",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, linksDir+`\kimi.exe`, []byte{})
+				m.SetSymlink(linksDir+`\kimi.exe`, pkgsDir+`\SomeoneElse.Kimi_Microsoft.Winget.Source_8wekyb3d8bbwe\kimi.exe`)
+			},
+			wantDebug: []string{"no Kimi Code channel claims it"},
+		},
+		{
+			name: "(w6) the legacy Kimi CLI's uv venv under %LOCALAPPDATA% reads Lib\\site-packages",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, home string) {
+				venv := joinPath(home, "AppData", "Local", "uv", "tools", "kimi-cli")
+				addFile(m, npmDir+`\kimi.cmd`, []byte("@echo off\r\n"))
+				m.SetSymlink(npmDir+`\kimi.cmd`, venv+`\Scripts\kimi.exe`)
+				addDistInfo(m, model.PlatformWindows, venv, "kimi_cli", "1.49.0")
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformWindows, `C:\Users\u\AppData\Local\uv\tools\kimi-cli`, "kimi_cli")},
+			want:       []aicliWant{{tool: "kimi-code", binary: npmDir + `\kimi.cmd`, version: "1.49.0"}},
+		},
+		{
+			name: "(w7) hermes.exe with the %LOCALAPPDATA% venv accepts",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, home string) {
+				addFile(m, `C:\Users\u\AppData\Local\hermes\bin\hermes.exe`, []byte{})
+				m.SetDir(hermesVenv)
+				addDistInfo(m, model.PlatformWindows, hermesVenv, "hermes_agent", hermesVersion)
+				setConfigDir(m, home, "~/AppData/Local/hermes")
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformWindows, hermesVenv, "hermes_agent")},
+			want: []aicliWant{{
+				tool: "hermes-agent", binary: `C:\Users\u\AppData\Local\hermes\bin\hermes.exe`,
+				version: hermesVersion, configRel: "~/AppData/Local/hermes",
+			}},
+		},
+		{
+			name: "(w7b) the hermes.cmd variant accepts too",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, `C:\Users\u\AppData\Local\hermes\bin\hermes.cmd`, []byte("@echo off\r\n"))
+				m.SetDir(hermesVenv)
+				addDistInfo(m, model.PlatformWindows, hermesVenv, "hermes_agent", hermesVersion)
+			},
+			allowGlobs: []string{distInfoGlob(model.PlatformWindows, hermesVenv, "hermes_agent")},
+			want:       []aicliWant{{tool: "hermes-agent", binary: `C:\Users\u\AppData\Local\hermes\bin\hermes.cmd`, version: hermesVersion}},
+		},
+		{
+			name: "(w7r) hermes.exe without the venv is rejected",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, `C:\Users\u\AppData\Local\hermes\bin\hermes.exe`, []byte{})
+			},
+			wantDebug: []string{"the installer launcher is there but " + hermesVenv + " is not"},
+		},
+		{
+			name: "(w8) the omp.cmd npm shim accepts even though its runner is bun.exe",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, npmDir+`\omp.cmd`, []byte("@ECHO off\r\n\"%dp0%\\bun.exe\" \"%dp0%\\node_modules\\@oh-my-pi\\pi-coding-agent\\dist\\cli.js\" %*\r\n"))
+				addManifest(m, npmDir+`\node_modules\@oh-my-pi\pi-coding-agent`, ompPackageName, ompVersion)
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: npmDir + `\omp.cmd`, version: ompVersion}},
+		},
+		{
+			name: "(w9) the Bun .exe is identified through its .bunx pointer",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, home string) {
+				bunBin := joinPath(home, ".bun", "bin")
+				pkgRoot := joinPath(home, ".bun", "install", "global", "node_modules", "@oh-my-pi", "pi-coding-agent")
+				addFile(m, bunBin+`\omp.exe`, []byte{})
+				addFile(m, bunBin+`\omp.bunx`, utf16LE(pkgRoot+`\dist\cli.js`))
+				addManifest(m, pkgRoot, ompPackageName, ompVersion)
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: `C:\Users\u\.bun\bin\omp.exe`, version: ompVersion}},
+		},
+		{
+			name: "(w10) the standalone %LOCALAPPDATA%\\omp\\omp.exe at or above the floor accepts",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, home string) {
+				addBinary(m, `C:\Users\u\AppData\Local\omp\omp.exe`, ompRealBytes)
+				setConfigDir(m, home, "~/.omp/agent")
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: `C:\Users\u\AppData\Local\omp\omp.exe`, version: "unknown", configRel: "~/.omp/agent"}},
+		},
+		{
+			name: "(w11) winget Oh My Pi accepts",
+			goos: model.PlatformWindows,
+			setup: func(m *executor.Mock, _ string) {
+				addFile(m, linksDir+`\omp.exe`, []byte{})
+				m.SetSymlink(linksDir+`\omp.exe`, pkgsDir+`\can1357.oh-my-pi_Microsoft.Winget.Source_8wekyb3d8bbwe\omp.exe`)
+			},
+			want: []aicliWant{{tool: "oh-my-pi", binary: linksDir + `\omp.exe`, version: "unknown"}},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TCC guard: one decoy per new binary name under ~/Documents, and a symlink from
+// an accepted anchor into ~/Downloads. Each decoy satisfies an accept rule, so a
+// green reject is the guard firing and not a ladder miss.
+// ---------------------------------------------------------------------------
+
+func TestAICLIAgents2_TCCGuard(t *testing.T) {
+	requireDarwinHost(t)
+	docs := "/Users/u/Documents"
+
+	decoys := []struct {
+		bin   string
+		setup func(m *executor.Mock, home, dir string)
+	}{
+		{"grok", func(m *executor.Mock, _, dir string) {
+			addNPMGlobal(m, dir+"/grok", dir+"/node_modules/@xai-official/grok", grokPackageName, "1.0.13")
+		}},
+		{"kimi", func(m *executor.Mock, _, dir string) {
+			addNPMGlobal(m, dir+"/kimi", dir+"/node_modules/@moonshot-ai/kimi-code", kimiPackageName, "0.12.0")
+		}},
+		{"muse", func(m *executor.Mock, _, dir string) {
+			addMuseInstall(m, dir, museVersion)
+		}},
+		{"hermes", func(m *executor.Mock, _, dir string) {
+			addFile(m, dir+"/hermes", []byte("#!/bin/bash\n"))
+		}},
+		{"omp", func(m *executor.Mock, _, dir string) {
+			addNPMGlobal(m, dir+"/omp", dir+"/node_modules/@oh-my-pi/pi-coding-agent", ompPackageName, ompVersion)
+		}},
+	}
+	for _, d := range decoys {
+		t.Run("~/Documents/bin/"+d.bin+" on PATH is never touched", func(t *testing.T) {
+			runAICLICase(t, aicliCase{
+				name:    d.bin,
+				goos:    model.PlatformDarwin,
+				skipper: true,
+				setup: func(m *executor.Mock, home string) {
+					dir := joinPath(home, "Documents", "bin")
+					m.SetPath(d.bin, dir+"/"+d.bin)
+					d.setup(m, home, dir)
+				},
+				noReadPrefix: []string{docs},
+				wantDebug:    []string{"under a macOS TCC-protected path"},
+			})
+		})
+	}
+
+	t.Run("~/.local/bin/muse -> ~/Downloads/muse is rejected before its sidecar is read", func(t *testing.T) {
+		runAICLICase(t, aicliCase{
+			name:    "symlink into Downloads",
+			goos:    model.PlatformDarwin,
+			skipper: true,
+			setup: func(m *executor.Mock, home string) {
+				addMuseInstall(m, joinPath(home, "Downloads"), museVersion)
+				link := joinPath(home, ".local", "bin", "muse")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(home, "Downloads", "muse"))
+			},
+			noReadPrefix: []string{"/Users/u/Downloads"},
+			wantDebug:    []string{"under a macOS TCC-protected path"},
+		})
+	})
+
+	t.Run("~/.local/bin/grok -> ~/Downloads/grok-1.0.13 is rejected; the same link into ~/.grok accepts", func(t *testing.T) {
+		runAICLICase(t, aicliCase{
+			name:    "grok symlink into Downloads",
+			goos:    model.PlatformDarwin,
+			skipper: true,
+			setup: func(m *executor.Mock, home string) {
+				link := joinPath(home, ".local", "bin", "grok")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(home, "Downloads", "grok-1.0.13"))
+			},
+			noReadPrefix: []string{"/Users/u/Downloads"},
+			wantDebug:    []string{"under a macOS TCC-protected path"},
+		})
+		runAICLICase(t, aicliCase{
+			name:    "grok symlink into ~/.grok",
+			goos:    model.PlatformDarwin,
+			skipper: true,
+			setup: func(m *executor.Mock, home string) {
+				link := joinPath(home, ".local", "bin", "grok")
+				addFile(m, link, []byte{})
+				m.SetSymlink(link, joinPath(home, ".grok", "bin", "grok-1.0.13"))
+			},
+			want: []aicliWant{{tool: "grok-build", binary: "/Users/u/.local/bin/grok", version: "1.0.13"}},
+		})
+	})
+}
+
+// TestAICLIAgents2_EmptyFixture: the five new specs produce nothing on the empty
+// fixture on every platform, and nothing is read outside the candidate probes.
+func TestAICLIAgents2_EmptyFixture(t *testing.T) {
+	for _, goos := range []string{model.PlatformLinux, model.PlatformDarwin, model.PlatformWindows} {
+		t.Run(goos, func(t *testing.T) {
+			m, _ := newAICLIMock(goos)
+			rec := &recExec{Mock: m, t: t, trapExec: true}
+			var tools []model.AITool
+			captureStderr(t, func() { tools = NewAICLIDetector(rec).Detect(context.Background()) })
+			if len(tools) != 0 {
+				t.Errorf("empty fixture: got %d rows, want 0; %+v", len(tools), tools)
+			}
+		})
+	}
+}

--- a/internal/detector/aicli_agents_test.go
+++ b/internal/detector/aicli_agents_test.go
@@ -252,7 +252,7 @@ func captureStderr(t *testing.T, fn func()) (out string) {
 // aicliNewSpecs are the specs this file owns. Every case asserts one row for
 // each spec it names in want and ZERO rows for the others, so a fixture built
 // for one agent cannot quietly start reporting another.
-var aicliNewSpecs = []string{"pi", "factory", "amp"}
+var aicliNewSpecs = []string{"pi", "factory", "amp", "grok-build", "kimi-code", "muse-code", "hermes-agent", "oh-my-pi"}
 
 type aicliWant struct {
 	tool      string
@@ -280,6 +280,10 @@ type aicliCase struct {
 	noLookup     []string // no LookPath name may contain these
 	wantDebug    []string
 	noDebug      []string
+	// allowGlobs are the fixture-specific patterns this case may glob on top
+	// of aicliAllowedGlobs: a sibling probe beside an accepted anchor
+	// (grok-*.exe, muse-bin-*) or a venv's dist-info directory.
+	allowGlobs []string
 }
 
 func findAITool(tools []model.AITool, name string) *model.AITool {
@@ -319,6 +323,7 @@ func aicliAllowedGlobs(home, goos string) map[string]bool {
 	allowed[filepath.Join(home, ".nvm", "versions", "node", "*", "bin")] = true
 	allowed[joinPath(home, ".local", "share", "fnm", "node-versions", "*", "installation", "bin")] = true
 	allowed[joinPath(home, ".local", "share", "mise", "installs", "node", "*", "bin")] = true
+	allowed[joinPath(home, ".local", "share", "mise", "installs", "github-can1357-oh-my-pi", "*")] = true
 	allowed[joinPath(home, ".volta", "tools", "image", "packages", "*", "bin")] = true
 	allowed[joinPath(home, ".volta", "tools", "image", "packages", "*", "*", "bin")] = true
 	allowed[joinPath(home, ".asdf", "installs", "nodejs", "*", "bin")] = true
@@ -415,6 +420,9 @@ func runAICLICase(t *testing.T, tc aicliCase) {
 	}
 
 	allowed := aicliAllowedGlobs(home, goos)
+	for _, pattern := range tc.allowGlobs {
+		allowed[pattern] = true
+	}
 	for _, pattern := range rec.globs {
 		if !allowed[pattern] {
 			t.Errorf("unexpected Glob(%q); the ladders may only glob the targeted install trees", pattern)
@@ -1510,10 +1518,11 @@ func TestAICLIAgents_NoWalkAndGlobBudget(t *testing.T) {
 		wantDistinct   int
 		wantTotalGlobs int
 	}{
-		{model.PlatformLinux, 6, 18},
-		{model.PlatformDarwin, 7, 21},
-		{model.PlatformWindows, 2, 6},
+		{model.PlatformLinux, 7, 56},
+		{model.PlatformDarwin, 8, 64},
+		{model.PlatformWindows, 2, 16},
 	}
+	resolvers := len(aicliNewSpecs)
 	for _, tc := range tests {
 		t.Run(tc.goos, func(t *testing.T) {
 			m, home := newAICLIMock(tc.goos)
@@ -1537,8 +1546,8 @@ func TestAICLIAgents_NoWalkAndGlobBudget(t *testing.T) {
 				t.Errorf("distinct patterns: got %d (%v), want %d", len(counts), counts, tc.wantDistinct)
 			}
 			for pattern, n := range counts {
-				if n != 3 {
-					t.Errorf("Glob(%q) called %d times, want 3 (once per resolver)", pattern, n)
+				if n != resolvers {
+					t.Errorf("Glob(%q) called %d times, want %d (once per resolver)", pattern, n, resolvers)
 				}
 			}
 		})

--- a/internal/detector/skills.go
+++ b/internal/detector/skills.go
@@ -324,6 +324,27 @@ func (d *SkillsDetector) resolveGlobalRoots(info *model.AgentSkillScanInfo) []sk
 	// project-level .agent/skills is factory_agent_project.
 	add(filepath.Join(home, ".agent", "skills"), "factory_agent_user", "factory", "global", "")
 
+	// grok_user / kimi_user / muse_user: each agent's own global root. All
+	// three also read ~/.agents/skills, which stays attributed to agents_user.
+	add(filepath.Join(home, ".grok", "skills"), "grok_user", "grok-build", "global", "")
+	add(filepath.Join(home, ".kimi-code", "skills"), "kimi_user", "kimi-code", "global", "")
+	add(filepath.Join(home, ".config", "muse", "skills"), "muse_user", "muse-code", "global", "")
+
+	// hermes_user: ~/.hermes/skills holds the bundled skills the installer
+	// copies, nested one category deep (<category>/<skill>/SKILL.md), plus
+	// .bundled_manifest and .hub/ metadata that enumerateRoot ignores. Windows
+	// keeps HERMES_HOME under %LOCALAPPDATA%.
+	if win {
+		add(resolveEnvPath(d.exec, `%LOCALAPPDATA%\hermes\skills`), "hermes_user", "hermes-agent", "global", "")
+	} else {
+		add(filepath.Join(home, ".hermes", "skills"), "hermes_user", "hermes-agent", "global", "")
+	}
+
+	// omp_user / omp_managed_user: Oh My Pi's user skills and the managed
+	// skills it syncs, both under its ~/.omp/agent root.
+	add(filepath.Join(home, ".omp", "agent", "skills"), "omp_user", "oh-my-pi", "global", "")
+	add(filepath.Join(home, ".omp", "agent", "managed-skills"), "omp_managed_user", "oh-my-pi", "global", "")
+
 	return roots
 }
 
@@ -357,6 +378,10 @@ func (d *SkillsDetector) resolveProjectRoots(project string, info *model.AgentSk
 	add([]string{".github", "skills"}, "github_project", "copilot")       // only .github/skills, never the rest of .github
 	add([]string{".gemini", "skills"}, "gemini_project", "gemini-cli")
 	add([]string{".aider", "skills"}, "aider_project", "aider") // community convention: loaded manually, but on-disk state is inventoried
+	add([]string{".grok", "skills"}, "grok_project", "grok-build")
+	add([]string{".kimi-code", "skills"}, "kimi_project", "kimi-code")
+	add([]string{".hermes", "skills"}, "hermes_project", "hermes-agent")
+	add([]string{".omp", "skills"}, "omp_project", "oh-my-pi") // Muse has no agent-specific project root; it reads .agents/.codex/.claude
 	return roots
 }
 
@@ -367,16 +392,20 @@ func (d *SkillsDetector) resolveProjectRoots(project string, info *model.AgentSk
 // table is how walkForProjectRoots recognizes a project it was never told about.
 // A change to one MUST change the other.
 var projectMarkerDirs = map[string][]string{
-	".claude":   {"skills"},
-	".agents":   {"skills"},
-	".opencode": {"skills", "skill"}, // both spellings, same as resolveProjectRoots
-	".cursor":   {"skills"},
-	".pi":       {"skills"},
-	".factory":  {"skills"},
-	".agent":    {"skills"}, // singular — Factory legacy, distinct from .agents
-	".github":   {"skills"}, // only .github/skills, never the rest of .github
-	".gemini":   {"skills"}, // Gemini CLI workspace skills
-	".aider":    {"skills"}, // Aider community convention (skills loaded manually)
+	".claude":    {"skills"},
+	".agents":    {"skills"},
+	".opencode":  {"skills", "skill"}, // both spellings, same as resolveProjectRoots
+	".cursor":    {"skills"},
+	".pi":        {"skills"},
+	".factory":   {"skills"},
+	".agent":     {"skills"}, // singular — Factory legacy, distinct from .agents
+	".github":    {"skills"}, // only .github/skills, never the rest of .github
+	".gemini":    {"skills"}, // Gemini CLI workspace skills
+	".aider":     {"skills"}, // Aider community convention (skills loaded manually)
+	".grok":      {"skills"},
+	".kimi-code": {"skills"},
+	".hermes":    {"skills"},
+	".omp":       {"skills"},
 }
 
 // walkForProjectRoots sweeps each search dir for projectMarkerDirs and returns

--- a/internal/detector/skills_homewalk_test.go
+++ b/internal/detector/skills_homewalk_test.go
@@ -58,6 +58,10 @@ func TestDetect_HomeWalkMarkerConventions(t *testing.T) {
 		{".github", "skills", "github_project", "copilot"},
 		{".gemini", "skills", "gemini_project", "gemini-cli"},
 		{".aider", "skills", "aider_project", "aider"},
+		{".grok", "skills", "grok_project", "grok-build"},
+		{".kimi-code", "skills", "kimi_project", "kimi-code"},
+		{".hermes", "skills", "hermes_project", "hermes-agent"},
+		{".omp", "skills", "omp_project", "oh-my-pi"},
 	}
 	for _, c := range cases {
 		t.Run(c.markerDir+"/"+c.child, func(t *testing.T) {

--- a/internal/detector/skills_test.go
+++ b/internal/detector/skills_test.go
@@ -1227,6 +1227,12 @@ func TestDetect_NewAgentGlobalSources(t *testing.T) {
 		{testHome + "/.factory/skills/facg", "factory_user", "factory"},
 		{testHome + "/.config/agents/skills/ampg", "amp_user", "amp"},
 		{testHome + "/.copilot/skills/copg", "copilot_user", "copilot"},
+		{testHome + "/.grok/skills/grokg", "grok_user", "grok-build"},
+		{testHome + "/.kimi-code/skills/kimig", "kimi_user", "kimi-code"},
+		{testHome + "/.config/muse/skills/museg", "muse_user", "muse-code"},
+		{testHome + "/.hermes/skills/hermg", "hermes_user", "hermes-agent"},
+		{testHome + "/.omp/agent/skills/ompg", "omp_user", "oh-my-pi"},
+		{testHome + "/.omp/agent/managed-skills/ompm", "omp_managed_user", "oh-my-pi"},
 	}
 	m, fs := newSkillsMock()
 	for _, c := range cases {
@@ -1248,12 +1254,39 @@ func TestDetect_NewAgentGlobalSources(t *testing.T) {
 	}
 }
 
+// TestDetect_HermesUserNestedLayout pins Hermes's bundled layout: skills sit one
+// category deep (<category>/<skill>/SKILL.md) beside .bundled_manifest and .hub/
+// metadata, so root_rel_path is two levels and the dot-entries are ignored.
+func TestDetect_HermesUserNestedLayout(t *testing.T) {
+	m, fs := newSkillsMock()
+	fs.addSkill(testHome+"/.hermes/skills/apple/apple-reminders", "SKILL.md", validFrontmatter("apple-reminders", "d"), nil)
+	fs.addFile(testHome+"/.hermes/skills/.bundled_manifest", "{}")
+	fs.addFile(testHome+"/.hermes/skills/.hub/index.json", "{}")
+	fs.commit()
+
+	records, _ := NewSkillsDetector(m).Detect(context.Background(), nil, nil)
+	if len(records) != 1 {
+		t.Fatalf("want exactly the nested skill, got %+v", records)
+	}
+	rec := findSkill(records, "hermes_user", "apple-reminders")
+	if rec == nil {
+		t.Fatalf("hermes_user apple-reminders not found; records=%+v", records)
+	}
+	if rec.Agent != "hermes-agent" || rec.Scope != "global" || rec.RootRelPath != "apple/apple-reminders" {
+		t.Errorf("agent=%q scope=%q root_rel_path=%q, want hermes-agent/global/apple/apple-reminders", rec.Agent, rec.Scope, rec.RootRelPath)
+	}
+}
+
 // TestDetect_NewAgentProjectSources covers the Pi/Factory/GitHub project roots,
 // including Factory's SINGULAR .agent/skills (distinct from the shared .agents).
 func TestDetect_NewAgentProjectSources(t *testing.T) {
 	proj := testHome + "/work/proj"
 	cases := []struct{ rel, source, agent string }{
 		{".pi/skills/pip", "pi_project", "pi"},
+		{".grok/skills/grokp", "grok_project", "grok-build"},
+		{".kimi-code/skills/kimip", "kimi_project", "kimi-code"},
+		{".hermes/skills/hermp", "hermes_project", "hermes-agent"},
+		{".omp/skills/ompp", "omp_project", "oh-my-pi"},
 		{".factory/skills/facp", "factory_project", "factory"},
 		{".agent/skills/facap", "factory_agent_project", "factory"},
 		{".github/skills/ghp", "github_project", "copilot"},

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -720,13 +720,15 @@ type AgentSkill struct {
 	HasShellInjection      bool   `json:"has_shell_injection,omitempty"`     // body has !`cmd` / ```! load-time exec
 
 	// Attribution
-	Agent  string `json:"agent"`  // "claude-code"|"codex"|"opencode"|"cursor"|"pi"|"factory"|"amp"|"copilot"|"gemini-cli"|"aider"|"shared"
+	Agent  string `json:"agent"`  // "claude-code"|"codex"|"opencode"|"cursor"|"pi"|"factory"|"amp"|"copilot"|"gemini-cli"|"aider"|"grok-build"|"kimi-code"|"muse-code"|"hermes-agent"|"oh-my-pi"|"shared"
 	Source string `json:"source"` // atomic attribution key. "claude_user"|"claude_project"|
 	//                              // "agents_user"|"agents_project"|"codex_user"|"codex_system"|"codex_admin"|
 	//                              // "opencode_user"|"opencode_project"|"cursor_user"|"cursor_project"|"pi_user"|
 	//                              // "pi_project"|"factory_user"|"factory_project"|"factory_agent_project"|
 	//                              // "factory_agent_user"|"amp_user"|"copilot_user"|"github_project"|
-	//                              // "gemini_user"|"gemini_project"|"aider_project"
+	//                              // "gemini_user"|"gemini_project"|"aider_project"|"grok_user"|"grok_project"|
+	//                              // "kimi_user"|"kimi_project"|"muse_user"|"hermes_user"|"hermes_project"|
+	//                              // "omp_user"|"omp_managed_user"|"omp_project"
 	Scope       string `json:"scope"`                  // "global" | "project" | "system"
 	ProjectPath string `json:"project_path,omitempty"` // project root for project scope
 	PluginName  string `json:"plugin_name,omitempty"`  // owning plugin, from skills.sh lock pluginName

--- a/internal/versionmeta/versionmeta.go
+++ b/internal/versionmeta/versionmeta.go
@@ -53,7 +53,7 @@ func FromBinary(ctx context.Context, exec executor.Executor, binaryPath string) 
 
 	if root := packageRoot(exec, resolved); root != "" {
 		name, version := npmManifest(exec, root)
-		if matchesTool(name, base) && isVersionLike(version) {
+		if matchesTool(name, base) && IsVersionLike(version) {
 			return version
 		}
 		// Inside a node_modules tree but the manifest doesn't claim this
@@ -126,7 +126,7 @@ func versionFromVersionsDir(resolved, base string) string {
 		if segments[i] != "versions" {
 			continue
 		}
-		if matchesTool(segments[i-1], base) && isVersionLike(segments[i+1]) {
+		if matchesTool(segments[i-1], base) && IsVersionLike(segments[i+1]) {
 			return segments[i+1]
 		}
 	}
@@ -144,7 +144,7 @@ func versionFromHomebrew(resolved string) string {
 			continue
 		}
 		v := stripHomebrewRevision(segments[i+2])
-		if isVersionLike(v) {
+		if IsVersionLike(v) {
 			return v
 		}
 	}
@@ -170,7 +170,7 @@ func versionFromAppBundle(ctx context.Context, exec executor.Executor, resolved 
 		return ""
 	}
 	v := strings.TrimSpace(stdout)
-	if !isVersionLike(v) {
+	if !IsVersionLike(v) {
 		return ""
 	}
 	return v
@@ -202,10 +202,10 @@ func matchesTool(name, base string) bool {
 	return name == base || strings.HasPrefix(name, base+"-") || strings.HasPrefix(name, base+"@")
 }
 
-// isVersionLike reports whether s looks like a version: optional "v", then a
+// IsVersionLike reports whether s looks like a version: optional "v", then a
 // digit, at least one dot, and only [0-9A-Za-z.+_-] throughout. Rejects
 // Caskroom "version,build" composites — callers fall back to exec for those.
-func isVersionLike(s string) bool {
+func IsVersionLike(s string) bool {
 	s = strings.TrimPrefix(s, "v")
 	if s == "" || s[0] < '0' || s[0] > '9' || !strings.Contains(s, ".") {
 		return false

--- a/internal/versionmeta/versionmeta_test.go
+++ b/internal/versionmeta/versionmeta_test.go
@@ -215,8 +215,8 @@ func TestIsVersionLike(t *testing.T) {
 		{"", false},
 	}
 	for _, tc := range tests {
-		if got := isVersionLike(tc.in); got != tc.want {
-			t.Errorf("isVersionLike(%q) = %v, want %v", tc.in, got, tc.want)
+		if got := IsVersionLike(tc.in); got != tc.want {
+			t.Errorf("IsVersionLike(%q) = %v, want %v", tc.in, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds five AI agent CLIs to the ladder-backed AI-CLI detector: `grok-build` (xAI), `kimi-code` (Moonshot), `muse-code` (Meta), `hermes-agent` (Nous Research), `oh-my-pi` (Stencil). All five share their binary name with an unrelated tool, so each follows the PR #182 pattern: `resolveVerified` walks candidates and an accept closure proves identity per install channel before a row is reported.

- **Identity channels**: npm manifest, vendor install dir (`~/.grok`, `~/.kimi-code`, `~/.omp`), Homebrew keg or cask, winget, pacman manifest, mise install tree, uv/pipx venv (Kimi legacy, Hermes).
- **Versions** come only from on-disk evidence: package manifests, versioned filenames, `dist-info` directory names, the Muse `.muse-version` sidecar (64-byte cap), Homebrew and mise path segments. `StaticVersionOnly` on all five; winget channels report `unknown`.
- **Never executed, never reads agent state**: no `config.toml`, `.env`, `auth.json`, `settings.json`, sessions, credentials, or logs. Every path goes through the TCC candidate guard.
- **Skills**: global roots (`~/.grok/skills`, `~/.kimi-code/skills`, `~/.config/muse/skills`, `~/.hermes/skills` or `%LOCALAPPDATA%\hermes\skills`, `~/.omp/agent/skills`, `~/.omp/agent/managed-skills`), project roots and marker dirs (`.grok`, `.kimi-code`, `.hermes`, `.omp`). Hermes nested `<category>/<skill>/SKILL.md` layout yields a two-level `root_rel_path`.
- `versionmeta.isVersionLike` exported as `IsVersionLike`; no other versionmeta change.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l internal/` clean
- [x] `go test ./internal/detector/... ./internal/versionmeta/...` (per-agent accept/reject cases, Windows cases, TCC guard decoys, glob budget, skills census rows, nested Hermes fixture)
- [x] dmg-mac and dmg-linux live scan: all five rows reported; negative pass drops `muse-code`/`hermes-agent` on linux, mac keeps them via Homebrew; `~/Documents/bin/grok` decoy skipped with no TCC access; 58 `hermes_user` skills
- [ ] dmg-windows live scan (Grok same-size copy rule, Hermes `%LOCALAPPDATA%` venv) — pending

## Release gate

agent-api `agentSkillSourceToAgent` entries for the ten new skill sources must deploy before this ships.
